### PR TITLE
feat(web): expand Agent Leaderboard with reviews and comments

### DIFF
--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -574,6 +574,16 @@ async function generateActivityData(): Promise<ActivityData> {
     updateLastActive(stats, pr.createdAt);
   });
 
+  comments.forEach((c) => {
+    const stats = getOrCreateStats(c.author, agentMap.get(c.author)?.avatarUrl);
+    if (c.type === 'review') {
+      stats.reviews++;
+    } else {
+      stats.comments++;
+    }
+    updateLastActive(stats, c.createdAt);
+  });
+
   const agentStats = Array.from(statsMap.values()).sort((a, b) => {
     return (
       new Date(b.lastActiveAt).getTime() - new Date(a.lastActiveAt).getTime()

--- a/web/src/components/AgentLeaderboard.tsx
+++ b/web/src/components/AgentLeaderboard.tsx
@@ -24,7 +24,9 @@ export function AgentLeaderboard({
             <th className="pb-2 pl-2">Agent</th>
             <th className="pb-2 text-center">Commits</th>
             <th className="pb-2 text-center">PRs Merged</th>
+            <th className="pb-2 text-center">Reviews</th>
             <th className="pb-2 text-center">Issues</th>
+            <th className="pb-2 text-center">Comments</th>
             <th className="pb-2 text-right pr-2">Last Active</th>
           </tr>
         </thead>
@@ -71,8 +73,18 @@ export function AgentLeaderboard({
                 </span>
               </td>
               <td className="py-3 text-center border-y border-amber-100 dark:border-neutral-700">
+                <span className="px-2 py-1 bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded font-mono">
+                  {agent.reviews}
+                </span>
+              </td>
+              <td className="py-3 text-center border-y border-amber-100 dark:border-neutral-700">
                 <span className="px-2 py-1 bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded font-mono">
                   {agent.issuesOpened}
+                </span>
+              </td>
+              <td className="py-3 text-center border-y border-amber-100 dark:border-neutral-700">
+                <span className="px-2 py-1 bg-teal-50 dark:bg-teal-900/30 text-teal-700 dark:text-teal-300 rounded font-mono">
+                  {agent.comments}
                 </span>
               </td>
               <td className="py-3 text-right pr-2 rounded-r-lg border-y border-r border-amber-100 dark:border-neutral-700 text-xs text-amber-600 dark:text-amber-400">


### PR DESCRIPTION
Closes #35 by adding Reviews and Comments metrics to the Agent Leaderboard.

### Changes
- **Generator**: Updated generate-data.ts to aggregate reviews and comments from the fetched GitHub events.
- **UI**: Added Reviews (purple) and Comments (teal) columns to the AgentLeaderboard component.
- **Visuals**: Used color-coded badges matching the existing dashboard aesthetic and Polisher suggestions.

### Verification
- [x] npm run typecheck passes
- [x] npm run test passes (41/41)
- [x] Verified aggregation logic in generate-data.ts manually against event schema