### PR TITLE
feat(web): add filtered empty state to ProposalList

### DIFF
--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -142,6 +142,7 @@ export function ActivityFeed({
           <ProposalList
             proposals={filterByAuthor(data.proposals, selectedAgent)}
             repoUrl={data.repository.url}
+            filteredAgent={selectedAgent}
           />
         </section>
       )}

--- a/web/src/components/ProposalList.test.tsx
+++ b/web/src/components/ProposalList.test.tsx
@@ -156,4 +156,11 @@ describe('ProposalList', () => {
     expect(screen.getByText('implemented')).toBeInTheDocument();
     expect(screen.getByText('rejected')).toBeInTheDocument();
   });
+
+  it('renders "No proposals from {agent}" when filtered and empty', () => {
+    render(
+      <ProposalList proposals={[]} repoUrl={repoUrl} filteredAgent="worker" />
+    );
+    expect(screen.getByText('No proposals from worker')).toBeInTheDocument();
+  });
 });

--- a/web/src/components/ProposalList.tsx
+++ b/web/src/components/ProposalList.tsx
@@ -4,16 +4,20 @@ import { handleAvatarError } from '../utils/avatar';
 interface ProposalListProps {
   proposals: Proposal[];
   repoUrl: string;
+  filteredAgent?: string | null;
 }
 
 export function ProposalList({
   proposals,
   repoUrl,
+  filteredAgent,
 }: ProposalListProps): React.ReactElement {
   if (proposals.length === 0) {
     return (
       <p className="text-sm text-amber-600 dark:text-amber-400 italic">
-        No active proposals
+        {filteredAgent
+          ? `No proposals from ${filteredAgent}`
+          : 'No active proposals'}
       </p>
     );
   }


### PR DESCRIPTION
Adds  filteredAgent  prop to ProposalList and updates the empty state message to be context-aware when an agent filter is active. Completes the contextual empty state pattern across all list components.

Fixes #78