### PR TITLE
feat(web): add relative timestamp to ProposalList cards

### DIFF
--- a/web/src/components/ProposalList.test.tsx
+++ b/web/src/components/ProposalList.test.tsx
@@ -257,6 +257,26 @@ describe('ProposalList', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('renders a relative timestamp in a time element', () => {
+    const createdAt = '2026-02-05T09:00:00Z';
+    const proposals: Proposal[] = [
+      {
+        number: 1,
+        title: 'Timestamp test',
+        phase: 'discussion',
+        author: 'worker',
+        createdAt,
+        commentCount: 0,
+      },
+    ];
+
+    render(<ProposalList proposals={proposals} repoUrl={repoUrl} />);
+
+    const timeEl = screen.getByText(/ago/i);
+    expect(timeEl.tagName.toLowerCase()).toBe('time');
+    expect(timeEl).toHaveAttribute('datetime', createdAt);
+  });
+
   it('includes focus indicators on link elements', () => {
     const proposals: Proposal[] = [
       {

--- a/web/src/components/ProposalList.tsx
+++ b/web/src/components/ProposalList.tsx
@@ -1,6 +1,6 @@
 import type { Proposal } from '../types/activity';
 import { handleAvatarError } from '../utils/avatar';
-import { formatDuration } from '../utils/time';
+import { formatDuration, formatTimeAgo } from '../utils/time';
 
 interface ProposalListProps {
   proposals: Proposal[];
@@ -56,6 +56,18 @@ export function ProposalList({
               <span className="text-xs text-amber-600 dark:text-amber-400">
                 @{proposal.author}
               </span>
+              <span
+                className="text-amber-400 dark:text-amber-600"
+                aria-hidden="true"
+              >
+                ·
+              </span>
+              <time
+                dateTime={proposal.createdAt}
+                className="text-[10px] text-amber-500 dark:text-amber-400"
+              >
+                {formatTimeAgo(new Date(proposal.createdAt))}
+              </time>
             </div>
             <div className="flex items-center gap-3">
               {proposal.votesSummary && (


### PR DESCRIPTION
Adds a relative timestamp (e.g. "2 days ago") to each proposal card in ProposalList, using the existing `createdAt` field and `formatTimeAgo` utility.

## Problem

ProposalList was the only list component that didn't display a timestamp despite having `createdAt` data available. Proposal age is important governance context — a discussion-phase proposal from 2 hours ago is early; one from 3 days ago may be stalling.

Fixes #104

## Changes

- **ProposalList.tsx**: Import `formatTimeAgo`, add `<time>` element with dot separator after author name
- **ProposalList.test.tsx**: Add test verifying `<time>` element renders with correct `datetime` attribute

## Pattern

Follows the same timestamp pattern as CommitList, IssueList, PullRequestList:
- `<time dateTime={isoString}>` with `text-[10px] text-amber-500 dark:text-amber-400`
- Dot separator (`·`) between author and timestamp, matching ActivityTimeline style

## Test plan

- [x] All 176 tests pass (`npm run test`)
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] ESLint clean
- [x] Prettier clean