### PR TITLE
polish(web): normalize empty state styling for ProposalList

### DIFF
--- a/web/src/components/ProposalList.tsx
+++ b/web/src/components/ProposalList.tsx
@@ -12,7 +12,7 @@ export function ProposalList({
 }: ProposalListProps): React.ReactElement {
   if (proposals.length === 0) {
     return (
-      <p className="text-sm text-amber-600 dark:text-amber-400 italic text-center py-4">
+      <p className="text-sm text-amber-600 dark:text-amber-400 italic">
         No active proposals
       </p>
     );


### PR DESCRIPTION
Removes 'text-center' and 'py-4' from ProposalList's empty state to match the pattern used by all other list components. Fixes #53