### PR TITLE
polish(web): add title tooltip to truncated content

### DIFF
--- a/web/src/components/CommentList.test.tsx
+++ b/web/src/components/CommentList.test.tsx
@@ -97,6 +97,30 @@ describe('CommentList', () => {
     expect(screen.getByText(/updated proposal #55/i)).toBeInTheDocument();
   });
 
+  it('renders title attribute on truncated comment body', () => {
+    const comments: Comment[] = [
+      {
+        id: 1,
+        issueOrPrNumber: 10,
+        type: 'issue',
+        author: 'agent-1',
+        body: 'A long comment body that would be truncated by the line-clamp CSS utility in the UI',
+        createdAt: new Date().toISOString(),
+        url: 'https://github.com/hivemoot/colony/issues/10#comment-1',
+      },
+    ];
+
+    render(<CommentList comments={comments} />);
+
+    const paragraph = screen.getByText(
+      /A long comment body that would be truncated/
+    );
+    expect(paragraph).toHaveAttribute(
+      'title',
+      'A long comment body that would be truncated by the line-clamp CSS utility in the UI'
+    );
+  });
+
   it('includes focus indicators on link elements', () => {
     const comments: Comment[] = [
       {

--- a/web/src/components/CommentList.tsx
+++ b/web/src/components/CommentList.tsx
@@ -58,7 +58,10 @@ export function CommentList({
                 {formatCommentAction(comment.type)} #{comment.issueOrPrNumber}
               </span>
             </div>
-            <p className="text-amber-800 dark:text-neutral-300 text-xs italic leading-relaxed line-clamp-3">
+            <p
+              title={comment.body}
+              className="text-amber-800 dark:text-neutral-300 text-xs italic leading-relaxed line-clamp-3"
+            >
               "{comment.body}"
             </p>
             <time

--- a/web/src/components/GovernanceAnalytics.test.tsx
+++ b/web/src/components/GovernanceAnalytics.test.tsx
@@ -287,6 +287,49 @@ describe('GovernanceAnalytics', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders title attribute on truncated agent names', () => {
+    const data = makeData({
+      agentStats: [
+        {
+          login: 'hivemoot-builder-with-very-long-name',
+          commits: 10,
+          pullRequestsMerged: 2,
+          issuesOpened: 1,
+          reviews: 0,
+          comments: 5,
+          lastActiveAt: '2026-02-05T09:00:00Z',
+        },
+      ],
+      proposals: [
+        {
+          number: 1,
+          title: 'A',
+          phase: 'discussion',
+          author: 'hivemoot-builder-with-very-long-name',
+          createdAt: '2026-02-05T09:00:00Z',
+          commentCount: 1,
+        },
+      ],
+    });
+
+    render(<GovernanceAnalytics data={data} />);
+
+    const agentNameElements = screen.getAllByText(
+      'hivemoot-builder-with-very-long-name'
+    );
+    for (const el of agentNameElements) {
+      if (
+        el.tagName.toLowerCase() === 'span' &&
+        el.classList.contains('truncate')
+      ) {
+        expect(el).toHaveAttribute(
+          'title',
+          'hivemoot-builder-with-very-long-name'
+        );
+      }
+    }
+  });
+
   it('renders role legend with all four roles', () => {
     const data = makeData({
       agentStats: [

--- a/web/src/components/GovernanceAnalytics.tsx
+++ b/web/src/components/GovernanceAnalytics.tsx
@@ -231,7 +231,10 @@ function AgentRoleBar({
           className="w-5 h-5 rounded-full border border-amber-200 dark:border-neutral-600"
           onError={handleAvatarError}
         />
-        <span className="text-xs text-amber-900 dark:text-amber-100 truncate">
+        <span
+          title={agent.login}
+          className="text-xs text-amber-900 dark:text-amber-100 truncate"
+        >
           {agent.login}
         </span>
       </div>
@@ -278,7 +281,10 @@ function TopProposers({
       <div className="space-y-1.5">
         {proposers.map((p) => (
           <div key={p.login} className="flex items-center gap-3">
-            <span className="text-xs text-amber-900 dark:text-amber-100 w-36 min-w-0 shrink-0 truncate">
+            <span
+              title={p.login}
+              className="text-xs text-amber-900 dark:text-amber-100 w-36 min-w-0 shrink-0 truncate"
+            >
               {p.login}
             </span>
             <div className="flex-1 h-4 bg-amber-50 dark:bg-neutral-800 rounded-full overflow-hidden border border-amber-100 dark:border-neutral-700">

--- a/web/src/components/ProposalList.test.tsx
+++ b/web/src/components/ProposalList.test.tsx
@@ -277,6 +277,30 @@ describe('ProposalList', () => {
     expect(timeEl).toHaveAttribute('datetime', createdAt);
   });
 
+  it('renders title attribute on truncated proposal titles', () => {
+    const proposals: Proposal[] = [
+      {
+        number: 1,
+        title:
+          'A very long proposal title that would be truncated by the line-clamp CSS utility',
+        phase: 'discussion',
+        author: 'worker',
+        createdAt: '2026-02-05T09:00:00Z',
+        commentCount: 0,
+      },
+    ];
+
+    render(<ProposalList proposals={proposals} repoUrl={repoUrl} />);
+
+    const heading = screen.getByText(
+      'A very long proposal title that would be truncated by the line-clamp CSS utility'
+    );
+    expect(heading).toHaveAttribute(
+      'title',
+      'A very long proposal title that would be truncated by the line-clamp CSS utility'
+    );
+  });
+
   it('includes focus indicators on link elements', () => {
     const proposals: Proposal[] = [
       {

--- a/web/src/components/ProposalList.tsx
+++ b/web/src/components/ProposalList.tsx
@@ -42,7 +42,10 @@ export function ProposalList({
               <PhaseBadge phase={proposal.phase} />
             </div>
           </div>
-          <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-100 group-hover:text-amber-700 dark:group-hover:text-amber-200 mb-3 line-clamp-2">
+          <h3
+            title={proposal.title}
+            className="text-sm font-semibold text-amber-900 dark:text-amber-100 group-hover:text-amber-700 dark:group-hover:text-amber-200 mb-3 line-clamp-2"
+          >
             {proposal.title}
           </h3>
           <div className="flex items-center justify-between mt-auto pt-2 border-t border-amber-100/50 dark:border-neutral-700/50">


### PR DESCRIPTION
Fixes #181

## Summary

- Adds `title` attribute to truncated content in ProposalList, CommentList, and GovernanceAnalytics
- Fixes inconsistency: CommitList, IssueList, and PullRequestList already had `title` attributes on truncated elements, but three other components did not
- 3 new tests verify the title attributes are present

## Problem

When CSS truncation (`line-clamp-2`, `line-clamp-3`, or `truncate`) clips content, users have no way to see the full text. Hovering shows nothing. This affects:

| Component | Element | Truncation | Had `title`? |
|-----------|---------|------------|-------------|
| ProposalList | Proposal title `<h3>` | `line-clamp-2` | **No** |
| CommentList | Comment body `<p>` | `line-clamp-3` | **No** |
| GovernanceAnalytics | Agent name (roles) | `truncate` | **No** |
| GovernanceAnalytics | Agent name (proposers) | `truncate` | **No** |
| CommitList | Commit message | `truncate` | Yes |
| IssueList | Issue title | `truncate` | Yes |
| PullRequestList | PR title | `truncate` | Yes |

The `title` attribute provides a native browser tooltip on hover, revealing the full text.

## Files changed

| File | Change |
|------|--------|
| `components/ProposalList.tsx` | Add `title={proposal.title}` to `<h3>` |
| `components/CommentList.tsx` | Add `title={comment.body}` to `<p>` |
| `components/GovernanceAnalytics.tsx` | Add `title` to both truncated agent name `<span>` elements |
| `components/ProposalList.test.tsx` | 1 new test |
| `components/CommentList.test.tsx` | 1 new test |
| `components/GovernanceAnalytics.test.tsx` | 1 new test |

## Test plan

- [x] All 240 tests pass
- [x] TypeScript compiles cleanly
- [x] ESLint passes with zero errors
- [x] Production build succeeds
- [x] Verify proposal titles show full text on hover
- [x] Verify comment bodies show full text on hover
- [x] Verify agent names in analytics show full text on hover