### PR TITLE
a11y(web): add loading live region, button types, and motion-safe footer link

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -112,6 +112,17 @@ describe('App', () => {
     });
   });
 
+  it('loading state has role="status" and aria-live for screen readers', async () => {
+    vi.mocked(fetch).mockImplementation(() => new Promise(() => {}));
+
+    render(<App />);
+    await waitFor(() => {
+      const loadingRegion = screen.getByRole('status');
+      expect(loadingRegion).toBeInTheDocument();
+      expect(loadingRegion).toHaveAttribute('aria-live', 'polite');
+    });
+  });
+
   it('loading spinner respects reduced motion preference', async () => {
     vi.mocked(fetch).mockImplementation(() => new Promise(() => {}));
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -51,7 +51,7 @@ function App(): React.ReactElement {
 
       <main className="flex-1 w-full max-w-6xl">
         {loading && (
-          <div className="text-center py-12">
+          <div className="text-center py-12" role="status" aria-live="polite">
             <div
               className="inline-block animate-spin motion-reduce:animate-none text-4xl"
               role="img"
@@ -117,7 +117,7 @@ function App(): React.ReactElement {
           href="https://github.com/hivemoot/hivemoot"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center justify-center px-6 py-3 bg-amber-100 hover:bg-amber-200 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-amber-900 dark:text-amber-100 font-medium rounded-lg transition-colors border border-amber-300 dark:border-neutral-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
+          className="inline-flex items-center justify-center px-6 py-3 bg-amber-100 hover:bg-amber-200 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-amber-900 dark:text-amber-100 font-medium rounded-lg motion-safe:transition-colors border border-amber-300 dark:border-neutral-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
         >
           Learn About Hivemoot
         </a>

--- a/web/src/components/ActivityFeed.test.tsx
+++ b/web/src/components/ActivityFeed.test.tsx
@@ -389,6 +389,20 @@ describe('ActivityFeed', () => {
       expect(screen.queryByText('Clear filter')).not.toBeInTheDocument();
     });
 
+    it('renders Clear filter as type="button" to prevent accidental form submission', () => {
+      render(
+        <ActivityFeed
+          {...defaultProps}
+          data={multiAgentData}
+          events={multiAgentEvents}
+          selectedAgent="worker"
+        />
+      );
+
+      const clearButton = screen.getByText('Clear filter');
+      expect(clearButton).toHaveAttribute('type', 'button');
+    });
+
     it('includes focus ring offset on Clear filter button', () => {
       render(
         <ActivityFeed

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -107,6 +107,7 @@ export function ActivityFeed({
               Filtered by: <strong>{selectedAgent}</strong>
             </span>
             <button
+              type="button"
               onClick={() => onSelectAgent(null)}
               className="text-xs text-amber-600 hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-200 underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800 rounded"
             >

--- a/web/src/components/ActivityTimeline.test.tsx
+++ b/web/src/components/ActivityTimeline.test.tsx
@@ -14,6 +14,24 @@ describe('ActivityTimeline', () => {
     expect(screen.getByText(/no recent activity yet/i)).toBeInTheDocument();
   });
 
+  it('labels the events list for screen readers', () => {
+    const events: ActivityEvent[] = [
+      {
+        id: 'commit-1',
+        type: 'commit',
+        summary: 'Commit pushed',
+        title: 'Test',
+        actor: 'worker',
+        createdAt: '2026-02-05T10:00:00Z',
+      },
+    ];
+
+    render(<ActivityTimeline events={events} />);
+
+    const list = screen.getByRole('list');
+    expect(list).toHaveAttribute('aria-label', 'Recent activity events');
+  });
+
   it('renders a list of activity events', () => {
     const events: ActivityEvent[] = [
       {

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -71,7 +71,7 @@ export function ActivityTimeline({
   }
 
   return (
-    <ul className="space-y-5">
+    <ul className="space-y-5" aria-label="Recent activity events">
       {events.map((event) => {
         const style = EVENT_STYLES[event.type];
         const eventDate = new Date(event.createdAt);

--- a/web/src/components/ErrorBoundary.test.tsx
+++ b/web/src/components/ErrorBoundary.test.tsx
@@ -78,6 +78,19 @@ describe('ErrorBoundary', () => {
     expect(screen.getByText('Safe component')).toBeInTheDocument();
   });
 
+  it('renders "Try Again" button with type="button"', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    const button = screen.getByRole('button', { name: /try again/i });
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
   it('includes focus-visible ring on the "Try Again" button', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -40,6 +40,7 @@ export class ErrorBoundary extends Component<Props, State> {
               {this.state.error?.message || 'A component failed to render.'}
             </p>
             <button
+              type="button"
               onClick={() => this.setState({ hasError: false, error: null })}
               className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium motion-safe:transition-colors shadow-sm motion-safe:active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
             >


### PR DESCRIPTION
Fixes #155

## Summary

- Adds `role="status"` and `aria-live="polite"` to the App.tsx loading state so screen readers announce when data finishes loading
- Adds `type="button"` to the "Clear filter" button in ActivityFeed and the "Try Again" button in ErrorBoundary, preventing unexpected form submission behavior
- Normalizes the last bare `transition-colors` to `motion-safe:transition-colors` on the "Learn About Hivemoot" footer link, completing the work from PR #122
- Adds `aria-label="Recent activity events"` to the ActivityTimeline `<ul>` for screen reader navigation context

## Files changed

| File | Change |
|------|--------|
| `App.tsx` | `role="status" aria-live="polite"` on loading div; `motion-safe:` prefix on footer link |
| `ActivityFeed.tsx` | `type="button"` on Clear filter button |
| `ErrorBoundary.tsx` | `type="button"` on Try Again button |
| `ActivityTimeline.tsx` | `aria-label` on events list |
| `App.test.tsx` | Test for loading region `role="status"` |
| `ActivityFeed.test.tsx` | Test for `type="button"` on Clear filter |
| `ErrorBoundary.test.tsx` | Test for `type="button"` on Try Again |
| `ActivityTimeline.test.tsx` | Test for list `aria-label` |

## Verification

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean  
- [x] `npm test` — 240/240 tests pass (4 new tests)
- [x] `npm run build` — successful