### PR TITLE
fix(web): distinguish between issue and PR comments in live activity

### DIFF
--- a/web/src/utils/activity.test.ts
+++ b/web/src/utils/activity.test.ts
@@ -315,6 +315,32 @@ describe('activity utils', () => {
       });
     });
 
+    it('maps IssueCommentEvent on PR correctly', () => {
+      const raw = [
+        {
+          id: '9',
+          type: 'IssueCommentEvent',
+          actor: { login: 'polisher' },
+          created_at: '2026-02-05T12:00:00Z',
+          payload: {
+            issue: {
+              number: 6,
+              title: 'Cool PR',
+              html_url: 'url',
+              pull_request: {},
+            },
+            comment: { html_url: 'comment-url' },
+          },
+        },
+      ];
+      const events = buildLiveEvents(raw, fallbackUrl);
+      expect(events[0]).toMatchObject({
+        type: 'comment',
+        summary: 'Commented on PR',
+        url: 'comment-url',
+      });
+    });
+
     it('maps PullRequestEvent correctly (opened)', () => {
       const raw = [
         {

--- a/web/src/utils/activity.ts
+++ b/web/src/utils/activity.ts
@@ -184,14 +184,20 @@ function mapGitHubEvent(
     }
     case 'IssueCommentEvent': {
       const payload = event.payload as {
-        issue?: { number: number; title: string; html_url: string };
+        issue?: {
+          number: number;
+          title: string;
+          html_url: string;
+          pull_request?: unknown;
+        };
         comment?: { html_url: string };
       };
       if (!payload.issue) return null;
+      const isPR = Boolean(payload.issue.pull_request);
       return {
         id: event.id,
         type: 'comment',
-        summary: 'Commented on issue',
+        summary: isPR ? 'Commented on PR' : 'Commented on issue',
         title: `#${payload.issue.number} ${payload.issue.title}`,
         url: payload.comment?.html_url ?? payload.issue.html_url,
         actor,


### PR DESCRIPTION
GitHub fires IssueCommentEvent for both issues and PRs. This change checks for the presence of 'pull_request' in the issue payload to provide the correct summary.

Fixes #94