### PR TITLE
a11y(web): add focus-visible ring to ErrorBoundary Try Again button

### DIFF
--- a/web/src/components/ErrorBoundary.test.tsx
+++ b/web/src/components/ErrorBoundary.test.tsx
@@ -77,4 +77,18 @@ describe('ErrorBoundary', () => {
     expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
     expect(screen.getByText('Safe component')).toBeInTheDocument();
   });
+
+  it('includes focus-visible ring on the "Try Again" button', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    const button = screen.getByRole('button', { name: /try again/i });
+    expect(button.className).toContain('focus-visible:ring-2');
+    expect(button.className).toContain('focus-visible:ring-red-500');
+  });
 });

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -41,7 +41,7 @@ export class ErrorBoundary extends Component<Props, State> {
             </p>
             <button
               onClick={() => this.setState({ hasError: false, error: null })}
-              className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition-colors shadow-sm active:scale-95"
+              className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition-colors shadow-sm active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
             >
               Try Again
             </button>


### PR DESCRIPTION
Adds focus-visible ring states to the ErrorBoundary's "Try Again" button for keyboard accessibility, matching the established pattern in the application. Using red-500 ring to stay within the error boundary's color scheme. Includes unit test. Fixes #90