### PR TITLE
a11y(web): normalize motion-safe prefix on transitions and transforms

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -99,7 +99,7 @@ function App(): React.ReactElement {
           href="https://github.com/hivemoot/colony"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center justify-center px-6 py-3 bg-amber-600 hover:bg-amber-700 text-white font-medium rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
+          className="inline-flex items-center justify-center px-6 py-3 bg-amber-600 hover:bg-amber-700 text-white font-medium rounded-lg motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
         >
           View on GitHub
         </a>
@@ -107,7 +107,7 @@ function App(): React.ReactElement {
           href="https://github.com/hivemoot/hivemoot"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center justify-center px-6 py-3 bg-amber-100 hover:bg-amber-200 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-amber-900 dark:text-amber-100 font-medium rounded-lg transition-colors border border-amber-300 dark:border-neutral-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
+          className="inline-flex items-center justify-center px-6 py-3 bg-amber-100 hover:bg-amber-200 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-amber-900 dark:text-amber-100 font-medium rounded-lg motion-safe:transition-colors border border-amber-300 dark:border-neutral-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
         >
           Learn About Hivemoot
         </a>

--- a/web/src/components/ActivityTimeline.test.tsx
+++ b/web/src/components/ActivityTimeline.test.tsx
@@ -139,7 +139,7 @@ describe('ActivityTimeline', () => {
       'href',
       'https://github.com/hivemoot/colony/commit/abc123'
     );
-    expect(link.className).toContain('transition-colors');
+    expect(link.className).toContain('motion-safe:transition-colors');
   });
 
   it('renders event without link when url is not provided', () => {

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -105,7 +105,7 @@ export function ActivityTimeline({
                   href={event.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mt-1 block text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-200 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+                  className="mt-1 block text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-200 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
                 >
                   {event.title}
                 </a>

--- a/web/src/components/AgentLeaderboard.tsx
+++ b/web/src/components/AgentLeaderboard.tsx
@@ -92,7 +92,7 @@ export function AgentLeaderboard({
                         `https://github.com/${agent.login}.png`
                       }
                       alt={agent.login}
-                      className={`w-8 h-8 rounded-full border transition-colors ${
+                      className={`w-8 h-8 rounded-full border motion-safe:transition-colors ${
                         isSelected
                           ? 'border-amber-500 dark:border-amber-400'
                           : 'border-amber-200 dark:border-neutral-600'
@@ -103,7 +103,7 @@ export function AgentLeaderboard({
                       href={`https://github.com/${agent.login}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="font-medium text-amber-900 dark:text-amber-100 hover:text-amber-600 dark:hover:text-amber-400 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+                      className="font-medium text-amber-900 dark:text-amber-100 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
                       onClick={(e) => e.stopPropagation()}
                     >
                       {agent.login}

--- a/web/src/components/CommentList.tsx
+++ b/web/src/components/CommentList.tsx
@@ -29,7 +29,7 @@ export function CommentList({
             href={comment.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="group block bg-amber-50/30 dark:bg-neutral-800/30 rounded p-2.5 border border-amber-100/50 dark:border-neutral-700/50 hover:border-amber-300 dark:hover:border-neutral-500 transition-colors"
+            className="group block bg-amber-50/30 dark:bg-neutral-800/30 rounded p-2.5 border border-amber-100/50 dark:border-neutral-700/50 hover:border-amber-300 dark:hover:border-neutral-500 motion-safe:transition-colors"
           >
             <div className="flex items-center gap-1.5 mb-2">
               <img

--- a/web/src/components/CommitList.test.tsx
+++ b/web/src/components/CommitList.test.tsx
@@ -70,7 +70,7 @@ describe('CommitList', () => {
     );
   });
 
-  it('applies transition-colors to list item links', () => {
+  it('applies motion-safe:transition-colors to list item links', () => {
     const commits: Commit[] = [
       {
         sha: 'abc1234',
@@ -83,6 +83,6 @@ describe('CommitList', () => {
     render(<CommitList commits={commits} repoUrl={repoUrl} />);
 
     const link = screen.getByRole('link');
-    expect(link.className).toContain('transition-colors');
+    expect(link.className).toContain('motion-safe:transition-colors');
   });
 });

--- a/web/src/components/CommitList.tsx
+++ b/web/src/components/CommitList.tsx
@@ -28,7 +28,7 @@ export function CommitList({
             href={`${repoUrl}/commit/${commit.sha}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="group block transition-colors"
+            className="group block motion-safe:transition-colors"
           >
             <code className="text-xs text-amber-700 dark:text-amber-300 font-mono group-hover:underline">
               {commit.sha}

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -41,7 +41,7 @@ export class ErrorBoundary extends Component<Props, State> {
             </p>
             <button
               onClick={() => this.setState({ hasError: false, error: null })}
-              className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition-colors shadow-sm active:scale-95"
+              className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium motion-safe:transition-colors shadow-sm motion-safe:active:scale-95"
             >
               Try Again
             </button>

--- a/web/src/components/IssueList.test.tsx
+++ b/web/src/components/IssueList.test.tsx
@@ -106,7 +106,7 @@ describe('IssueList', () => {
     expect(screen.queryByText('help wanted')).not.toBeInTheDocument();
   });
 
-  it('applies transition-colors to list item links', () => {
+  it('applies motion-safe:transition-colors to list item links', () => {
     const issues: Issue[] = [
       {
         number: 1,
@@ -121,6 +121,6 @@ describe('IssueList', () => {
     render(<IssueList issues={issues} repoUrl={repoUrl} />);
 
     const link = screen.getByRole('link');
-    expect(link.className).toContain('transition-colors');
+    expect(link.className).toContain('motion-safe:transition-colors');
   });
 });

--- a/web/src/components/IssueList.tsx
+++ b/web/src/components/IssueList.tsx
@@ -27,7 +27,7 @@ export function IssueList({
             href={`${repoUrl}/issues/${issue.number}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="group block transition-colors"
+            className="group block motion-safe:transition-colors"
           >
             <div className="flex items-center gap-2">
               <span className="text-xs text-amber-700 dark:text-amber-300">

--- a/web/src/components/ProjectHealth.tsx
+++ b/web/src/components/ProjectHealth.tsx
@@ -16,7 +16,7 @@ export function ProjectHealth({
         href={`${repository.url}/stargazers`}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-amber-600 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
         title="Stars"
       >
         <span role="img" aria-label="star">
@@ -31,7 +31,7 @@ export function ProjectHealth({
         href={`${repository.url}/network/members`}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-amber-600 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
         title="Forks"
       >
         <span role="img" aria-label="fork">
@@ -46,7 +46,7 @@ export function ProjectHealth({
         href={`${repository.url}/issues`}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-amber-600 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
         title="Open Issues"
       >
         <span role="img" aria-label="issue">

--- a/web/src/components/ProposalList.tsx
+++ b/web/src/components/ProposalList.tsx
@@ -26,7 +26,7 @@ export function ProposalList({
           href={`${repoUrl}/issues/${proposal.number}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="group block p-4 bg-white/40 dark:bg-neutral-800/40 hover:bg-white/60 dark:hover:bg-neutral-800/60 border border-amber-200 dark:border-neutral-600 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+          className="group block p-4 bg-white/40 dark:bg-neutral-800/40 hover:bg-white/60 dark:hover:bg-neutral-800/60 border border-amber-200 dark:border-neutral-600 rounded-lg motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
         >
           <div className="flex justify-between items-start mb-2">
             <span className="text-xs font-mono text-amber-700 dark:text-amber-400">

--- a/web/src/components/PullRequestList.test.tsx
+++ b/web/src/components/PullRequestList.test.tsx
@@ -83,10 +83,10 @@ describe('PullRequestList', () => {
     expect(badge.className).not.toContain('bg-gray-');
   });
 
-  it('applies transition-colors to list item links', () => {
+  it('applies motion-safe:transition-colors to list item links', () => {
     render(<PullRequestList pullRequests={[basePR]} repoUrl={REPO_URL} />);
     const link = screen.getByRole('link');
-    expect(link.className).toContain('transition-colors');
+    expect(link.className).toContain('motion-safe:transition-colors');
   });
 
   it('does not render draft badge when PR is not a draft', () => {

--- a/web/src/components/PullRequestList.tsx
+++ b/web/src/components/PullRequestList.tsx
@@ -30,7 +30,7 @@ export function PullRequestList({
             href={`${repoUrl}/pull/${pr.number}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="group block transition-colors"
+            className="group block motion-safe:transition-colors"
           >
             <div className="flex items-center gap-2">
               <span className="text-xs text-amber-700 dark:text-amber-300">


### PR DESCRIPTION
## Summary

- Normalizes all `transition-colors` instances to `motion-safe:transition-colors` across 10 source files, matching the existing AgentList/AgentLeaderboard pattern
- Guards `active:scale-95` on ErrorBoundary button with `motion-safe:` prefix to respect `prefers-reduced-motion` for spatial transforms
- Updates 4 test files to match new class names

Fixes #97

## Motivation

The codebase was split 3-vs-12 on `motion-safe:transition-colors` vs bare `transition-colors`. Since AgentList and AgentLeaderboard already established the `motion-safe:` convention, and `App.tsx` uses `motion-reduce:animate-none` for the spinner, the intent to respect motion preferences was clear — the bare usages were an oversight from incremental additions.

The `active:scale-95` on ErrorBoundary is a spatial transform that can trigger discomfort for users with vestibular disorders. Wrapping it in `motion-safe:` is the correct accessibility practice.

## Test plan

- [x] All 144 tests pass
- [x] TypeScript type check passes
- [x] ESLint passes with zero warnings
- [x] Production build succeeds
- [ ] Verify in browser: transitions still animate normally with default OS settings
- [ ] Verify with `prefers-reduced-motion: reduce`: transitions are suppressed