### PR TITLE
fix(web): Include comments in static activity timeline

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -129,6 +129,11 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', { name: /discussion/i, level: 2 })
     ).toBeInTheDocument();
+
+    // Comments should appear in the activity timeline (as event badges)
+    expect(
+      screen.getAllByText(/commented on issue #1/i).length
+    ).toBeGreaterThanOrEqual(1);
   });
 
   it('shows error state on fetch failure', async () => {

--- a/web/src/utils/activity.ts
+++ b/web/src/utils/activity.ts
@@ -71,8 +71,24 @@ export function buildStaticEvents(
     };
   });
 
+  const commentEvents = (data.comments ?? []).map((comment) => {
+    const isReview = comment.type === 'review';
+    const targetLabel = comment.type === 'issue' ? 'issue' : 'PR';
+    return {
+      id: `comment-${comment.id}`,
+      type: isReview ? ('review' as const) : ('comment' as const),
+      summary: isReview
+        ? `Reviewed PR #${comment.issueOrPrNumber}`
+        : `Commented on ${targetLabel} #${comment.issueOrPrNumber}`,
+      title: `#${comment.issueOrPrNumber}`,
+      url: comment.url,
+      actor: comment.author,
+      createdAt: comment.createdAt,
+    };
+  });
+
   return sortAndLimit(
-    [...commitEvents, ...issueEvents, ...pullRequestEvents],
+    [...commitEvents, ...issueEvents, ...pullRequestEvents, ...commentEvents],
     maxEvents
   );
 }


### PR DESCRIPTION
## Summary
- Adds comment and review events to `buildStaticEvents()` in `activity.ts`
- Closes the parity gap between live mode (which already shows comment events) and static mode (which did not)
- Updates test to verify comments appear in the activity timeline

## Context

PR #19 added a Discussion feed to the dashboard, but the static activity timeline (`buildStaticEvents`) was not updated to include comment events. This meant:

- **Live mode**: Shows comments, reviews, and PR review comments in the timeline
- **Static mode**: Only showed commits, issues, and PRs

This fix maps `Comment` objects to `ActivityEvent` entries, matching the behavior of the live feed's `IssueCommentEvent` and `PullRequestReviewEvent` handlers.

## Changes
- `web/src/utils/activity.ts` — Add `commentEvents` mapping in `buildStaticEvents()`
- `web/src/App.test.tsx` — Add assertion verifying comment events appear in timeline

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] All 6 tests pass
- [x] Production build succeeds