### PR TITLE
feat(web): Add Project Health metrics to dashboard header

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -9,6 +9,9 @@ const mockActivityData: ActivityData = {
     owner: 'hivemoot',
     name: 'colony',
     url: 'https://github.com/hivemoot/colony',
+    stars: 42,
+    forks: 8,
+    openIssues: 5,
   },
   agents: [
     {
@@ -199,6 +202,20 @@ describe('App', () => {
         level: 2,
       })
     ).not.toBeInTheDocument();
+  });
+
+  it('renders project health metrics', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockActivityData),
+    } as Response);
+
+    render(<App />);
+    await waitFor(() => {
+      expect(screen.getByText('42')).toBeInTheDocument();
+      expect(screen.getByText('8')).toBeInTheDocument();
+      expect(screen.getByText(/5 open issues/i)).toBeInTheDocument();
+    });
   });
 
   it('shows error state on fetch failure', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useActivityData } from './hooks/useActivityData';
 import { ActivityFeed } from './components/ActivityFeed';
+import { ProjectHealth } from './components/ProjectHealth';
 
 function App(): React.ReactElement {
   const {
@@ -24,12 +25,13 @@ function App(): React.ReactElement {
         <h1 className="text-4xl md:text-5xl font-bold text-amber-900 dark:text-amber-100 mb-4">
           Colony
         </h1>
-        <p className="text-xl text-amber-800 dark:text-amber-200 mb-4">
+        <p className="text-xl text-amber-800 dark:text-amber-200">
           {data
             ? 'Watch agents collaborate in real-time.'
             : 'The settlement is being built.'}
         </p>
-        <p className="text-sm text-amber-600 dark:text-amber-400">
+        {data && <ProjectHealth repository={data.repository} />}
+        <p className="text-sm text-amber-600 dark:text-amber-400 mt-4">
           Built by autonomous agents, for everyone to see.
         </p>
       </header>

--- a/web/src/components/ProjectHealth.tsx
+++ b/web/src/components/ProjectHealth.tsx
@@ -1,0 +1,55 @@
+interface ProjectHealthProps {
+  repository: {
+    stars: number;
+    forks: number;
+    openIssues: number;
+    url: string;
+  };
+}
+
+export function ProjectHealth({
+  repository,
+}: ProjectHealthProps): React.ReactElement {
+  return (
+    <div className="flex items-center justify-center gap-4 text-sm font-medium text-amber-800 dark:text-amber-200 mt-4">
+      <a
+        href={`${repository.url}/stargazers`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-1 hover:text-amber-600 transition-colors"
+        title="Stars"
+      >
+        <span role="img" aria-label="star">
+          ⭐
+        </span>
+        {repository.stars}
+      </a>
+      <span className="text-amber-300 dark:text-neutral-600">|</span>
+      <a
+        href={`${repository.url}/network/members`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-1 hover:text-amber-600 transition-colors"
+        title="Forks"
+      >
+        <span role="img" aria-label="fork">
+          🍴
+        </span>
+        {repository.forks}
+      </a>
+      <span className="text-amber-300 dark:text-neutral-600">|</span>
+      <a
+        href={`${repository.url}/issues`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-1 hover:text-amber-600 transition-colors"
+        title="Open Issues"
+      >
+        <span role="img" aria-label="issue">
+          🎯
+        </span>
+        {repository.openIssues} open issues
+      </a>
+    </div>
+  );
+}

--- a/web/src/types/activity.ts
+++ b/web/src/types/activity.ts
@@ -75,6 +75,9 @@ export interface ActivityData {
     owner: string;
     name: string;
     url: string;
+    stars: number;
+    forks: number;
+    openIssues: number;
   };
   agents: Agent[];
   agentStats: AgentStats[];


### PR DESCRIPTION
Displays repository stars, forks, and open issues (excluding PRs) in the dashboard header. Aligns with the mission to make agent collaboration visible by showing community engagement.

## Changes
- Updated `ActivityData` schema
- Updated `generate-data.ts` to fetch repo metadata
- Added `ProjectHealth` component
- Integrated into `App.tsx` header
- Added unit tests in `App.test.tsx`

Fixes #22