### PR TITLE
a11y(web): add focus ring offset to ProjectHealth, ActivityTimeline, AgentLeaderboard

### DIFF
--- a/web/src/components/ActivityTimeline.test.tsx
+++ b/web/src/components/ActivityTimeline.test.tsx
@@ -142,6 +142,28 @@ describe('ActivityTimeline', () => {
     expect(link.className).toContain('motion-safe:transition-colors');
   });
 
+  it('includes focus ring offset on event title links', () => {
+    const events: ActivityEvent[] = [
+      {
+        id: 'commit-1',
+        type: 'commit',
+        summary: 'Commit pushed',
+        title: 'Test commit',
+        url: 'https://github.com/hivemoot/colony/commit/abc123',
+        actor: 'worker',
+        createdAt: '2026-02-05T10:00:00Z',
+      },
+    ];
+
+    render(<ActivityTimeline events={events} />);
+
+    const link = screen.getByRole('link', { name: 'Test commit' });
+    expect(link.className).toContain('focus-visible:ring-offset-1');
+    expect(link.className).toContain(
+      'dark:focus-visible:ring-offset-neutral-800'
+    );
+  });
+
   it('renders event without link when url is not provided', () => {
     const events: ActivityEvent[] = [
       {

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -105,7 +105,7 @@ export function ActivityTimeline({
                   href={event.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mt-1 block text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-200 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+                  className="mt-1 block text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-200 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
                 >
                   {event.title}
                 </a>

--- a/web/src/components/AgentLeaderboard.test.tsx
+++ b/web/src/components/AgentLeaderboard.test.tsx
@@ -119,6 +119,16 @@ describe('AgentLeaderboard', () => {
     expect(onSelect).toHaveBeenCalledWith('agent-1');
   });
 
+  it('includes focus ring offset on agent name links', () => {
+    render(<AgentLeaderboard stats={stats} />);
+
+    const link = screen.getByRole('link', { name: 'agent-1' });
+    expect(link.className).toContain('focus-visible:ring-offset-1');
+    expect(link.className).toContain(
+      'dark:focus-visible:ring-offset-neutral-800'
+    );
+  });
+
   it('has proper ARIA attributes on the filter button', () => {
     render(<AgentLeaderboard stats={stats} selectedAgent="agent-1" />);
 

--- a/web/src/components/AgentLeaderboard.tsx
+++ b/web/src/components/AgentLeaderboard.tsx
@@ -104,7 +104,7 @@ export function AgentLeaderboard({
                       href={`https://github.com/${agent.login}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="relative z-20 font-medium text-amber-900 dark:text-amber-100 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+                      className="relative z-20 font-medium text-amber-900 dark:text-amber-100 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
                       onClick={(e) => e.stopPropagation()}
                     >
                       {agent.login}

--- a/web/src/components/ProjectHealth.test.tsx
+++ b/web/src/components/ProjectHealth.test.tsx
@@ -57,6 +57,26 @@ describe('ProjectHealth', () => {
     );
   });
 
+  it('includes focus ring offset on all links', () => {
+    render(
+      <ProjectHealth
+        repository={mockRepo}
+        activeAgentsCount={3}
+        activeProposalsCount={2}
+      />
+    );
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(5);
+
+    links.forEach((link) => {
+      expect(link.className).toContain('focus-visible:ring-offset-1');
+      expect(link.className).toContain(
+        'dark:focus-visible:ring-offset-neutral-900'
+      );
+    });
+  });
+
   it('renders singular labels when count is 1', () => {
     render(
       <ProjectHealth

--- a/web/src/components/ProjectHealth.tsx
+++ b/web/src/components/ProjectHealth.tsx
@@ -20,7 +20,7 @@ export function ProjectHealth({
         href={`${repository.url}/stargazers`}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-900"
         title="Stars"
       >
         <span role="img" aria-label="star">
@@ -35,7 +35,7 @@ export function ProjectHealth({
         href={`${repository.url}/network/members`}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-900"
         title="Forks"
       >
         <span role="img" aria-label="fork">
@@ -50,7 +50,7 @@ export function ProjectHealth({
         href={`${repository.url}/issues`}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-900"
         title="Open Issues"
       >
         <span role="img" aria-label="issue">
@@ -64,7 +64,7 @@ export function ProjectHealth({
       </span>
       <a
         href="#agents"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-900"
         title="Active Agents"
       >
         <span role="img" aria-label="active agents">
@@ -78,7 +78,7 @@ export function ProjectHealth({
       </span>
       <a
         href="#proposals"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-900"
         title="Active Proposals"
       >
         <span role="img" aria-label="active proposals">


### PR DESCRIPTION
## Summary

- Add `focus-visible:ring-offset-1` and dark mode offset to **ProjectHealth** (5 links), **ActivityTimeline** (event title link), and **AgentLeaderboard** (agent name link)
- These were the only focusable links in the codebase missing ring-offset classes
- Tests added for all three components verifying ring-offset presence

Fixes #127

## Motivation

Every other focusable link in the codebase already includes `ring-offset` to create a visible gap between the focus ring and the element's background. These three components were the only exceptions, making focus rings harder to see — especially in dark mode where the amber ring can blend with the background.

## Changes

| File | Change |
|------|--------|
| `ProjectHealth.tsx` | 5× add `focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-900` |
| `ActivityTimeline.tsx` | 1× add `focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800` |
| `AgentLeaderboard.tsx` | 1× add `focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800` |
| `ProjectHealth.test.tsx` | Add test: all 5 links include ring-offset |
| `ActivityTimeline.test.tsx` | Add test: event title link includes ring-offset |
| `AgentLeaderboard.test.tsx` | Add test: agent name link includes ring-offset |

## Test plan

- [x] All 178 tests pass
- [x] TypeScript type check passes
- [x] Zero lint violations
- [ ] Verify focus ring gap is visible with keyboard navigation
- [ ] Verify in both light and dark mode