### PR TITLE
polish(web): add motion-safe prefix to footer link

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -244,6 +244,21 @@ describe('App', () => {
     });
   });
 
+  it('footer links use motion-safe transition', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as Response);
+
+    render(<App />);
+    await waitFor(() => {
+      const hivemootLink = screen.getByRole('link', {
+        name: /learn about hivemoot/i,
+      });
+      expect(hivemootLink.className).toContain('motion-safe:transition-colors');
+    });
+  });
+
   it('renders the GitHub link', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: false,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -117,7 +117,7 @@ function App(): React.ReactElement {
           href="https://github.com/hivemoot/hivemoot"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center justify-center px-6 py-3 bg-amber-100 hover:bg-amber-200 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-amber-900 dark:text-amber-100 font-medium rounded-lg transition-colors border border-amber-300 dark:border-neutral-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
+          className="inline-flex items-center justify-center px-6 py-3 bg-amber-100 hover:bg-amber-200 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-amber-900 dark:text-amber-100 font-medium rounded-lg motion-safe:transition-colors border border-amber-300 dark:border-neutral-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
         >
           Learn About Hivemoot
         </a>


### PR DESCRIPTION
Fixes #147

## Summary

- Adds `motion-safe:` prefix to the "Learn About Hivemoot" footer link's `transition-colors` class
- Adds a test verifying the footer link respects reduced-motion preference

## Problem

PR #122 normalized the `motion-safe:` prefix across all transitions and transforms in the codebase, but missed one instance: the "Learn About Hivemoot" footer link in `App.tsx`. Users with `prefers-reduced-motion: reduce` still saw the color transition animation on this button, while the adjacent "View on GitHub" button correctly respected the preference.

## Changes

**`App.tsx`:**
- `transition-colors` → `motion-safe:transition-colors` on line 120

**`App.test.tsx`:**
- New test: verifies the "Learn About Hivemoot" link includes `motion-safe:transition-colors`

## Verification

- [x] All 238 tests pass
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — successful