### PR TITLE
polish(web): add focus ring offset and label overflow indicator

### DIFF
--- a/web/src/components/ActivityFeed.test.tsx
+++ b/web/src/components/ActivityFeed.test.tsx
@@ -389,6 +389,23 @@ describe('ActivityFeed', () => {
       expect(screen.queryByText('Clear filter')).not.toBeInTheDocument();
     });
 
+    it('includes focus ring offset on Clear filter button', () => {
+      render(
+        <ActivityFeed
+          {...defaultProps}
+          data={multiAgentData}
+          events={multiAgentEvents}
+          selectedAgent="worker"
+        />
+      );
+
+      const clearButton = screen.getByText('Clear filter');
+      expect(clearButton.className).toContain('focus-visible:ring-offset-1');
+      expect(clearButton.className).toContain(
+        'dark:focus-visible:ring-offset-neutral-800'
+      );
+    });
+
     it('calls onSelectAgent(null) when Clear filter is clicked', () => {
       const onSelectAgent = vi.fn();
       render(

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -108,7 +108,7 @@ export function ActivityFeed({
             </span>
             <button
               onClick={() => onSelectAgent(null)}
-              className="text-xs text-amber-600 hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-200 underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 rounded"
+              className="text-xs text-amber-600 hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-200 underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800 rounded"
             >
               Clear filter
             </button>

--- a/web/src/components/ActivityTimeline.test.tsx
+++ b/web/src/components/ActivityTimeline.test.tsx
@@ -142,6 +142,28 @@ describe('ActivityTimeline', () => {
     expect(link.className).toContain('motion-safe:transition-colors');
   });
 
+  it('includes focus ring offset on event links', () => {
+    const events: ActivityEvent[] = [
+      {
+        id: 'commit-1',
+        type: 'commit',
+        summary: 'Commit pushed',
+        title: 'Test commit',
+        url: 'https://github.com/hivemoot/colony/commit/abc123',
+        actor: 'worker',
+        createdAt: '2026-02-05T10:00:00Z',
+      },
+    ];
+
+    render(<ActivityTimeline events={events} />);
+
+    const link = screen.getByRole('link', { name: 'Test commit' });
+    expect(link.className).toContain('focus-visible:ring-offset-1');
+    expect(link.className).toContain(
+      'dark:focus-visible:ring-offset-neutral-800'
+    );
+  });
+
   it('renders event without link when url is not provided', () => {
     const events: ActivityEvent[] = [
       {

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -105,7 +105,7 @@ export function ActivityTimeline({
                   href={event.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="mt-1 block text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-200 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+                  className="mt-1 block text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-200 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
                 >
                   {event.title}
                 </a>

--- a/web/src/components/AgentLeaderboard.test.tsx
+++ b/web/src/components/AgentLeaderboard.test.tsx
@@ -119,6 +119,16 @@ describe('AgentLeaderboard', () => {
     expect(onSelect).toHaveBeenCalledWith('agent-1');
   });
 
+  it('includes focus ring offset on agent name links', () => {
+    render(<AgentLeaderboard stats={stats} />);
+
+    const link = screen.getByRole('link', { name: 'agent-1' });
+    expect(link.className).toContain('focus-visible:ring-offset-1');
+    expect(link.className).toContain(
+      'dark:focus-visible:ring-offset-neutral-800'
+    );
+  });
+
   it('has proper ARIA attributes on the filter button', () => {
     render(<AgentLeaderboard stats={stats} selectedAgent="agent-1" />);
 

--- a/web/src/components/AgentLeaderboard.tsx
+++ b/web/src/components/AgentLeaderboard.tsx
@@ -104,7 +104,7 @@ export function AgentLeaderboard({
                       href={`https://github.com/${agent.login}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="relative z-20 font-medium text-amber-900 dark:text-amber-100 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+                      className="relative z-20 font-medium text-amber-900 dark:text-amber-100 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
                       onClick={(e) => e.stopPropagation()}
                     >
                       {agent.login}

--- a/web/src/components/AgentList.test.tsx
+++ b/web/src/components/AgentList.test.tsx
@@ -89,6 +89,16 @@ describe('AgentList', () => {
     expect(selectedWrapper?.className).not.toContain('opacity-40');
   });
 
+  it('includes focus ring offset on agent login links', () => {
+    render(<AgentList agents={[{ login: 'agent-1' }]} />);
+
+    const link = screen.getByRole('link', { name: 'agent-1' });
+    expect(link.className).toContain('focus-visible:ring-offset-1');
+    expect(link.className).toContain(
+      'dark:focus-visible:ring-offset-neutral-800'
+    );
+  });
+
   it('marks the bee badge as decorative with aria-hidden', () => {
     const { container } = render(<AgentList agents={[{ login: 'agent-1' }]} />);
     const badge = container.querySelector('.bg-amber-500');

--- a/web/src/components/AgentList.tsx
+++ b/web/src/components/AgentList.tsx
@@ -72,7 +72,7 @@ export function AgentList({
               href={`https://github.com/${agent.login}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs mt-1 text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+              className="text-xs mt-1 text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
             >
               {agent.login}
             </a>

--- a/web/src/components/IssueList.test.tsx
+++ b/web/src/components/IssueList.test.tsx
@@ -106,6 +106,66 @@ describe('IssueList', () => {
     expect(screen.queryByText('help wanted')).not.toBeInTheDocument();
   });
 
+  it('shows overflow indicator when issue has more than 2 labels', () => {
+    const issues: Issue[] = [
+      {
+        number: 1,
+        title: 'Multi-label issue',
+        state: 'open',
+        labels: [
+          'enhancement',
+          'documentation',
+          'help wanted',
+          'good first issue',
+        ],
+        author: 'scout',
+        createdAt: '2026-02-05T09:00:00Z',
+      },
+    ];
+
+    render(<IssueList issues={issues} repoUrl={repoUrl} />);
+
+    expect(screen.getByText('+2 more')).toBeInTheDocument();
+    expect(
+      screen.getByTitle('help wanted, good first issue')
+    ).toBeInTheDocument();
+  });
+
+  it('does not show overflow indicator when issue has 2 or fewer labels', () => {
+    const issues: Issue[] = [
+      {
+        number: 1,
+        title: 'Two-label issue',
+        state: 'open',
+        labels: ['bug', 'enhancement'],
+        author: 'scout',
+        createdAt: '2026-02-05T09:00:00Z',
+      },
+    ];
+
+    render(<IssueList issues={issues} repoUrl={repoUrl} />);
+
+    expect(screen.queryByText(/more/)).not.toBeInTheDocument();
+  });
+
+  it('shows correct overflow count for exactly 3 labels', () => {
+    const issues: Issue[] = [
+      {
+        number: 1,
+        title: 'Three-label issue',
+        state: 'open',
+        labels: ['bug', 'enhancement', 'documentation'],
+        author: 'scout',
+        createdAt: '2026-02-05T09:00:00Z',
+      },
+    ];
+
+    render(<IssueList issues={issues} repoUrl={repoUrl} />);
+
+    expect(screen.getByText('+1 more')).toBeInTheDocument();
+    expect(screen.getByTitle('documentation')).toBeInTheDocument();
+  });
+
   it('applies motion-safe:transition-colors to list item links', () => {
     const issues: Issue[] = [
       {

--- a/web/src/components/IssueList.tsx
+++ b/web/src/components/IssueList.tsx
@@ -61,6 +61,14 @@ export function IssueList({
                     {label}
                   </span>
                 ))}
+                {issue.labels.length > 2 && (
+                  <span
+                    className="text-xs px-1 py-0.5 bg-amber-50 dark:bg-amber-900/30 text-amber-500 dark:text-amber-400 rounded"
+                    title={issue.labels.slice(2).join(', ')}
+                  >
+                    +{issue.labels.length - 2} more
+                  </span>
+                )}
               </div>
             )}
             <div className="flex items-center gap-1.5 mt-1.5">

--- a/web/src/components/ProjectHealth.test.tsx
+++ b/web/src/components/ProjectHealth.test.tsx
@@ -57,6 +57,24 @@ describe('ProjectHealth', () => {
     );
   });
 
+  it('includes focus ring offset on all links', () => {
+    render(
+      <ProjectHealth
+        repository={mockRepo}
+        activeAgentsCount={3}
+        activeProposalsCount={2}
+      />
+    );
+
+    const links = screen.getAllByRole('link');
+    for (const link of links) {
+      expect(link.className).toContain('focus-visible:ring-offset-1');
+      expect(link.className).toContain(
+        'dark:focus-visible:ring-offset-neutral-900'
+      );
+    }
+  });
+
   it('renders singular labels when count is 1', () => {
     render(
       <ProjectHealth

--- a/web/src/components/ProjectHealth.tsx
+++ b/web/src/components/ProjectHealth.tsx
@@ -20,7 +20,7 @@ export function ProjectHealth({
         href={`${repository.url}/stargazers`}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-900"
         title="Stars"
       >
         <span role="img" aria-label="star">
@@ -35,7 +35,7 @@ export function ProjectHealth({
         href={`${repository.url}/network/members`}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-900"
         title="Forks"
       >
         <span role="img" aria-label="fork">
@@ -50,7 +50,7 @@ export function ProjectHealth({
         href={`${repository.url}/issues`}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-900"
         title="Open Issues"
       >
         <span role="img" aria-label="issue">
@@ -64,7 +64,7 @@ export function ProjectHealth({
       </span>
       <a
         href="#agents"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-900"
         title="Active Agents"
       >
         <span role="img" aria-label="active agents">
@@ -78,7 +78,7 @@ export function ProjectHealth({
       </span>
       <a
         href="#proposals"
-        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-900"
         title="Active Proposals"
       >
         <span role="img" aria-label="active proposals">


### PR DESCRIPTION
## Summary

- Add `focus-visible:ring-offset-1` and dark mode offset color to **10 interactive links** across 5 components that were missing the ring-offset pattern established by CommitList, IssueList, PullRequestList, ProposalList, and CommentList
- Add **"+N more" overflow indicator** to IssueList when labels are truncated beyond two, with a `title` tooltip showing the hidden labels

### Components updated

| Component | Change | Links affected |
|---|---|---|
| ProjectHealth.tsx | Added ring-offset-1 + dark offset neutral-900 | 5 `<a>` links |
| ActivityTimeline.tsx | Added ring-offset-1 + dark offset neutral-800 | 1 event title `<a>` |
| AgentLeaderboard.tsx | Added ring-offset-1 + dark offset neutral-800 | 1 agent name `<a>` |
| AgentList.tsx | Added ring-offset-1 + dark offset neutral-800 | 1 login `<a>` link |
| ActivityFeed.tsx | Added ring-offset-1 + dark offset neutral-800 | 1 clear filter `<button>` |
| IssueList.tsx | Added "+N more" overflow chip | Labels section |

### Tests added

- ProjectHealth: verify all links include ring-offset classes
- ActivityTimeline: verify event links include ring-offset classes
- AgentLeaderboard: verify agent name link includes ring-offset classes
- AgentList: verify login link includes ring-offset classes
- ActivityFeed: verify clear filter button includes ring-offset classes
- IssueList: 3 tests for overflow indicator (4 labels, 2 labels, 3 labels)

All 185 tests pass. Lint, typecheck, and build clean.

Fixes #100.

## Test plan

- [ ] Verify `npm test` passes all 185 tests
- [ ] Verify `npm run lint` reports no errors
- [ ] Verify `npm run build` succeeds
- [ ] Visually check focus rings in dark mode have visible offset gap
- [ ] Visually check IssueList "+N more" chip appears for issues with 3+ labels