### PR TITLE
refactor(web): extract RepositoryConfig type and make useActivityData configurable

### DIFF
--- a/web/src/hooks/useActivityData.ts
+++ b/web/src/hooks/useActivityData.ts
@@ -3,6 +3,7 @@ import type {
   ActivityData,
   ActivityEvent,
   ActivityMode,
+  RepositoryConfig,
 } from '../types/activity';
 import {
   buildLiveEvents,
@@ -22,7 +23,7 @@ interface UseActivityDataResult {
   liveMessage: string | null;
 }
 
-const DEFAULT_REPOSITORY = {
+const DEFAULT_REPOSITORY: RepositoryConfig = {
   owner: 'hivemoot',
   name: 'colony',
   url: 'https://github.com/hivemoot/colony',
@@ -33,7 +34,9 @@ const LIVE_BASE_MS = 20_000;
 const LIVE_MAX_MS = 5 * 60_000;
 const LIVE_EVENTS_ENDPOINT = 'https://api.github.com/repos';
 
-export function useActivityData(): UseActivityDataResult {
+export function useActivityData(config?: {
+  repository?: RepositoryConfig;
+}): UseActivityDataResult {
   const [data, setData] = useState<ActivityData | null>(null);
   const [staticEvents, setStaticEvents] = useState<ActivityEvent[]>([]);
   const [loading, setLoading] = useState(true);
@@ -49,7 +52,8 @@ export function useActivityData(): UseActivityDataResult {
   const backoffRef = useRef<number>(LIVE_BASE_MS);
   const hasDataRef = useRef(false);
   const initialFetchRef = useRef(true);
-  const repository = data?.repository ?? DEFAULT_REPOSITORY;
+  const repository =
+    data?.repository ?? config?.repository ?? DEFAULT_REPOSITORY;
   const { owner, name, url } = repository;
 
   useEffect(() => {

--- a/web/src/types/activity.ts
+++ b/web/src/types/activity.ts
@@ -54,6 +54,12 @@ export interface Comment {
   url: string;
 }
 
+export interface RepositoryConfig {
+  owner: string;
+  name: string;
+  url: string;
+}
+
 export interface Agent {
   login: string;
   avatarUrl?: string;
@@ -72,10 +78,7 @@ export interface AgentStats {
 
 export interface ActivityData {
   generatedAt: string;
-  repository: {
-    owner: string;
-    name: string;
-    url: string;
+  repository: RepositoryConfig & {
     stars: number;
     forks: number;
     openIssues: number;


### PR DESCRIPTION
## Summary

- Extract `RepositoryConfig` interface to `types/activity.ts` for reuse across the codebase
- Reuse `RepositoryConfig` in `ActivityData.repository` via intersection type, replacing the inline shape
- Make `useActivityData` accept an optional `config.repository` parameter, falling back to the existing default
- Zero breaking changes: all existing call sites and tests continue working without modification

## Motivation

`useActivityData.ts` hardcodes a single repository at the module level. This makes the hook structurally unable to support multi-repo (#111) without a refactor. Extracting the config now — while the hook is stable — is cheaper than bundling it into #111's larger changes.

Fixes #117

## Changes

- `types/activity.ts`: Add `RepositoryConfig` interface; use intersection type for `ActivityData.repository`
- `hooks/useActivityData.ts`: Import `RepositoryConfig`, type the default constant, accept optional config with three-way fallback (`data > config > default`)

## Test plan

- [ ] Existing tests pass without modification (hook signature is backward-compatible)
- [ ] TypeScript compilation succeeds (intersection type preserves all existing properties)
- [ ] No visual or behavioral changes to the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)