### PR TITLE
a11y(web): add error alert role and skip-to-content link

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -230,7 +230,7 @@ describe('App', () => {
     });
   });
 
-  it('shows error state on fetch failure', async () => {
+  it('shows error state on fetch failure with alert role', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: false,
       status: 500,
@@ -242,6 +242,23 @@ describe('App', () => {
         screen.getByText(/failed to load activity data/i)
       ).toBeInTheDocument();
     });
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/failed to load activity data/i);
+  });
+
+  it('renders skip-to-content link targeting main', async () => {
+    vi.mocked(fetch).mockImplementation(() => new Promise(() => {}));
+
+    render(<App />);
+    await waitFor(() => {
+      const skipLink = screen.getByText(/skip to content/i);
+      expect(skipLink).toBeInTheDocument();
+      expect(skipLink).toHaveAttribute('href', '#main-content');
+    });
+
+    expect(document.getElementById('main-content')).not.toBeNull();
+    expect(document.getElementById('main-content')?.tagName).toBe('MAIN');
   });
 
   it('renders the GitHub link', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,12 @@ function App(): React.ReactElement {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-amber-50 to-amber-100 dark:from-neutral-900 dark:to-neutral-800 flex flex-col items-center px-4 py-8">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-amber-600 focus:text-white focus:rounded-lg focus:text-sm focus:font-medium focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:focus:ring-offset-neutral-900"
+      >
+        Skip to content
+      </a>
       <header className="text-center max-w-2xl mb-8">
         <div className="text-6xl mb-6" role="img" aria-label="bee">
           🐝
@@ -49,7 +55,7 @@ function App(): React.ReactElement {
         </p>
       </header>
 
-      <main className="flex-1 w-full max-w-6xl">
+      <main id="main-content" className="flex-1 w-full max-w-6xl">
         {loading && (
           <div className="text-center py-12">
             <div
@@ -66,7 +72,10 @@ function App(): React.ReactElement {
         )}
 
         {error && !hasActivity && (
-          <div className="bg-red-100 dark:bg-red-900/50 border border-red-300 dark:border-red-700 rounded-lg p-4 text-center">
+          <div
+            role="alert"
+            className="bg-red-100 dark:bg-red-900/50 border border-red-300 dark:border-red-700 rounded-lg p-4 text-center"
+          >
             <p className="text-red-800 dark:text-red-200">
               Failed to load activity data
             </p>


### PR DESCRIPTION
Fixes #159

## Summary

- Adds `role="alert"` to the error state div in `App.tsx` so screen readers announce data loading failures (WCAG 4.1.3)
- Adds a skip-to-content link as the first focusable element, allowing keyboard users to bypass the header and jump directly to `<main>` (WCAG 2.4.1)
- Adds `id="main-content"` to the `<main>` element as the skip link target

## Files changed

| File | Change |
|------|--------|
| `App.tsx` | Add `role="alert"` to error div; add skip-to-content link; add `id="main-content"` to `<main>` |
| `App.test.tsx` | Test: error state has `role="alert"`; test: skip link targets main element |

## Verification

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 237/237 tests pass (2 new tests)
- [x] `npm run build` — successful