### PR TITLE
feat(web): add inconclusive phase support and increase proposal limit

### DIFF
--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -58,7 +58,8 @@ export interface Proposal {
     | 'voting'
     | 'ready-to-implement'
     | 'implemented'
-    | 'rejected';
+    | 'rejected'
+    | 'inconclusive';
   author: string;
   createdAt: string;
   commentCount: number;
@@ -395,6 +396,7 @@ async function fetchProposals(
     'ready-to-implement',
     'implemented',
     'rejected',
+    'inconclusive',
   ] as const;
 
   for (const i of proposalIssues) {
@@ -452,7 +454,7 @@ async function fetchProposals(
       (a, b) =>
         new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
     )
-    .slice(0, 10);
+    .slice(0, 20);
 }
 
 export function mapEvents(

--- a/web/src/components/ProposalList.test.tsx
+++ b/web/src/components/ProposalList.test.tsx
@@ -146,6 +146,14 @@ describe('ProposalList', () => {
         createdAt: '2026-02-05T05:00:00Z',
         commentCount: 1,
       },
+      {
+        number: 6,
+        title: 'Inconclusive phase',
+        phase: 'inconclusive',
+        author: 'f',
+        createdAt: '2026-02-05T04:00:00Z',
+        commentCount: 1,
+      },
     ];
 
     render(<ProposalList proposals={proposals} repoUrl={repoUrl} />);
@@ -155,6 +163,7 @@ describe('ProposalList', () => {
     expect(screen.getByText('ready to implement')).toBeInTheDocument();
     expect(screen.getByText('implemented')).toBeInTheDocument();
     expect(screen.getByText('rejected')).toBeInTheDocument();
+    expect(screen.getByText('inconclusive')).toBeInTheDocument();
   });
 
   it('renders vote and comment emojis with aria-labels', () => {

--- a/web/src/components/ProposalList.tsx
+++ b/web/src/components/ProposalList.tsx
@@ -100,6 +100,8 @@ function PhaseBadge({
       'bg-neutral-100 text-neutral-800 dark:bg-neutral-900/50 dark:text-neutral-200 border-neutral-200 dark:border-neutral-800',
     rejected:
       'bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-200 border-red-200 dark:border-red-800',
+    inconclusive:
+      'bg-orange-100 text-orange-800 dark:bg-orange-900/50 dark:text-orange-200 border-orange-200 dark:border-orange-800',
   };
 
   return (

--- a/web/src/types/activity.ts
+++ b/web/src/types/activity.ts
@@ -34,7 +34,8 @@ export interface Proposal {
     | 'voting'
     | 'ready-to-implement'
     | 'implemented'
-    | 'rejected';
+    | 'rejected'
+    | 'inconclusive';
   author: string;
   createdAt: string;
   commentCount: number;


### PR DESCRIPTION
## Summary

- Adds `inconclusive` as a recognized governance phase in both the data pipeline and frontend
- Increases the proposal display limit from 10 to 20 to accommodate growing governance activity
- Adds orange phase badge styling for inconclusive proposals
- Updates tests to cover the new phase

## Problem

The Hivemoot Queen uses an `inconclusive` label when voting doesn't reach consensus, but the data pipeline silently dropped these proposals because `inconclusive` wasn't in the `validPhases` array. This made ~12 proposals invisible on the dashboard — nearly half of all governance history.

The 10-proposal display cap also meant that even after adding the phase, older proposals (including many `ready-to-implement` ones that demonstrate successful governance) were hidden.

## Changes

| File | Change |
|---|---|
| `web/src/types/activity.ts` | Add `inconclusive` to `Proposal['phase']` union |
| `web/scripts/generate-data.ts` | Add `inconclusive` to `validPhases`, increase limit 10→20 |
| `web/src/components/ProposalList.tsx` | Add orange badge styling for `inconclusive` phase |
| `web/src/components/ProposalList.test.tsx` | Add test coverage for `inconclusive` phase rendering |

## Test plan

- [x] All 175 existing tests pass
- [x] New test verifies `inconclusive` phase badge renders correctly
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Production build succeeds

Fixes #103