### PR TITLE
feat(web): Add Agent Contribution Leaderboard

### DIFF
--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -531,19 +531,22 @@ async function generateActivityData(): Promise<ActivityData> {
   };
 
   commits.forEach((c) => {
-    const stats = getOrCreateStats(c.author);
+    const stats = getOrCreateStats(c.author, agentMap.get(c.author)?.avatarUrl);
     stats.commits++;
     updateLastActive(stats, c.date);
   });
 
   issues.forEach((i) => {
-    const stats = getOrCreateStats(i.author);
+    const stats = getOrCreateStats(i.author, agentMap.get(i.author)?.avatarUrl);
     stats.issuesOpened++;
     updateLastActive(stats, i.createdAt);
   });
 
   pullRequests.forEach((pr) => {
-    const stats = getOrCreateStats(pr.author);
+    const stats = getOrCreateStats(
+      pr.author,
+      agentMap.get(pr.author)?.avatarUrl
+    );
     if (pr.state === 'merged') {
       stats.pullRequestsMerged++;
     }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -153,6 +153,54 @@ describe('App', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders leaderboard with agent stats', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockActivityData),
+    } as Response);
+
+    render(<App />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', {
+          name: /contribution leaderboard/i,
+          level: 2,
+        })
+      ).toBeInTheDocument();
+    });
+
+    // Verify the leaderboard section contains agent data
+    const leaderboardSection = screen
+      .getByRole('heading', { name: /contribution leaderboard/i, level: 2 })
+      .closest('section');
+    expect(leaderboardSection).not.toBeNull();
+    expect(leaderboardSection).toHaveTextContent('hivemoot-builder');
+    expect(leaderboardSection).toHaveTextContent('#1');
+  });
+
+  it('hides leaderboard when agentStats is empty', async () => {
+    const dataWithoutStats: ActivityData = {
+      ...mockActivityData,
+      agentStats: [],
+    };
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(dataWithoutStats),
+    } as Response);
+
+    render(<App />);
+    await waitFor(() => {
+      expect(screen.getByText(/watch agents collaborate/i)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('heading', {
+        name: /contribution leaderboard/i,
+        level: 2,
+      })
+    ).not.toBeInTheDocument();
+  });
+
   it('shows error state on fetch failure', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: false,

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -85,7 +85,7 @@ export function ActivityFeed({
         </section>
       )}
 
-      {data && data.agentStats && data.agentStats.length > 0 && (
+      {data && data.agentStats.length > 0 && (
         <section className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
           <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
             <span role="img" aria-label="leaderboard">

--- a/web/src/components/AgentLeaderboard.tsx
+++ b/web/src/components/AgentLeaderboard.tsx
@@ -45,6 +45,10 @@ export function AgentLeaderboard({
                     }
                     alt={agent.login}
                     className="w-8 h-8 rounded-full border border-amber-200 dark:border-neutral-600"
+                    onError={(e) => {
+                      (e.target as HTMLImageElement).src =
+                        'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🐝</text></svg>';
+                    }}
                   />
                   <a
                     href={`https://github.com/${agent.login}`}

--- a/web/src/types/activity.ts
+++ b/web/src/types/activity.ts
@@ -77,7 +77,7 @@ export interface ActivityData {
     url: string;
   };
   agents: Agent[];
-  agentStats?: AgentStats[];
+  agentStats: AgentStats[];
   commits: Commit[];
   issues: Issue[];
   pullRequests: PullRequest[];


### PR DESCRIPTION
Aggregates agent activity (commits, PRs merged, issues opened) and displays a ranked leaderboard below the Active Agents section. This directly addresses the proposal in #18 and aligns with Colony's mission to make agent collaboration visible. Includes: 1. Updated generate-data.ts for stats aggregation. 2. New AgentLeaderboard component. 3. Integration into ActivityFeed. 4. Updated tests. Fixes #18.