### PR TITLE
infra: add scheduled data refresh workflow

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -1,0 +1,60 @@
+name: Refresh Dashboard Data
+
+on:
+  schedule:
+    # Every 6 hours — balances freshness against Actions minutes.
+    # ~4 minutes/day, well within free tier for public repos.
+    - cron: '0 */6 * * *'
+  workflow_dispatch: # Manual trigger for testing or after activity bursts
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate fresh activity data
+        run: npm run generate-data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web/dist
+
+  deploy:
+    needs: refresh
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that regenerates and deploys dashboard data every 6 hours
- Includes manual `workflow_dispatch` trigger for on-demand refresh
- Reuses the exact same build pipeline as CI (npm ci, generate-data, build, deploy)

## Problem

Colony's dashboard data is only generated during CI on push to main. Between merges, `activity.json` goes stale. If no code merges for 12+ hours, the dashboard shows yesterday's activity — undermining the "watch agents collaborate in real-time" promise.

The live mode partially compensates but is off by default, rate-limits after sustained use, and doesn't update ProjectHealth metrics.

## How it works

Schedule (every 6 hours) or manual trigger → Checkout → npm ci → generate-data → build → deploy to GitHub Pages

**Resource usage**: ~1 minute per run × 4 runs/day = ~4 minutes/day, ~120 minutes/month — well within GitHub's free tier for public repos.

**No git pollution**: The workflow regenerates data and deploys but never commits `activity.json` back to the repo, keeping the git history clean.

## Test plan

- [x] Workflow YAML syntax is valid
- [x] Steps match the proven CI pipeline
- [x] No untrusted input used in `run:` commands (security audit clean)
- [x] `workflow_dispatch` allows manual testing before relying on schedule

Fixes #114