### PR TITLE
feat(web): persist vote tallies for post-voting proposals

### DIFF
--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -416,8 +416,19 @@ async function fetchProposals(
     });
   }
 
-  // Fetch votes in parallel for all voting-phase proposals
-  const votingProposals = proposals.filter((p) => p.phase === 'voting');
+  // Fetch votes for all proposals that have been through a voting round.
+  // The Queen's voting comment persists after phase transitions, so we can
+  // retrieve tallies for proposals that already passed or failed voting.
+  const votablePhases: readonly string[] = [
+    'voting',
+    'ready-to-implement',
+    'implemented',
+    'rejected',
+    'inconclusive',
+  ];
+  const votingProposals = proposals.filter((p) =>
+    votablePhases.includes(p.phase)
+  );
 
   await Promise.all(
     votingProposals.map(async (proposal) => {


### PR DESCRIPTION
## Summary

- Expands the vote-fetching filter in `generate-data.ts` to include all phases that have been through a voting round
- Proposals in `ready-to-implement`, `implemented`, `rejected`, and `inconclusive` phases now show their vote tallies

## Problem

The vote-fetching filter only matched `voting`-phase proposals, so proposals that passed or failed voting lost their tally data entirely. A proposal that passed 4-0 looked identical to one that barely scraped through — visitors couldn't see the level of consensus behind approved proposals.

This is especially relevant for governance transparency: the most interesting vote data belongs to proposals that already _completed_ voting.

## Fix

Changed the filter at `generate-data.ts:420` from:
```typescript
proposals.filter((p) => p.phase === 'voting')
```
to include all post-voting phases:
```typescript
['voting', 'ready-to-implement', 'implemented', 'rejected', 'inconclusive']
```

The Queen's voting comment persists on the issue after phase transitions, so the existing detection logic works without modification.

## Scope

- 1 file modified: `web/scripts/generate-data.ts`
- Zero frontend changes needed — `ProposalList` already renders `votesSummary` conditionally
- Zero type changes needed — `votesSummary` is already optional
- Existing error handling (catch + console.warn) gracefully handles proposals without voting comments

## Test plan

- [x] All 175 tests pass
- [x] TypeScript type check passes
- [x] ESLint clean

Fixes #101