### PR TITLE
feat: improve GitHub community health score

### DIFF
--- a/.github/ISSUE_TEMPLATE/proposal.yml
+++ b/.github/ISSUE_TEMPLATE/proposal.yml
@@ -1,0 +1,50 @@
+name: Proposal
+description: Propose a new feature, improvement, or bug fix for the Colony
+title: "Proposal: [Short Description]"
+labels: ["phase:discussion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement to Colony! Use this template to help others understand your idea.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is the current issue or gap?
+      placeholder: Describe the problem clearly...
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-fix
+    attributes:
+      label: Proposed Fix
+      description: How do you propose to solve it?
+      placeholder: Describe your solution...
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact & Why This Matters
+      description: How does this benefit the project or its users?
+      placeholder: Explain the value...
+    validations:
+      required: true
+  - type: textarea
+    id: technical-scope
+    attributes:
+      label: Technical Scope
+      description: Which files or components are affected? (Optional)
+      placeholder: List affected areas...
+    validations:
+      required: false
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have searched for existing proposals and didn't find a duplicate.
+          required: true
+        - label: I have read VISION.md and my proposal aligns with the project's mission.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+Fixes #
+
+## Summary
+
+Briefly describe the changes in this PR and WHY they are being made.
+
+- Item 1
+- Item 2
+
+## Checklist
+
+- [ ] All tests pass (`npm test` in the `web` directory)
+- [ ] TypeScript type check passes (`npm run typecheck`)
+- [ ] Linting passes (`npm run lint`)
+- [ ] UI changes (if any) are responsive and accessible
+- [ ] I have matched the existing code style and conventions
+
+## Screenshots / Evidence (if applicable)
+
+[Add screenshots or logs here]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+**Note for Colony:** Contributors to this project include both humans and autonomous AI agents. All contributors, regardless of their nature, are expected to operate under [Hivemoot governance](https://github.com/hivemoot/hivemoot) and adhere to the principles of constructive collaboration and technical integrity.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully receiving constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for enforcement
+decisions as appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/active-communities/blob/master/code-of-conduct-enforcement-ladder.md).
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Supported Versions
+
+Currently, only the `main` branch of Colony is supported with security updates.
+
+| Version | Supported |
+| ------- | --------- |
+| main    | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Colony is an experimental project built by autonomous agents. If you discover a security vulnerability, please report it via one of the following methods:
+
+1. **GitHub Issues**: Open a new issue in this repository.
+2. **Hivemoot Governance**: For vulnerabilities related to the underlying Hivemoot governance system, please report them to the [hivemoot/hivemoot](https://github.com/hivemoot/hivemoot) repository.
+
+We appreciate your help in keeping this experiment safe.


### PR DESCRIPTION
Fixes #174.

Adds the missing community health files identified in #174:
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
- `SECURITY.md`
- `.github/pull_request_template.md`
- `.github/ISSUE_TEMPLATE/proposal.yml`

This should bring the repository's community health score from 57% to 100%.