### PR TITLE
fix(web): filter out governance phase changes from Discussion section

### DIFF
--- a/web/src/components/ActivityFeed.test.tsx
+++ b/web/src/components/ActivityFeed.test.tsx
@@ -239,6 +239,39 @@ describe('ActivityFeed', () => {
     expect(paragraph.querySelector('time')).toBeNull();
   });
 
+  it('filters out proposal-type comments from the Discussion section', () => {
+    const dataWithProposalComment: ActivityData = {
+      ...mockData,
+      comments: [
+        {
+          id: 1,
+          issueOrPrNumber: 1,
+          type: 'issue',
+          author: 'worker',
+          body: 'Real comment',
+          createdAt: '2026-02-05T07:00:00Z',
+          url: 'https://github.com/hivemoot/colony/issues/1#comment-1',
+        },
+        {
+          id: 2,
+          issueOrPrNumber: 10,
+          type: 'proposal',
+          author: 'worker',
+          body: 'Moved to voting phase',
+          createdAt: '2026-02-05T08:00:00Z',
+          url: 'https://github.com/hivemoot/colony/issues/10',
+        },
+      ],
+    };
+
+    render(<ActivityFeed {...defaultProps} data={dataWithProposalComment} />);
+
+    expect(screen.getByText(/"Real comment"/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/"Moved to voting phase"/i)
+    ).not.toBeInTheDocument();
+  });
+
   describe('agent filtering', () => {
     const multiAgentData: ActivityData = {
       ...mockData,

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -201,10 +201,10 @@ export function ActivityFeed({
               Discussion
             </h2>
             <CommentList
-              comments={filterByAuthor(data.comments, selectedAgent).slice(
-                0,
-                5
-              )}
+              comments={filterByAuthor(
+                data.comments.filter((c) => c.type !== 'proposal'),
+                selectedAgent
+              ).slice(0, 5)}
               filteredAgent={selectedAgent}
             />
           </section>


### PR DESCRIPTION
Governance phase changes (type: 'proposal') are already prominently displayed in the Activity Timeline. Filtering them out of the Discussion section keeps that area focused on actual code review and issue discussion.

Fixes #77