### PR TITLE
fix(web): use singular time units in formatTimeAgo

### DIFF
--- a/web/src/utils/time.test.ts
+++ b/web/src/utils/time.test.ts
@@ -11,7 +11,7 @@ describe('formatTimeAgo', () => {
 
   it('returns "X minutes ago" for 60s–3599s', () => {
     const oneMin = new Date(now - 60 * 1000);
-    expect(formatTimeAgo(oneMin, now)).toBe('1 minutes ago');
+    expect(formatTimeAgo(oneMin, now)).toBe('1 minute ago');
 
     const fiftyNineMin = new Date(now - 3599 * 1000);
     expect(formatTimeAgo(fiftyNineMin, now)).toBe('59 minutes ago');
@@ -19,7 +19,7 @@ describe('formatTimeAgo', () => {
 
   it('returns "X hours ago" for 3600s–86399s', () => {
     const oneHour = new Date(now - 3600 * 1000);
-    expect(formatTimeAgo(oneHour, now)).toBe('1 hours ago');
+    expect(formatTimeAgo(oneHour, now)).toBe('1 hour ago');
 
     const twentyThreeHours = new Date(now - 23 * 3600 * 1000 - 59 * 60 * 1000);
     expect(formatTimeAgo(twentyThreeHours, now)).toBe('23 hours ago');
@@ -27,7 +27,7 @@ describe('formatTimeAgo', () => {
 
   it('returns "X days ago" for >= 86400s', () => {
     const oneDay = new Date(now - 86400 * 1000);
-    expect(formatTimeAgo(oneDay, now)).toBe('1 days ago');
+    expect(formatTimeAgo(oneDay, now)).toBe('1 day ago');
 
     const tenDays = new Date(now - 10 * 86400 * 1000);
     expect(formatTimeAgo(tenDays, now)).toBe('10 days ago');
@@ -35,15 +35,15 @@ describe('formatTimeAgo', () => {
 
   it('handles boundary conditions', () => {
     expect(formatTimeAgo(new Date(now - 59 * 1000), now)).toBe('just now');
-    expect(formatTimeAgo(new Date(now - 60 * 1000), now)).toBe('1 minutes ago');
+    expect(formatTimeAgo(new Date(now - 60 * 1000), now)).toBe('1 minute ago');
     expect(formatTimeAgo(new Date(now - 3599 * 1000), now)).toBe(
       '59 minutes ago'
     );
-    expect(formatTimeAgo(new Date(now - 3600 * 1000), now)).toBe('1 hours ago');
+    expect(formatTimeAgo(new Date(now - 3600 * 1000), now)).toBe('1 hour ago');
     expect(formatTimeAgo(new Date(now - 86399 * 1000), now)).toBe(
       '23 hours ago'
     );
-    expect(formatTimeAgo(new Date(now - 86400 * 1000), now)).toBe('1 days ago');
+    expect(formatTimeAgo(new Date(now - 86400 * 1000), now)).toBe('1 day ago');
   });
 });
 

--- a/web/src/utils/time.ts
+++ b/web/src/utils/time.ts
@@ -2,9 +2,16 @@ export function formatTimeAgo(date: Date, now = Date.now()): string {
   const seconds = Math.floor((now - date.getTime()) / 1000);
 
   if (seconds < 60) return 'just now';
-  if (seconds < 3600) return `${Math.floor(seconds / 60)} minutes ago`;
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)} hours ago`;
-  return `${Math.floor(seconds / 86400)} days ago`;
+  if (seconds < 3600) {
+    const m = Math.floor(seconds / 60);
+    return `${m} ${m === 1 ? 'minute' : 'minutes'} ago`;
+  }
+  if (seconds < 86400) {
+    const h = Math.floor(seconds / 3600);
+    return `${h} ${h === 1 ? 'hour' : 'hours'} ago`;
+  }
+  const d = Math.floor(seconds / 86400);
+  return `${d} ${d === 1 ? 'day' : 'days'} ago`;
 }
 
 /**


### PR DESCRIPTION
Fixes #143

Fixes the incorrect pluralization in `formatTimeAgo` — "1 minutes ago" now correctly reads "1 minute ago", and same for hours and days.

## Changes

- `time.ts`: Added singular/plural branching for minute, hour, and day units
- `time.test.ts`: Updated expectations for count=1 cases (`1 minute ago`, `1 hour ago`, `1 day ago`)

## Context

This is the unique remaining contribution from PR #39, extracted into a focused PR after that branch developed irreconcilable conflicts with upstream. The casing fixes from #39 are covered separately by PR #48.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` — all tests pass
- [x] `npm run build` succeeds