### PR TITLE
feat(web): Live GitHub Activity Feed with real-time polling

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -60,16 +60,20 @@ describe('App', () => {
     } as Response);
 
     render(<App />);
-    expect(
-      screen.getByRole('heading', { name: /colony/i })
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /colony/i })
+      ).toBeInTheDocument();
+    });
   });
 
-  it('shows loading state initially', () => {
+  it('shows loading state initially', async () => {
     vi.mocked(fetch).mockImplementation(() => new Promise(() => {}));
 
     render(<App />);
-    expect(screen.getByText(/loading activity data/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/loading activity data/i)).toBeInTheDocument();
+    });
   });
 
   it('shows placeholder when no data is available', async () => {
@@ -121,10 +125,14 @@ describe('App', () => {
     } as Response);
 
     render(<App />);
-    const githubLink = screen.getByRole('link', { name: /view on github/i });
-    expect(githubLink).toHaveAttribute(
-      'href',
-      'https://github.com/hivemoot/colony'
-    );
+    await waitFor(() => {
+      const githubLink = screen.getByRole('link', {
+        name: /view on github/i,
+      });
+      expect(githubLink).toHaveAttribute(
+        'href',
+        'https://github.com/hivemoot/colony'
+      );
+    });
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,18 @@ import { useActivityData } from './hooks/useActivityData';
 import { ActivityFeed } from './components/ActivityFeed';
 
 function App(): React.ReactElement {
-  const { data, loading, error } = useActivityData();
+  const {
+    data,
+    events,
+    loading,
+    error,
+    lastUpdated,
+    mode,
+    liveEnabled,
+    setLiveEnabled,
+    liveMessage,
+  } = useActivityData();
+  const hasActivity = Boolean(data) || events.length > 0;
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-amber-50 to-amber-100 dark:from-neutral-900 dark:to-neutral-800 flex flex-col items-center px-4 py-8">
@@ -39,7 +50,7 @@ function App(): React.ReactElement {
           </div>
         )}
 
-        {error && (
+        {error && !hasActivity && (
           <div className="bg-red-100 dark:bg-red-900/50 border border-red-300 dark:border-red-700 rounded-lg p-4 text-center">
             <p className="text-red-800 dark:text-red-200">
               Failed to load activity data
@@ -50,7 +61,7 @@ function App(): React.ReactElement {
           </div>
         )}
 
-        {!loading && !error && !data && (
+        {!loading && !error && !hasActivity && (
           <div className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600 text-center">
             <p className="text-amber-700 dark:text-amber-300 mb-4">
               Agent activity: <span className="font-semibold">coming soon</span>
@@ -61,7 +72,17 @@ function App(): React.ReactElement {
           </div>
         )}
 
-        {!loading && !error && data && <ActivityFeed data={data} />}
+        {!loading && hasActivity && (
+          <ActivityFeed
+            data={data}
+            events={events}
+            mode={mode}
+            lastUpdated={lastUpdated}
+            liveEnabled={liveEnabled}
+            onToggleLive={setLiveEnabled}
+            liveMessage={liveMessage}
+          />
+        )}
       </main>
 
       <footer className="mt-8 flex flex-col sm:flex-row gap-4 justify-center">

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -1,84 +1,157 @@
-import type { ActivityData } from '../types/activity';
+import type {
+  ActivityData,
+  ActivityEvent,
+  ActivityMode,
+} from '../types/activity';
+import { ActivityTimeline } from './ActivityTimeline';
 import { CommitList } from './CommitList';
 import { IssueList } from './IssueList';
 import { PullRequestList } from './PullRequestList';
 import { AgentList } from './AgentList';
+import { formatTimeAgo } from '../utils/time';
 
 interface ActivityFeedProps {
-  data: ActivityData;
+  data: ActivityData | null;
+  events: ActivityEvent[];
+  mode: ActivityMode;
+  lastUpdated: Date | null;
+  liveEnabled: boolean;
+  onToggleLive: (enabled: boolean) => void;
+  liveMessage: string | null;
 }
 
-export function ActivityFeed({ data }: ActivityFeedProps): React.ReactElement {
-  const generatedDate = new Date(data.generatedAt);
-  const timeAgo = formatTimeAgo(generatedDate);
+export function ActivityFeed({
+  data,
+  events,
+  mode,
+  lastUpdated,
+  liveEnabled,
+  onToggleLive,
+  liveMessage,
+}: ActivityFeedProps): React.ReactElement {
+  const timeAgo = lastUpdated ? formatTimeAgo(lastUpdated) : 'unknown';
+  const statusLabel = getStatusLabel(mode);
+  const statusStyles = getStatusStyles(mode);
 
   return (
     <div className="w-full max-w-4xl mx-auto space-y-8">
-      <div className="text-center">
-        <p className="text-sm text-amber-600 dark:text-amber-400">
-          Last updated: {timeAgo}
-        </p>
-      </div>
-
       <section className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
-        <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
-          <span role="img" aria-label="bees">
-            🐝
-          </span>
-          Active Agents
-        </h2>
-        <AgentList agents={data.agents} />
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100">
+              Live Activity Feed
+            </h2>
+            <p className="text-sm text-amber-600 dark:text-amber-400">
+              Last updated: {timeAgo}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <span className={`text-xs px-2 py-1 rounded-full ${statusStyles}`}>
+              {statusLabel}
+            </span>
+            <label className="flex items-center gap-2 text-sm text-amber-700 dark:text-amber-200">
+              <input
+                type="checkbox"
+                className="h-4 w-4 accent-amber-600"
+                checked={liveEnabled}
+                onChange={(event) => onToggleLive(event.target.checked)}
+              />
+              <span>Live mode</span>
+            </label>
+          </div>
+        </div>
+        {liveMessage && (
+          <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
+            {liveMessage}
+          </p>
+        )}
+        <div className="mt-4">
+          <ActivityTimeline events={events} />
+        </div>
       </section>
 
-      <div className="grid gap-6 md:grid-cols-3">
-        <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
-          <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
-            <span role="img" aria-label="commit">
-              📝
+      {data && (
+        <section className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+          <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
+            <span role="img" aria-label="bees">
+              🐝
             </span>
-            Recent Commits
+            Active Agents
           </h2>
-          <CommitList
-            commits={data.commits.slice(0, 5)}
-            repoUrl={data.repository.url}
-          />
+          <AgentList agents={data.agents} />
         </section>
+      )}
 
-        <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
-          <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
-            <span role="img" aria-label="issue">
-              🎯
-            </span>
-            Issues
-          </h2>
-          <IssueList
-            issues={data.issues.slice(0, 5)}
-            repoUrl={data.repository.url}
-          />
-        </section>
+      {data && (
+        <div className="grid gap-6 md:grid-cols-3">
+          <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+            <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
+              <span role="img" aria-label="commit">
+                📝
+              </span>
+              Recent Commits
+            </h2>
+            <CommitList
+              commits={data.commits.slice(0, 5)}
+              repoUrl={data.repository.url}
+            />
+          </section>
 
-        <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
-          <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
-            <span role="img" aria-label="pull request">
-              🔀
-            </span>
-            Pull Requests
-          </h2>
-          <PullRequestList
-            pullRequests={data.pullRequests.slice(0, 5)}
-            repoUrl={data.repository.url}
-          />
-        </section>
-      </div>
+          <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+            <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
+              <span role="img" aria-label="issue">
+                🎯
+              </span>
+              Issues
+            </h2>
+            <IssueList
+              issues={data.issues.slice(0, 5)}
+              repoUrl={data.repository.url}
+            />
+          </section>
+
+          <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+            <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
+              <span role="img" aria-label="pull request">
+                🔀
+              </span>
+              Pull Requests
+            </h2>
+            <PullRequestList
+              pullRequests={data.pullRequests.slice(0, 5)}
+              repoUrl={data.repository.url}
+            />
+          </section>
+        </div>
+      )}
     </div>
   );
 }
 
-function formatTimeAgo(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+function getStatusLabel(mode: ActivityMode): string {
+  switch (mode) {
+    case 'live':
+      return 'Live';
+    case 'connecting':
+      return 'Connecting';
+    case 'fallback':
+      return 'Static (fallback)';
+    case 'static':
+    default:
+      return 'Static';
+  }
+}
 
-  if (seconds < 60) return 'just now';
-  if (seconds < 3600) return `${Math.floor(seconds / 60)} minutes ago`;
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)} hours ago`;
-  return `${Math.floor(seconds / 86400)} days ago`;
+function getStatusStyles(mode: ActivityMode): string {
+  switch (mode) {
+    case 'live':
+      return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
+    case 'connecting':
+      return 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200';
+    case 'fallback':
+      return 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200';
+    case 'static':
+    default:
+      return 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200';
+  }
 }

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -1,0 +1,124 @@
+import type { ActivityEvent, ActivityEventType } from '../types/activity';
+import { formatTimeAgo } from '../utils/time';
+
+interface ActivityTimelineProps {
+  events: ActivityEvent[];
+}
+
+const EVENT_STYLES: Record<
+  ActivityEventType,
+  { icon: string; dotClass: string; badgeClass: string; label: string }
+> = {
+  commit: {
+    icon: '📝',
+    dotClass: 'bg-amber-500',
+    badgeClass:
+      'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+    label: 'Commit',
+  },
+  issue: {
+    icon: '🎯',
+    dotClass: 'bg-orange-500',
+    badgeClass:
+      'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200',
+    label: 'Issue',
+  },
+  pull_request: {
+    icon: '🔀',
+    dotClass: 'bg-sky-500',
+    badgeClass: 'bg-sky-100 text-sky-800 dark:bg-sky-900 dark:text-sky-200',
+    label: 'PR',
+  },
+  merge: {
+    icon: '✅',
+    dotClass: 'bg-green-500',
+    badgeClass:
+      'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+    label: 'Merge',
+  },
+  comment: {
+    icon: '💬',
+    dotClass: 'bg-teal-500',
+    badgeClass: 'bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200',
+    label: 'Comment',
+  },
+  review: {
+    icon: '🧭',
+    dotClass: 'bg-slate-500',
+    badgeClass:
+      'bg-slate-100 text-slate-800 dark:bg-slate-900 dark:text-slate-200',
+    label: 'Review',
+  },
+};
+
+export function ActivityTimeline({
+  events,
+}: ActivityTimelineProps): React.ReactElement {
+  if (events.length === 0) {
+    return (
+      <p className="text-sm text-amber-600 dark:text-amber-400 italic">
+        No recent activity yet
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-5">
+      {events.map((event) => {
+        const style = EVENT_STYLES[event.type];
+        const eventDate = new Date(event.createdAt);
+        const timeAgo = formatTimeAgo(eventDate);
+
+        return (
+          <li key={event.id} className="flex gap-3">
+            <div className="mt-1 flex flex-col items-center">
+              <span className={`h-2.5 w-2.5 rounded-full ${style.dotClass}`} />
+            </div>
+            <div className="flex-1">
+              <div className="flex flex-wrap items-center gap-2 text-xs text-amber-600 dark:text-amber-300">
+                <span
+                  className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 ${style.badgeClass}`}
+                >
+                  <span role="img" aria-label={style.label}>
+                    {style.icon}
+                  </span>
+                  {event.summary}
+                </span>
+                <span className="text-amber-400 dark:text-amber-500">•</span>
+                <span>{timeAgo}</span>
+              </div>
+              {event.url ? (
+                <a
+                  href={event.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-1 block text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-200"
+                >
+                  {event.title}
+                </a>
+              ) : (
+                <p className="mt-1 text-amber-900 dark:text-amber-100 font-medium">
+                  {event.title}
+                </p>
+              )}
+              <div className="flex items-center gap-1.5 mt-1">
+                <img
+                  src={`https://github.com/${event.actor}.png`}
+                  alt={event.actor}
+                  className="w-4 h-4 rounded-full border border-amber-200 dark:border-neutral-600"
+                  onError={(e) => {
+                    (e.target as HTMLImageElement).src =
+                      'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🐝</text></svg>';
+                  }}
+                />
+                <span className="text-xs text-amber-600 dark:text-amber-400">
+                  {event.actor}
+                </span>
+              </div>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/web/src/hooks/useActivityData.ts
+++ b/web/src/hooks/useActivityData.ts
@@ -1,18 +1,60 @@
-import { useState, useEffect } from 'react';
-import type { ActivityData } from '../types/activity';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  ActivityData,
+  ActivityEvent,
+  ActivityMode,
+} from '../types/activity';
+import {
+  buildLiveEvents,
+  buildStaticEvents,
+  type GitHubEvent,
+} from '../utils/activity';
 
 interface UseActivityDataResult {
   data: ActivityData | null;
+  events: ActivityEvent[];
   loading: boolean;
   error: string | null;
+  lastUpdated: Date | null;
+  mode: ActivityMode;
+  liveEnabled: boolean;
+  setLiveEnabled: (enabled: boolean) => void;
+  liveMessage: string | null;
 }
+
+const DEFAULT_REPOSITORY = {
+  owner: 'hivemoot',
+  name: 'colony',
+  url: 'https://github.com/hivemoot/colony',
+};
+
+const STATIC_POLL_MS = 60_000;
+const LIVE_BASE_MS = 20_000;
+const LIVE_MAX_MS = 5 * 60_000;
+const LIVE_EVENTS_ENDPOINT = 'https://api.github.com/repos';
 
 export function useActivityData(): UseActivityDataResult {
   const [data, setData] = useState<ActivityData | null>(null);
+  const [staticEvents, setStaticEvents] = useState<ActivityEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [lastStaticUpdated, setLastStaticUpdated] = useState<Date | null>(null);
+
+  const [liveEnabled, setLiveEnabled] = useState(false);
+  const [liveEvents, setLiveEvents] = useState<ActivityEvent[]>([]);
+  const [lastLiveUpdated, setLastLiveUpdated] = useState<Date | null>(null);
+  const [liveError, setLiveError] = useState<string | null>(null);
+
+  const etagRef = useRef<string | null>(null);
+  const backoffRef = useRef<number>(LIVE_BASE_MS);
+  const hasDataRef = useRef(false);
+  const initialFetchRef = useRef(true);
+  const repository = data?.repository ?? DEFAULT_REPOSITORY;
+  const { owner, name, url } = repository;
 
   useEffect(() => {
+    let active = true;
+
     async function fetchData(): Promise<void> {
       try {
         // Use import.meta.env.BASE_URL for correct path in production
@@ -22,23 +64,162 @@ export function useActivityData(): UseActivityDataResult {
         if (!response.ok) {
           // Data file may not exist yet (development or first build)
           if (response.status === 404) {
-            setData(null);
+            if (!hasDataRef.current) {
+              setData(null);
+              setStaticEvents([]);
+            }
+            setError(null);
             return;
           }
           throw new Error(`Failed to fetch activity data: ${response.status}`);
         }
 
         const activityData: ActivityData = await response.json();
+        if (!active) return;
+
+        hasDataRef.current = true;
         setData(activityData);
+        setStaticEvents(buildStaticEvents(activityData));
+        setLastStaticUpdated(new Date());
+        setError(null);
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Unknown error');
+        if (!hasDataRef.current) {
+          setError(err instanceof Error ? err.message : 'Unknown error');
+        }
       } finally {
-        setLoading(false);
+        if (initialFetchRef.current) {
+          initialFetchRef.current = false;
+          setLoading(false);
+        }
       }
     }
 
     fetchData();
+
+    const intervalId = window.setInterval(fetchData, STATIC_POLL_MS);
+    return (): void => {
+      active = false;
+      window.clearInterval(intervalId);
+    };
   }, []);
 
-  return { data, loading, error };
+  useEffect(() => {
+    if (!liveEnabled) {
+      setLiveEvents([]);
+      setLastLiveUpdated(null);
+      setLiveError(null);
+      etagRef.current = null;
+      backoffRef.current = LIVE_BASE_MS;
+      return;
+    }
+
+    let cancelled = false;
+    let timeoutId: number | null = null;
+
+    const repoUrl = url;
+    const liveUrl = `${LIVE_EVENTS_ENDPOINT}/${owner}/${name}/events?per_page=30`;
+
+    const scheduleNext = (delay: number): void => {
+      timeoutId = window.setTimeout(fetchLiveEvents, delay);
+    };
+
+    const fetchLiveEvents = async (): Promise<void> => {
+      try {
+        const headers: Record<string, string> = {
+          Accept: 'application/vnd.github.v3+json',
+        };
+        if (etagRef.current) {
+          headers['If-None-Match'] = etagRef.current;
+        }
+
+        const response = await fetch(liveUrl, { headers });
+
+        if (response.status === 304) {
+          setLiveError(null);
+          setLastLiveUpdated(new Date());
+          backoffRef.current = LIVE_BASE_MS;
+        } else if (response.ok) {
+          const nextEtag = response.headers.get('etag');
+          if (nextEtag) {
+            etagRef.current = nextEtag;
+          }
+          const payload = (await response.json()) as GitHubEvent[];
+          if (!cancelled) {
+            setLiveEvents(buildLiveEvents(payload, repoUrl));
+            setLastLiveUpdated(new Date());
+            setLiveError(null);
+          }
+          backoffRef.current = LIVE_BASE_MS;
+        } else if (response.status === 403 || response.status === 429) {
+          setLiveError('rate-limit');
+          backoffRef.current = Math.min(backoffRef.current * 2, LIVE_MAX_MS);
+        } else {
+          throw new Error(`Live feed error: ${response.status}`);
+        }
+      } catch (err) {
+        setLiveError(err instanceof Error ? err.message : 'Live feed error');
+        backoffRef.current = Math.min(backoffRef.current * 2, LIVE_MAX_MS);
+      } finally {
+        if (!cancelled) {
+          scheduleNext(backoffRef.current);
+        }
+      }
+    };
+
+    fetchLiveEvents();
+
+    return (): void => {
+      cancelled = true;
+      if (timeoutId) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [liveEnabled, owner, name, url]);
+
+  const usingLiveEvents =
+    liveEnabled && liveEvents.length > 0 && liveError === null;
+
+  const mode: ActivityMode = useMemo(() => {
+    if (!liveEnabled) return 'static';
+    if (usingLiveEvents) return 'live';
+    return liveError ? 'fallback' : 'connecting';
+  }, [liveEnabled, liveError, usingLiveEvents]);
+
+  const events = useMemo(
+    () => (usingLiveEvents ? liveEvents : staticEvents),
+    [usingLiveEvents, liveEvents, staticEvents]
+  );
+
+  const lastUpdated = useMemo(() => {
+    if (usingLiveEvents) {
+      return lastLiveUpdated;
+    }
+    return lastStaticUpdated;
+  }, [usingLiveEvents, lastLiveUpdated, lastStaticUpdated]);
+
+  const liveMessage = useMemo(() => {
+    if (!liveEnabled) return null;
+    if (mode === 'connecting') {
+      return 'Connecting to GitHub live feed…';
+    }
+    if (mode === 'fallback') {
+      if (liveError === 'rate-limit') {
+        return 'Live feed paused (rate limited). Showing static data.';
+      }
+      return 'Live feed unavailable. Showing static data.';
+    }
+    return null;
+  }, [liveEnabled, mode, liveError]);
+
+  return {
+    data,
+    events,
+    loading,
+    error,
+    lastUpdated,
+    mode,
+    liveEnabled,
+    setLiveEnabled,
+    liveMessage,
+  };
 }

--- a/web/src/types/activity.ts
+++ b/web/src/types/activity.ts
@@ -10,7 +10,9 @@ export interface Issue {
   title: string;
   state: 'open' | 'closed';
   labels: string[];
+  author?: string;
   createdAt: string;
+  closedAt?: string | null;
 }
 
 export interface PullRequest {
@@ -19,6 +21,8 @@ export interface PullRequest {
   state: 'open' | 'closed' | 'merged';
   author: string;
   createdAt: string;
+  closedAt?: string | null;
+  mergedAt?: string | null;
 }
 
 export interface Agent {
@@ -37,4 +41,24 @@ export interface ActivityData {
   commits: Commit[];
   issues: Issue[];
   pullRequests: PullRequest[];
+}
+
+export type ActivityEventType =
+  | 'commit'
+  | 'issue'
+  | 'pull_request'
+  | 'comment'
+  | 'merge'
+  | 'review';
+
+export type ActivityMode = 'static' | 'connecting' | 'live' | 'fallback';
+
+export interface ActivityEvent {
+  id: string;
+  type: ActivityEventType;
+  summary: string;
+  title: string;
+  url?: string;
+  actor: string;
+  createdAt: string;
 }

--- a/web/src/utils/activity.ts
+++ b/web/src/utils/activity.ts
@@ -1,0 +1,228 @@
+import type { ActivityData, ActivityEvent } from '../types/activity';
+
+export const DEFAULT_EVENT_LIMIT = 30;
+
+export interface GitHubEvent {
+  id: string;
+  type: string;
+  actor?: { login: string };
+  repo?: { name: string };
+  created_at: string;
+  payload?: unknown;
+}
+
+export function buildStaticEvents(
+  data: ActivityData,
+  maxEvents = DEFAULT_EVENT_LIMIT
+): ActivityEvent[] {
+  const repoUrl = data.repository.url;
+
+  const commitEvents = data.commits.map((commit) => ({
+    id: `commit-${commit.sha}`,
+    type: 'commit' as const,
+    summary: 'Commit pushed',
+    title: `${commit.sha} ${commit.message}`.trim(),
+    url: `${repoUrl}/commit/${commit.sha}`,
+    actor: commit.author,
+    createdAt: commit.date,
+  }));
+
+  const issueEvents = data.issues.map((issue) => {
+    const summary = issue.state === 'closed' ? 'Issue closed' : 'Issue opened';
+    const createdAt =
+      issue.state === 'closed' && issue.closedAt
+        ? issue.closedAt
+        : issue.createdAt;
+
+    return {
+      id: `issue-${issue.number}-${issue.state}`,
+      type: 'issue' as const,
+      summary,
+      title: `#${issue.number} ${issue.title}`,
+      url: `${repoUrl}/issues/${issue.number}`,
+      actor: issue.author ?? 'unknown',
+      createdAt,
+    };
+  });
+
+  const pullRequestEvents = data.pullRequests.map((pr) => {
+    const summary =
+      pr.state === 'merged'
+        ? 'PR merged'
+        : pr.state === 'closed'
+          ? 'PR closed'
+          : 'PR opened';
+    const createdAt =
+      pr.state === 'merged' && pr.mergedAt
+        ? pr.mergedAt
+        : pr.state === 'closed' && pr.closedAt
+          ? pr.closedAt
+          : pr.createdAt;
+
+    return {
+      id: `pr-${pr.number}-${pr.state}`,
+      type:
+        pr.state === 'merged' ? ('merge' as const) : ('pull_request' as const),
+      summary,
+      title: `#${pr.number} ${pr.title}`,
+      url: `${repoUrl}/pull/${pr.number}`,
+      actor: pr.author,
+      createdAt,
+    };
+  });
+
+  return sortAndLimit(
+    [...commitEvents, ...issueEvents, ...pullRequestEvents],
+    maxEvents
+  );
+}
+
+export function buildLiveEvents(
+  rawEvents: GitHubEvent[],
+  fallbackRepoUrl: string,
+  maxEvents = DEFAULT_EVENT_LIMIT
+): ActivityEvent[] {
+  const mapped = rawEvents
+    .map((event) => mapGitHubEvent(event, fallbackRepoUrl))
+    .filter((event): event is ActivityEvent => Boolean(event));
+
+  return sortAndLimit(mapped, maxEvents);
+}
+
+function mapGitHubEvent(
+  event: GitHubEvent,
+  fallbackRepoUrl: string
+): ActivityEvent | null {
+  const actor = event.actor?.login ?? 'unknown';
+  const createdAt = event.created_at;
+  const repoUrl = event.repo?.name
+    ? `https://github.com/${event.repo.name}`
+    : fallbackRepoUrl;
+
+  switch (event.type) {
+    case 'PushEvent': {
+      const payload = event.payload as {
+        commits?: Array<{ sha: string; message: string }>;
+      };
+      const commit = payload?.commits?.[0];
+      if (!commit) return null;
+      const shortSha = commit.sha?.slice(0, 7);
+      const message = commit.message?.split('\n')[0] ?? 'Commit';
+      return {
+        id: event.id,
+        type: 'commit',
+        summary: 'Commit pushed',
+        title: `${shortSha ?? ''} ${message}`.trim(),
+        url: commit.sha ? `${repoUrl}/commit/${commit.sha}` : repoUrl,
+        actor,
+        createdAt,
+      };
+    }
+    case 'IssuesEvent': {
+      const payload = event.payload as {
+        action?: string;
+        issue?: { number: number; title: string; html_url: string };
+      };
+      if (!payload.issue) return null;
+      return {
+        id: event.id,
+        type: 'issue',
+        summary: `Issue ${formatAction(payload.action)}`,
+        title: `#${payload.issue.number} ${payload.issue.title}`,
+        url: payload.issue.html_url,
+        actor,
+        createdAt,
+      };
+    }
+    case 'IssueCommentEvent': {
+      const payload = event.payload as {
+        issue?: { number: number; title: string; html_url: string };
+        comment?: { html_url: string };
+      };
+      if (!payload.issue) return null;
+      return {
+        id: event.id,
+        type: 'comment',
+        summary: 'Commented on issue',
+        title: `#${payload.issue.number} ${payload.issue.title}`,
+        url: payload.comment?.html_url ?? payload.issue.html_url,
+        actor,
+        createdAt,
+      };
+    }
+    case 'PullRequestEvent': {
+      const payload = event.payload as {
+        action?: string;
+        pull_request?: {
+          number: number;
+          title: string;
+          html_url: string;
+          merged?: boolean;
+        };
+      };
+      if (!payload.pull_request) return null;
+      const merged = payload.action === 'closed' && payload.pull_request.merged;
+      return {
+        id: event.id,
+        type: merged ? 'merge' : 'pull_request',
+        summary: merged ? 'PR merged' : `PR ${formatAction(payload.action)}`,
+        title: `#${payload.pull_request.number} ${payload.pull_request.title}`,
+        url: payload.pull_request.html_url,
+        actor,
+        createdAt,
+      };
+    }
+    case 'PullRequestReviewCommentEvent': {
+      const payload = event.payload as {
+        pull_request?: { number: number; title: string; html_url: string };
+        comment?: { html_url: string };
+      };
+      if (!payload.pull_request) return null;
+      return {
+        id: event.id,
+        type: 'comment',
+        summary: 'Commented on PR',
+        title: `#${payload.pull_request.number} ${payload.pull_request.title}`,
+        url: payload.comment?.html_url ?? payload.pull_request.html_url,
+        actor,
+        createdAt,
+      };
+    }
+    case 'PullRequestReviewEvent': {
+      const payload = event.payload as {
+        pull_request?: { number: number; title: string; html_url: string };
+        review?: { state?: string };
+      };
+      if (!payload.pull_request) return null;
+      return {
+        id: event.id,
+        type: 'review',
+        summary: `PR review ${formatAction(payload.review?.state)}`,
+        title: `#${payload.pull_request.number} ${payload.pull_request.title}`,
+        url: payload.pull_request.html_url,
+        actor,
+        createdAt,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+function formatAction(action?: string): string {
+  if (!action) return 'updated';
+  const normalized = action.replace(/_/g, ' ');
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+function sortAndLimit(
+  events: ActivityEvent[],
+  maxEvents: number
+): ActivityEvent[] {
+  return [...events]
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )
+    .slice(0, maxEvents);
+}

--- a/web/src/utils/time.ts
+++ b/web/src/utils/time.ts
@@ -1,0 +1,8 @@
+export function formatTimeAgo(date: Date, now = Date.now()): string {
+  const seconds = Math.floor((now - date.getTime()) / 1000);
+
+  if (seconds < 60) return 'just now';
+  if (seconds < 3600) return `${Math.floor(seconds / 60)} minutes ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)} hours ago`;
+  return `${Math.floor(seconds / 86400)} days ago`;
+}


### PR DESCRIPTION
## Summary

Implements the Live GitHub Activity Feed proposed in Issue #7.

## Features

- **Default mode**: Poll static `activity.json` every 60s for reliable baseline
- **Live mode (toggle)**: Poll GitHub Events API with ETag caching for near real-time updates
- **Exponential backoff**: Handles rate limits gracefully (20s base, 5min max)
- **Automatic fallback**: Reverts to static data on API errors or rate limits
- **Status indicators**: Shows 'Last updated Xs ago' + Live/Static/Connecting badge
- **ActivityTimeline component**: Unified chronological event display
- **Event support**: PRs, Issues, Comments, and Merge events

## Implementation Notes

Static-first approach keeps the site reliable by default while enabling optional real-time visibility. The live mode uses ETags for efficient polling and exponential backoff to respect GitHub API limits.

The `mode` state machine handles transitions between:
- `static`: Default mode, polling activity.json
- `connecting`: Live mode enabled, waiting for first API response  
- `live`: Successfully receiving real-time data
- `fallback`: Live enabled but showing static data due to errors

## Test Plan

- `npm run typecheck` ✅
- `npm run lint` ✅  
- `npm run test` ✅ (6 tests pass)
- `npm run build` — builds successfully

## Screenshots

Toggle appears in the Activity Feed header. Status badge shows current mode and last update time.

Fixes #7