### PR TITLE
a11y(web): normalize motion-safe prefix on all transitions and transforms

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -109,7 +109,7 @@ function App(): React.ReactElement {
           href="https://github.com/hivemoot/colony"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center justify-center px-6 py-3 bg-amber-600 hover:bg-amber-700 text-white font-medium rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
+          className="inline-flex items-center justify-center px-6 py-3 bg-amber-600 hover:bg-amber-700 text-white font-medium rounded-lg motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
         >
           View on GitHub
         </a>

--- a/web/src/components/ActivityTimeline.test.tsx
+++ b/web/src/components/ActivityTimeline.test.tsx
@@ -139,7 +139,7 @@ describe('ActivityTimeline', () => {
       'href',
       'https://github.com/hivemoot/colony/commit/abc123'
     );
-    expect(link.className).toContain('transition-colors');
+    expect(link.className).toContain('motion-safe:transition-colors');
   });
 
   it('renders event without link when url is not provided', () => {

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -105,7 +105,7 @@ export function ActivityTimeline({
                   href={event.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mt-1 block text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-200 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+                  className="mt-1 block text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-200 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
                 >
                   {event.title}
                 </a>

--- a/web/src/components/AgentLeaderboard.tsx
+++ b/web/src/components/AgentLeaderboard.tsx
@@ -92,7 +92,7 @@ export function AgentLeaderboard({
                         `https://github.com/${agent.login}.png`
                       }
                       alt={agent.login}
-                      className={`w-8 h-8 rounded-full border transition-colors ${
+                      className={`w-8 h-8 rounded-full border motion-safe:transition-colors ${
                         isSelected
                           ? 'border-amber-500 dark:border-amber-400'
                           : 'border-amber-200 dark:border-neutral-600'
@@ -103,7 +103,7 @@ export function AgentLeaderboard({
                       href={`https://github.com/${agent.login}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="font-medium text-amber-900 dark:text-amber-100 hover:text-amber-600 dark:hover:text-amber-400 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+                      className="font-medium text-amber-900 dark:text-amber-100 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
                       onClick={(e) => e.stopPropagation()}
                     >
                       {agent.login}

--- a/web/src/components/CommentList.tsx
+++ b/web/src/components/CommentList.tsx
@@ -29,7 +29,7 @@ export function CommentList({
             href={comment.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="group block bg-amber-50/30 dark:bg-neutral-800/30 rounded p-2.5 border border-amber-100/50 dark:border-neutral-700/50 hover:border-amber-300 dark:hover:border-neutral-500 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
+            className="group block bg-amber-50/30 dark:bg-neutral-800/30 rounded p-2.5 border border-amber-100/50 dark:border-neutral-700/50 hover:border-amber-300 dark:hover:border-neutral-500 motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
           >
             <div className="flex items-center gap-1.5 mb-2">
               <img

--- a/web/src/components/CommitList.test.tsx
+++ b/web/src/components/CommitList.test.tsx
@@ -70,7 +70,7 @@ describe('CommitList', () => {
     );
   });
 
-  it('applies transition-colors to list item links', () => {
+  it('applies motion-safe:transition-colors to list item links', () => {
     const commits: Commit[] = [
       {
         sha: 'abc1234',
@@ -83,7 +83,7 @@ describe('CommitList', () => {
     render(<CommitList commits={commits} repoUrl={repoUrl} />);
 
     const link = screen.getByRole('link');
-    expect(link.className).toContain('transition-colors');
+    expect(link.className).toContain('motion-safe:transition-colors');
   });
 
   it('renders a relative timestamp in a time element', () => {

--- a/web/src/components/CommitList.tsx
+++ b/web/src/components/CommitList.tsx
@@ -29,7 +29,7 @@ export function CommitList({
             href={`${repoUrl}/commit/${commit.sha}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="group block transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
+            className="group block motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
           >
             <code className="text-xs text-amber-700 dark:text-amber-300 font-mono group-hover:underline">
               {commit.sha}

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -41,7 +41,7 @@ export class ErrorBoundary extends Component<Props, State> {
             </p>
             <button
               onClick={() => this.setState({ hasError: false, error: null })}
-              className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition-colors shadow-sm active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
+              className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium motion-safe:transition-colors shadow-sm motion-safe:active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
             >
               Try Again
             </button>

--- a/web/src/components/IssueList.test.tsx
+++ b/web/src/components/IssueList.test.tsx
@@ -106,7 +106,7 @@ describe('IssueList', () => {
     expect(screen.queryByText('help wanted')).not.toBeInTheDocument();
   });
 
-  it('applies transition-colors to list item links', () => {
+  it('applies motion-safe:transition-colors to list item links', () => {
     const issues: Issue[] = [
       {
         number: 1,
@@ -121,7 +121,7 @@ describe('IssueList', () => {
     render(<IssueList issues={issues} repoUrl={repoUrl} />);
 
     const link = screen.getByRole('link');
-    expect(link.className).toContain('transition-colors');
+    expect(link.className).toContain('motion-safe:transition-colors');
   });
 
   it('renders a relative timestamp using closedAt if available', () => {

--- a/web/src/components/IssueList.tsx
+++ b/web/src/components/IssueList.tsx
@@ -29,7 +29,7 @@ export function IssueList({
             href={`${repoUrl}/issues/${issue.number}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="group block transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
+            className="group block motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
           >
             <div className="flex items-center gap-2">
               <span className="text-xs text-amber-700 dark:text-amber-300">

--- a/web/src/components/ProjectHealth.tsx
+++ b/web/src/components/ProjectHealth.tsx
@@ -20,7 +20,7 @@ export function ProjectHealth({
         href={`${repository.url}/stargazers`}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
         title="Stars"
       >
         <span role="img" aria-label="star">
@@ -35,7 +35,7 @@ export function ProjectHealth({
         href={`${repository.url}/network/members`}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
         title="Forks"
       >
         <span role="img" aria-label="fork">
@@ -50,7 +50,7 @@ export function ProjectHealth({
         href={`${repository.url}/issues`}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
         title="Open Issues"
       >
         <span role="img" aria-label="issue">
@@ -64,7 +64,7 @@ export function ProjectHealth({
       </span>
       <a
         href="#agents"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
         title="Active Agents"
       >
         <span role="img" aria-label="active agents">
@@ -78,7 +78,7 @@ export function ProjectHealth({
       </span>
       <a
         href="#proposals"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
         title="Active Proposals"
       >
         <span role="img" aria-label="active proposals">

--- a/web/src/components/ProposalList.tsx
+++ b/web/src/components/ProposalList.tsx
@@ -30,7 +30,7 @@ export function ProposalList({
           href={`${repoUrl}/issues/${proposal.number}`}
           target="_blank"
           rel="noopener noreferrer"
-          className="group block p-4 bg-white/40 dark:bg-neutral-800/40 hover:bg-white/60 dark:hover:bg-neutral-800/60 border border-amber-200 dark:border-neutral-600 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
+          className="group block p-4 bg-white/40 dark:bg-neutral-800/40 hover:bg-white/60 dark:hover:bg-neutral-800/60 border border-amber-200 dark:border-neutral-600 rounded-lg motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
         >
           <div className="flex justify-between items-start mb-2">
             <span className="text-xs font-mono text-amber-700 dark:text-amber-400">

--- a/web/src/components/PullRequestList.test.tsx
+++ b/web/src/components/PullRequestList.test.tsx
@@ -83,10 +83,10 @@ describe('PullRequestList', () => {
     expect(badge.className).not.toContain('bg-gray-');
   });
 
-  it('applies transition-colors to list item links', () => {
+  it('applies motion-safe:transition-colors to list item links', () => {
     render(<PullRequestList pullRequests={[basePR]} repoUrl={REPO_URL} />);
     const link = screen.getByRole('link');
-    expect(link.className).toContain('transition-colors');
+    expect(link.className).toContain('motion-safe:transition-colors');
   });
 
   it('includes focus indicators on link elements', () => {

--- a/web/src/components/PullRequestList.tsx
+++ b/web/src/components/PullRequestList.tsx
@@ -31,7 +31,7 @@ export function PullRequestList({
             href={`${repoUrl}/pull/${pr.number}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="group block transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
+            className="group block motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
           >
             <div className="flex items-center gap-2">
               <span className="text-xs text-amber-700 dark:text-amber-300">


### PR DESCRIPTION
## Summary

Normalizes all bare `transition-colors` to `motion-safe:transition-colors` across 10 source files, and guards `active:scale-95` on the ErrorBoundary button with `motion-safe:`. Updates 4 test files to match.

Supersedes #99 which accumulated merge conflicts from 8+ commits merging to main since it was branched.

Fixes #97

## Motivation

The codebase had a split convention: AgentList and AgentLeaderboard (row-level) used `motion-safe:transition-colors`, while the other 10 components used bare `transition-colors`. Since the project already respects `prefers-reduced-motion` (App.tsx uses `motion-reduce:animate-none` for the spinner), all transitions should be gated behind `motion-safe:`.

The `active:scale-95` on ErrorBoundary is a spatial transform that can trigger discomfort for users with vestibular disorders — wrapping it in `motion-safe:` is the correct accessibility practice.

## Changes

| File | Change |
|------|--------|
| `App.tsx` | 2× `transition-colors` → `motion-safe:transition-colors` |
| `ActivityTimeline.tsx` | 1× `transition-colors` → `motion-safe:transition-colors` |
| `AgentLeaderboard.tsx` | 2× `transition-colors` → `motion-safe:transition-colors` |
| `CommentList.tsx` | 1× `transition-colors` → `motion-safe:transition-colors` |
| `CommitList.tsx` | 1× `transition-colors` → `motion-safe:transition-colors` |
| `ErrorBoundary.tsx` | `transition-colors` → `motion-safe:transition-colors`, `active:scale-95` → `motion-safe:active:scale-95` |
| `IssueList.tsx` | 1× `transition-colors` → `motion-safe:transition-colors` |
| `ProjectHealth.tsx` | 5× `transition-colors` → `motion-safe:transition-colors` |
| `ProposalList.tsx` | 1× `transition-colors` → `motion-safe:transition-colors` |
| `PullRequestList.tsx` | 1× `transition-colors` → `motion-safe:transition-colors` |
| 4 test files | Updated class assertions to match |

## Test plan

- [x] All 176 tests pass
- [x] TypeScript type check passes
- [x] Zero new lint violations
- [ ] Verify transitions animate normally with default OS settings
- [ ] Verify with `prefers-reduced-motion: reduce`: transitions suppressed