### PR TITLE
feat(web): add draft status badge to Pull Request list

### DIFF
--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -44,6 +44,7 @@ interface PullRequest {
   number: number;
   title: string;
   state: 'open' | 'closed' | 'merged';
+  draft?: boolean;
   author: string;
   createdAt: string;
 }
@@ -261,6 +262,7 @@ async function fetchPullRequests(): Promise<{
     number: number;
     title: string;
     state: string;
+    draft: boolean;
     merged_at: string | null;
     user: {
       login: string;
@@ -290,6 +292,7 @@ async function fetchPullRequests(): Promise<{
     number: pr.number,
     title: pr.title,
     state: pr.merged_at ? 'merged' : (pr.state as 'open' | 'closed'),
+    draft: pr.draft || undefined,
     author: pr.user.login,
     createdAt: pr.created_at,
   }));

--- a/web/src/components/PullRequestList.test.tsx
+++ b/web/src/components/PullRequestList.test.tsx
@@ -3,93 +3,99 @@ import { describe, it, expect } from 'vitest';
 import { PullRequestList } from './PullRequestList';
 import type { PullRequest } from '../types/activity';
 
-describe('PullRequestList', () => {
-  const repoUrl = 'https://github.com/hivemoot/colony';
+const REPO_URL = 'https://github.com/hivemoot/colony';
 
-  it('renders "No pull requests yet" when pullRequests array is empty', () => {
-    render(<PullRequestList pullRequests={[]} repoUrl={repoUrl} />);
+const basePR: PullRequest = {
+  number: 10,
+  title: 'feat: add dashboard',
+  state: 'open',
+  author: 'hivemoot-builder',
+  createdAt: '2026-02-01T00:00:00Z',
+};
+
+describe('PullRequestList', () => {
+  it('renders empty state when no pull requests', () => {
+    render(<PullRequestList pullRequests={[]} repoUrl={REPO_URL} />);
     expect(screen.getByText(/no pull requests yet/i)).toBeInTheDocument();
   });
 
-  it('renders a list of pull requests with correct details', () => {
-    const pullRequests: PullRequest[] = [
-      {
-        number: 1,
-        title: 'Add new feature',
-        state: 'open',
-        author: 'worker',
-        createdAt: '2026-02-05T09:00:00Z',
-      },
-      {
-        number: 2,
-        title: 'Fix bug',
-        state: 'merged',
-        author: 'scout',
-        createdAt: '2026-02-05T08:00:00Z',
-        mergedAt: '2026-02-05T10:00:00Z',
-      },
-      {
-        number: 3,
-        title: 'Closed PR',
-        state: 'closed',
-        author: 'polisher',
-        createdAt: '2026-02-05T07:00:00Z',
-        closedAt: '2026-02-05T11:00:00Z',
-      },
-    ];
+  it('renders PR with number, title, author, and link', () => {
+    render(<PullRequestList pullRequests={[basePR]} repoUrl={REPO_URL} />);
 
-    render(<PullRequestList pullRequests={pullRequests} repoUrl={repoUrl} />);
-
-    expect(screen.getByText('#1')).toBeInTheDocument();
-    expect(screen.getByText('Add new feature')).toBeInTheDocument();
-    expect(screen.getByText('open')).toBeInTheDocument();
-    expect(screen.getByText('worker')).toBeInTheDocument();
-
-    expect(screen.getByText('#2')).toBeInTheDocument();
-    expect(screen.getByText('Fix bug')).toBeInTheDocument();
-    expect(screen.getByText('merged')).toBeInTheDocument();
-    expect(screen.getByText('scout')).toBeInTheDocument();
-
-    expect(screen.getByText('#3')).toBeInTheDocument();
-    expect(screen.getByText('Closed PR')).toBeInTheDocument();
-    expect(screen.getByText('closed')).toBeInTheDocument();
-    expect(screen.getByText('polisher')).toBeInTheDocument();
-  });
-
-  it('links to the correct pull request URL', () => {
-    const pullRequests: PullRequest[] = [
-      {
-        number: 42,
-        title: 'Test PR',
-        state: 'open',
-        author: 'agent-1',
-        createdAt: '2026-02-05T09:00:00Z',
-      },
-    ];
-
-    render(<PullRequestList pullRequests={pullRequests} repoUrl={repoUrl} />);
+    expect(screen.getByText('#10')).toBeInTheDocument();
+    expect(screen.getByText('feat: add dashboard')).toBeInTheDocument();
+    expect(screen.getByText('hivemoot-builder')).toBeInTheDocument();
 
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute(
       'href',
-      'https://github.com/hivemoot/colony/pull/42'
+      'https://github.com/hivemoot/colony/pull/10'
     );
   });
 
+  it('renders open state badge', () => {
+    render(<PullRequestList pullRequests={[basePR]} repoUrl={REPO_URL} />);
+    expect(screen.getByText('open')).toBeInTheDocument();
+  });
+
+  it('renders merged state badge', () => {
+    const mergedPR: PullRequest = { ...basePR, state: 'merged' };
+    render(<PullRequestList pullRequests={[mergedPR]} repoUrl={REPO_URL} />);
+    expect(screen.getByText('merged')).toBeInTheDocument();
+  });
+
+  it('renders closed state badge', () => {
+    const closedPR: PullRequest = { ...basePR, state: 'closed' };
+    render(<PullRequestList pullRequests={[closedPR]} repoUrl={REPO_URL} />);
+    expect(screen.getByText('closed')).toBeInTheDocument();
+  });
+
   it('renders author avatar images', () => {
-    const pullRequests: PullRequest[] = [
+    render(<PullRequestList pullRequests={[basePR]} repoUrl={REPO_URL} />);
+
+    const avatar = screen.getByAltText('hivemoot-builder');
+    expect(avatar).toHaveAttribute(
+      'src',
+      'https://github.com/hivemoot-builder.png'
+    );
+  });
+
+  it('renders draft badge when PR is a draft', () => {
+    const draftPR: PullRequest = { ...basePR, draft: true };
+    render(<PullRequestList pullRequests={[draftPR]} repoUrl={REPO_URL} />);
+    expect(screen.getByText('draft')).toBeInTheDocument();
+    // State badge should still be present alongside draft badge
+    expect(screen.getByText('open')).toBeInTheDocument();
+  });
+
+  it('does not render draft badge when PR is not a draft', () => {
+    render(<PullRequestList pullRequests={[basePR]} repoUrl={REPO_URL} />);
+    expect(screen.queryByText('draft')).not.toBeInTheDocument();
+  });
+
+  it('does not render draft badge when draft is explicitly false', () => {
+    const nonDraftPR: PullRequest = { ...basePR, draft: false };
+    render(<PullRequestList pullRequests={[nonDraftPR]} repoUrl={REPO_URL} />);
+    expect(screen.queryByText('draft')).not.toBeInTheDocument();
+  });
+
+  it('renders multiple pull requests', () => {
+    const prs: PullRequest[] = [
+      basePR,
+      { ...basePR, number: 11, title: 'fix: resolve crash', state: 'merged' },
       {
-        number: 1,
-        title: 'Test PR',
+        ...basePR,
+        number: 12,
+        title: 'wip: new feature',
         state: 'open',
-        author: 'worker',
-        createdAt: '2026-02-05T09:00:00Z',
+        draft: true,
       },
     ];
+    render(<PullRequestList pullRequests={prs} repoUrl={REPO_URL} />);
 
-    render(<PullRequestList pullRequests={pullRequests} repoUrl={repoUrl} />);
-
-    const avatar = screen.getByAltText('worker');
-    expect(avatar).toHaveAttribute('src', 'https://github.com/worker.png');
+    expect(screen.getByText('#10')).toBeInTheDocument();
+    expect(screen.getByText('#11')).toBeInTheDocument();
+    expect(screen.getByText('#12')).toBeInTheDocument();
+    expect(screen.getByText('draft')).toBeInTheDocument();
   });
 });

--- a/web/src/components/PullRequestList.tsx
+++ b/web/src/components/PullRequestList.tsx
@@ -31,6 +31,11 @@ export function PullRequestList({
               <span className="text-xs text-amber-700 dark:text-amber-300">
                 #{pr.number}
               </span>
+              {pr.draft && (
+                <span className="text-xs px-1.5 py-0.5 rounded bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                  draft
+                </span>
+              )}
               <span
                 className={`text-xs px-1.5 py-0.5 rounded ${getStateStyles(pr.state)}`}
               >

--- a/web/src/types/activity.ts
+++ b/web/src/types/activity.ts
@@ -19,6 +19,7 @@ export interface PullRequest {
   number: number;
   title: string;
   state: 'open' | 'closed' | 'merged';
+  draft?: boolean;
   author: string;
   createdAt: string;
   closedAt?: string | null;


### PR DESCRIPTION
## Summary
- Adds optional `draft?: boolean` field to the `PullRequest` type for backward compatibility
- Updates `generate-data.ts` to capture the `draft` field from the GitHub PR API response
- Displays a neutral gray "Draft" badge in `PullRequestList` next to the state badge when a PR is a draft
- Adds 9 tests for `PullRequestList` covering empty state, all PR states, draft/non-draft rendering, and multi-PR lists

Fixes #23

## Test plan
- [x] All 22 tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] Generator script type check passes (`npx tsc --noEmit -p tsconfig.node.json`)