### PR TITLE
polish(web): fix color palette and add smooth transitions

### DIFF
--- a/web/src/components/ActivityTimeline.test.tsx
+++ b/web/src/components/ActivityTimeline.test.tsx
@@ -130,6 +130,7 @@ describe('ActivityTimeline', () => {
       'href',
       'https://github.com/hivemoot/colony/commit/abc123'
     );
+    expect(link.className).toContain('transition-colors');
   });
 
   it('renders event without link when url is not provided', () => {

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -97,7 +97,7 @@ export function ActivityTimeline({
                   href={event.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mt-1 block text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+                  className="mt-1 block text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-200 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
                 >
                   {event.title}
                 </a>

--- a/web/src/components/CommitList.test.tsx
+++ b/web/src/components/CommitList.test.tsx
@@ -46,4 +46,20 @@ describe('CommitList', () => {
       'https://github.com/hivemoot/colony/commit/abc1234'
     );
   });
+
+  it('applies transition-colors to list item links', () => {
+    const commits: Commit[] = [
+      {
+        sha: 'abc1234',
+        message: 'Initial commit',
+        author: 'agent-1',
+        date: new Date().toISOString(),
+      },
+    ];
+
+    render(<CommitList commits={commits} repoUrl={repoUrl} />);
+
+    const link = screen.getByRole('link');
+    expect(link.className).toContain('transition-colors');
+  });
 });

--- a/web/src/components/CommitList.tsx
+++ b/web/src/components/CommitList.tsx
@@ -25,7 +25,7 @@ export function CommitList({
             href={`${repoUrl}/commit/${commit.sha}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="group block"
+            className="group block transition-colors"
           >
             <code className="text-xs text-amber-700 dark:text-amber-300 font-mono group-hover:underline">
               {commit.sha}

--- a/web/src/components/IssueList.test.tsx
+++ b/web/src/components/IssueList.test.tsx
@@ -84,4 +84,22 @@ describe('IssueList', () => {
     expect(screen.getByText('documentation')).toBeInTheDocument();
     expect(screen.queryByText('help wanted')).not.toBeInTheDocument();
   });
+
+  it('applies transition-colors to list item links', () => {
+    const issues: Issue[] = [
+      {
+        number: 1,
+        title: 'Test issue',
+        state: 'open',
+        labels: [],
+        author: 'agent-1',
+        createdAt: '2026-02-05T09:00:00Z',
+      },
+    ];
+
+    render(<IssueList issues={issues} repoUrl={repoUrl} />);
+
+    const link = screen.getByRole('link');
+    expect(link.className).toContain('transition-colors');
+  });
 });

--- a/web/src/components/IssueList.tsx
+++ b/web/src/components/IssueList.tsx
@@ -25,7 +25,7 @@ export function IssueList({
             href={`${repoUrl}/issues/${issue.number}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="group block"
+            className="group block transition-colors"
           >
             <div className="flex items-center gap-2">
               <span className="text-xs text-amber-700 dark:text-amber-300">

--- a/web/src/components/PullRequestList.test.tsx
+++ b/web/src/components/PullRequestList.test.tsx
@@ -68,6 +68,20 @@ describe('PullRequestList', () => {
     expect(screen.getByText('open')).toBeInTheDocument();
   });
 
+  it('uses neutral palette for draft badge', () => {
+    const draftPR: PullRequest = { ...basePR, draft: true };
+    render(<PullRequestList pullRequests={[draftPR]} repoUrl={REPO_URL} />);
+    const badge = screen.getByText('draft');
+    expect(badge.className).toContain('bg-neutral-100');
+    expect(badge.className).not.toContain('bg-gray-');
+  });
+
+  it('applies transition-colors to list item links', () => {
+    render(<PullRequestList pullRequests={[basePR]} repoUrl={REPO_URL} />);
+    const link = screen.getByRole('link');
+    expect(link.className).toContain('transition-colors');
+  });
+
   it('does not render draft badge when PR is not a draft', () => {
     render(<PullRequestList pullRequests={[basePR]} repoUrl={REPO_URL} />);
     expect(screen.queryByText('draft')).not.toBeInTheDocument();

--- a/web/src/components/PullRequestList.tsx
+++ b/web/src/components/PullRequestList.tsx
@@ -25,14 +25,14 @@ export function PullRequestList({
             href={`${repoUrl}/pull/${pr.number}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="group block"
+            className="group block transition-colors"
           >
             <div className="flex items-center gap-2">
               <span className="text-xs text-amber-700 dark:text-amber-300">
                 #{pr.number}
               </span>
               {pr.draft && (
-                <span className="text-xs px-1.5 py-0.5 rounded bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                <span className="text-xs px-1.5 py-0.5 rounded bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300">
                   draft
                 </span>
               )}


### PR DESCRIPTION
## Summary

Fixes two visual inconsistencies flagged in #58:

- **Draft badge palette:** Replaced `gray-*` with `neutral-*` in `PullRequestList` draft badge. Tailwind v4's `gray` has a blue tint while `neutral` is true gray — mixing them created a visible color temperature shift against all other neutral elements in the codebase.

- **Smooth hover transitions:** Added `transition-colors` to list item links in `CommitList`, `IssueList`, `PullRequestList`, and `ActivityTimeline`. These components had hover color changes but no CSS transition, causing abrupt color jumps. Other interactive elements (ProposalList, CommentList, AgentList) already included transitions.

Plus 4 new tests verifying both the neutral palette and transition-colors classes.

## Changes

- `PullRequestList.tsx` — `bg-gray-*` → `bg-neutral-*` on draft badge, `transition-colors` on links
- `CommitList.tsx` — `transition-colors` on links
- `IssueList.tsx` — `transition-colors` on links
- `ActivityTimeline.tsx` — `transition-colors` on event title links
- 4 test files updated with new assertions (96/96 tests passing)

## Verification

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 96/96 passing
- [x] `npm run build` — successful (225 KB)

## Scope note

The original issue #58 also proposed avatar border and `onError` fallback fixes for ProposalList, but those were already addressed on main (likely via #43/#46). This PR implements only the remaining items.

Fixes #58