### PR TITLE
fix(web): add NaN guard to formatTimeAgo

### DIFF
--- a/web/src/utils/time.test.ts
+++ b/web/src/utils/time.test.ts
@@ -33,6 +33,11 @@ describe('formatTimeAgo', () => {
     expect(formatTimeAgo(tenDays, now)).toBe('10 days ago');
   });
 
+  it('returns empty string for invalid date', () => {
+    expect(formatTimeAgo(new Date('invalid'))).toBe('');
+    expect(formatTimeAgo(new Date(NaN))).toBe('');
+  });
+
   it('handles boundary conditions', () => {
     expect(formatTimeAgo(new Date(now - 59 * 1000), now)).toBe('just now');
     expect(formatTimeAgo(new Date(now - 60 * 1000), now)).toBe('1 minutes ago');

--- a/web/src/utils/time.ts
+++ b/web/src/utils/time.ts
@@ -1,5 +1,8 @@
 export function formatTimeAgo(date: Date, now = Date.now()): string {
-  const seconds = Math.floor((now - date.getTime()) / 1000);
+  const ms = date.getTime();
+  if (isNaN(ms)) return '';
+
+  const seconds = Math.floor((now - ms) / 1000);
 
   if (seconds < 60) return 'just now';
   if (seconds < 3600) return `${Math.floor(seconds / 60)} minutes ago`;


### PR DESCRIPTION
Fixes #142

## Summary

- Adds `isNaN()` guard at the top of `formatTimeAgo` to prevent "NaN days ago" from appearing when called with an invalid `Date`
- Returns empty string for invalid dates so the UI renders nothing instead of garbage text
- Matches the defensive pattern already used by the sibling `formatDuration` function
- Adds test covering `new Date('invalid')` and `new Date(NaN)` inputs

## Test plan

- [x] Existing tests pass (195/195)
- [x] New test verifies empty string for invalid dates
- [x] TypeScript type check passes
- [x] ESLint passes