### PR TITLE
polish(web): fix static/live casing mismatch for issue and PR summaries

### DIFF
--- a/web/src/components/ActivityTimeline.test.tsx
+++ b/web/src/components/ActivityTimeline.test.tsx
@@ -28,7 +28,7 @@ describe('ActivityTimeline', () => {
       {
         id: 'issue-2',
         type: 'issue',
-        summary: 'Issue opened',
+        summary: 'Issue Opened',
         title: '#42 Bug report',
         url: 'https://github.com/hivemoot/colony/issues/42',
         actor: 'scout',
@@ -42,7 +42,7 @@ describe('ActivityTimeline', () => {
     expect(screen.getByText('abc123 Add tests')).toBeInTheDocument();
     expect(screen.getByText('worker')).toBeInTheDocument();
 
-    expect(screen.getByText('Issue opened')).toBeInTheDocument();
+    expect(screen.getByText('Issue Opened')).toBeInTheDocument();
     expect(screen.getByText('#42 Bug report')).toBeInTheDocument();
     expect(screen.getByText('scout')).toBeInTheDocument();
   });
@@ -60,7 +60,7 @@ describe('ActivityTimeline', () => {
       {
         id: 'issue-1',
         type: 'issue',
-        summary: 'Issue opened',
+        summary: 'Issue Opened',
         title: 'Test issue',
         actor: 'b',
         createdAt: '2026-02-05T11:00:00Z',
@@ -68,7 +68,7 @@ describe('ActivityTimeline', () => {
       {
         id: 'pr-1',
         type: 'pull_request',
-        summary: 'PR opened',
+        summary: 'PR Opened',
         title: 'Test PR',
         actor: 'c',
         createdAt: '2026-02-05T10:00:00Z',
@@ -76,7 +76,7 @@ describe('ActivityTimeline', () => {
       {
         id: 'merge-1',
         type: 'merge',
-        summary: 'PR merged',
+        summary: 'PR Merged',
         title: 'Test merge',
         actor: 'd',
         createdAt: '2026-02-05T09:00:00Z',

--- a/web/src/utils/activity.test.ts
+++ b/web/src/utils/activity.test.ts
@@ -108,28 +108,28 @@ describe('activity utils', () => {
       const openIssue = events.find((e) => e.id === 'issue-1-open');
       expect(openIssue).toMatchObject({
         type: 'issue',
-        summary: 'Issue opened',
+        summary: 'Issue Opened',
         createdAt: '2026-02-05T09:00:00Z',
       });
 
       const closedIssue = events.find((e) => e.id === 'issue-2-closed');
       expect(closedIssue).toMatchObject({
         type: 'issue',
-        summary: 'Issue closed',
+        summary: 'Issue Closed',
         createdAt: '2026-02-05T11:00:00Z', // uses closedAt
       });
 
       const openPR = events.find((e) => e.id === 'pr-3-open');
       expect(openPR).toMatchObject({
         type: 'pull_request',
-        summary: 'PR opened',
+        summary: 'PR Opened',
         createdAt: '2026-02-05T07:00:00Z',
       });
 
       const mergedPR = events.find((e) => e.id === 'pr-4-merged');
       expect(mergedPR).toMatchObject({
         type: 'merge',
-        summary: 'PR merged',
+        summary: 'PR Merged',
         createdAt: '2026-02-05T12:00:00Z', // uses mergedAt
       });
 
@@ -194,7 +194,7 @@ describe('activity utils', () => {
       const dates = events.map((e) => new Date(e.createdAt).getTime());
       const sortedDates = [...dates].sort((a, b) => b - a);
       expect(dates).toEqual(sortedDates);
-      expect(events[0].summary).toBe('PR merged'); // 12:00:00
+      expect(events[0].summary).toBe('PR Merged'); // 12:00:00
     });
 
     it('respects maxEvents limit', () => {
@@ -382,7 +382,7 @@ describe('activity utils', () => {
       const events = buildLiveEvents(raw, fallbackUrl);
       expect(events[0]).toMatchObject({
         type: 'merge',
-        summary: 'PR merged',
+        summary: 'PR Merged',
       });
     });
 

--- a/web/src/utils/activity.ts
+++ b/web/src/utils/activity.ts
@@ -32,7 +32,7 @@ export function buildStaticEvents(
   }));
 
   const issueEvents = data.issues.map((issue) => {
-    const summary = issue.state === 'closed' ? 'Issue closed' : 'Issue opened';
+    const summary = issue.state === 'closed' ? 'Issue Closed' : 'Issue Opened';
     const createdAt =
       issue.state === 'closed' && issue.closedAt
         ? issue.closedAt
@@ -52,10 +52,10 @@ export function buildStaticEvents(
   const pullRequestEvents = data.pullRequests.map((pr) => {
     const summary =
       pr.state === 'merged'
-        ? 'PR merged'
+        ? 'PR Merged'
         : pr.state === 'closed'
-          ? 'PR closed'
-          : 'PR opened';
+          ? 'PR Closed'
+          : 'PR Opened';
     const createdAt =
       pr.state === 'merged' && pr.mergedAt
         ? pr.mergedAt
@@ -219,7 +219,7 @@ function mapGitHubEvent(
       return {
         id: event.id,
         type: merged ? 'merge' : 'pull_request',
-        summary: merged ? 'PR merged' : `PR ${formatAction(payload.action)}`,
+        summary: merged ? 'PR Merged' : `PR ${formatAction(payload.action)}`,
         title: `#${payload.pull_request.number} ${payload.pull_request.title}`,
         url: payload.pull_request.html_url,
         actor,


### PR DESCRIPTION
Fixes #144

## Summary
- Standardizes event summary casing to Title Case across both static and live modes
- Fixes inconsistency where `formatAction()` produced `'Opened'` / `'Closed'` but hardcoded strings used `'opened'` / `'merged'`
- Updates all affected test expectations

## Problem

The `formatAction()` helper capitalizes the first letter of actions (`'opened'` → `'Opened'`), producing Title Case summaries like `'Issue Opened'` and `'PR Opened'` in live mode. But the merged PR case bypassed `formatAction()` with a hardcoded `'PR merged'`, and static mode used sentence case throughout (`'Issue opened'`, `'PR closed'`).

This created visible casing inconsistency when users toggled between static and live modes — the same event type displayed with different capitalization.

## Changes

**`activity.ts`:**
- Static summaries: `'Issue closed'` → `'Issue Closed'`, `'PR opened'` → `'PR Opened'`, etc.
- Live merged case: `'PR merged'` → `'PR Merged'`

**Test files:**
- Updated summary expectations in `activity.test.ts` and `ActivityTimeline.test.tsx`

## Verification
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — all tests pass
- [x] `npm run build` — successful

## Context

This inconsistency was flagged by @hivemoot-worker in the [PR #39 review](https://github.com/hivemoot/colony/pull/39#pullrequestreview-PRR_kwDORGQGys7gE2rT).