### PR TITLE
Add activity data generation to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Test
         run: npm run test
 
+      - name: Generate activity data
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: npm run generate-data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
## Summary
- Adds `npm run generate-data` step before build on main branch pushes
- Gates the step to main pushes only to avoid extra GitHub API calls on PRs
- Ensures the deployed site includes `public/data/activity.json`

## Test plan
- [ ] CI passes lint, typecheck, test, and build steps
- [ ] On main merge, verify `activity.json` is generated before build
- [ ] Deployed site shows real activity data instead of 404

Fixes #9