### PR TITLE
a11y(web): replace raw timestamp spans with semantic time elements

### DIFF
--- a/web/src/components/ActivityFeed.test.tsx
+++ b/web/src/components/ActivityFeed.test.tsx
@@ -222,4 +222,18 @@ describe('ActivityFeed', () => {
     render(<ActivityFeed {...defaultProps} lastUpdated={null} />);
     expect(screen.getByText(/last updated: unknown/i)).toBeInTheDocument();
   });
+
+  it('renders last updated timestamp in a semantic time element', () => {
+    render(<ActivityFeed {...defaultProps} />);
+    const paragraph = screen.getByText(/last updated/i);
+    const timeEl = paragraph.querySelector('time');
+    expect(timeEl).toBeInTheDocument();
+    expect(timeEl).toHaveAttribute('datetime', '2026-02-05T12:00:00.000Z');
+  });
+
+  it('does not render a time element when lastUpdated is null', () => {
+    render(<ActivityFeed {...defaultProps} lastUpdated={null} />);
+    const paragraph = screen.getByText(/last updated: unknown/i);
+    expect(paragraph.querySelector('time')).toBeNull();
+  });
 });

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -45,7 +45,12 @@ export function ActivityFeed({
               Live Activity Feed
             </h2>
             <p className="text-sm text-amber-600 dark:text-amber-400">
-              Last updated: {timeAgo}
+              Last updated:{' '}
+              {lastUpdated ? (
+                <time dateTime={lastUpdated.toISOString()}>{timeAgo}</time>
+              ) : (
+                timeAgo
+              )}
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-3">

--- a/web/src/components/ActivityTimeline.test.tsx
+++ b/web/src/components/ActivityTimeline.test.tsx
@@ -152,7 +152,7 @@ describe('ActivityTimeline', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders time ago for each event', () => {
+  it('renders time ago in a semantic time element with dateTime', () => {
     const events: ActivityEvent[] = [
       {
         id: 'commit-1',
@@ -166,7 +166,9 @@ describe('ActivityTimeline', () => {
 
     render(<ActivityTimeline events={events} />);
 
-    expect(screen.getByText('5 minutes ago')).toBeInTheDocument();
+    const timeEl = screen.getByText('5 minutes ago');
+    expect(timeEl.tagName).toBe('TIME');
+    expect(timeEl).toHaveAttribute('datetime', '2026-02-05T10:00:00Z');
   });
 
   it('renders actor avatars', () => {

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -91,7 +91,7 @@ export function ActivityTimeline({
                 >
                   •
                 </span>
-                <span>{timeAgo}</span>
+                <time dateTime={event.createdAt}>{timeAgo}</time>
               </div>
               {event.url ? (
                 <a

--- a/web/src/components/AgentLeaderboard.test.tsx
+++ b/web/src/components/AgentLeaderboard.test.tsx
@@ -62,4 +62,25 @@ describe('AgentLeaderboard', () => {
     expect(screen.getByText('agent-1')).toBeInTheDocument();
     expect(screen.getByText('agent-2')).toBeInTheDocument();
   });
+
+  it('renders last active timestamp in a semantic time element', () => {
+    const isoDate = '2026-02-05T10:00:00Z';
+    const stats: AgentStats[] = [
+      {
+        login: 'agent-1',
+        commits: 1,
+        pullRequestsMerged: 0,
+        issuesOpened: 0,
+        reviews: 0,
+        comments: 0,
+        lastActiveAt: isoDate,
+      },
+    ];
+
+    render(<AgentLeaderboard stats={stats} />);
+
+    const timeEl = document.querySelector('time');
+    expect(timeEl).toBeInTheDocument();
+    expect(timeEl).toHaveAttribute('datetime', isoDate);
+  });
 });

--- a/web/src/components/AgentLeaderboard.tsx
+++ b/web/src/components/AgentLeaderboard.tsx
@@ -100,7 +100,9 @@ export function AgentLeaderboard({
                 </span>
               </td>
               <td className="py-3 text-right pr-2 rounded-r-lg border-y border-r border-amber-100 dark:border-neutral-700 text-xs text-amber-600 dark:text-amber-400">
-                {formatTimeAgo(new Date(agent.lastActiveAt))}
+                <time dateTime={agent.lastActiveAt}>
+                  {formatTimeAgo(new Date(agent.lastActiveAt))}
+                </time>
               </td>
             </tr>
           ))}

--- a/web/src/components/CommentList.test.tsx
+++ b/web/src/components/CommentList.test.tsx
@@ -41,4 +41,25 @@ describe('CommentList', () => {
     expect(screen.getByText(/commented on PR #11/i)).toBeInTheDocument();
     expect(screen.getByText('"This is a PR review"')).toBeInTheDocument();
   });
+
+  it('renders comment timestamps in semantic time elements with dateTime', () => {
+    const isoDate = '2026-02-05T07:00:00Z';
+    const comments: Comment[] = [
+      {
+        id: 1,
+        issueOrPrNumber: 10,
+        type: 'issue',
+        author: 'agent-1',
+        body: 'Test',
+        createdAt: isoDate,
+        url: 'https://github.com/hivemoot/colony/issues/10#comment-1',
+      },
+    ];
+
+    render(<CommentList comments={comments} />);
+
+    const timeEl = document.querySelector('time');
+    expect(timeEl).toBeInTheDocument();
+    expect(timeEl).toHaveAttribute('datetime', isoDate);
+  });
 });

--- a/web/src/components/CommentList.tsx
+++ b/web/src/components/CommentList.tsx
@@ -46,7 +46,10 @@ export function CommentList({
             <p className="text-amber-800 dark:text-neutral-300 text-xs italic leading-relaxed line-clamp-3">
               "{comment.body}"
             </p>
-            <time className="block mt-1.5 text-[10px] text-amber-500 dark:text-amber-500">
+            <time
+              dateTime={comment.createdAt}
+              className="block mt-1.5 text-[10px] text-amber-500 dark:text-amber-500"
+            >
               {formatTimeAgo(new Date(comment.createdAt))}
             </time>
           </a>


### PR DESCRIPTION
## Summary

Replaces plain text timestamp elements with semantic `<time dateTime="...">` across the dashboard, improving accessibility for screen readers and providing machine-readable ISO 8601 timestamps for structured data.

**Changes in 4 components:**

1. **ActivityFeed.tsx** — "Last updated" text wrapped in `<time dateTime>` when a valid date is available; falls back to plain text for "unknown"
2. **AgentLeaderboard.tsx** — "Last Active" column values wrapped in `<time dateTime={agent.lastActiveAt}>`
3. **ActivityTimeline.tsx** — Event timestamps changed from `<span>` to `<time dateTime={event.createdAt}>`
4. **CommentList.tsx** — Added missing `dateTime={comment.createdAt}` attribute to existing `<time>` element

**Tests:** 6 new test assertions across 4 test files verify `<time>` elements render with correct `dateTime` attributes. All 96 tests passing, lint clean, build green.

**Impact:** Zero visual change. Purely semantic/accessibility improvement following the existing `CommentList` pattern.

Fixes #61