### PR TITLE
fix(web): use UTC for ColonyStory milestone dates

### DIFF
--- a/web/src/components/ColonyStory.test.tsx
+++ b/web/src/components/ColonyStory.test.tsx
@@ -123,4 +123,14 @@ describe('ColonyStory', () => {
     const items = container.querySelectorAll('li');
     expect(items).toHaveLength(8);
   });
+
+  it('renders milestone dates in UTC regardless of local timezone', () => {
+    render(<ColonyStory data={baseData} />);
+
+    // The first milestone uses date '2026-02-01' — should always render as "Feb 1"
+    // regardless of the viewer's timezone. Without UTC handling, users in
+    // timezones east of UTC would see "Jan 31".
+    const timeElements = document.querySelectorAll('time');
+    expect(timeElements[0].textContent).toBe('Feb 1');
+  });
 });

--- a/web/src/components/ColonyStory.tsx
+++ b/web/src/components/ColonyStory.tsx
@@ -58,9 +58,10 @@ export function ColonyStory({ data }: ColonyStoryProps): React.ReactElement {
 }
 
 function formatMilestoneDate(iso: string): string {
-  const date = new Date(iso + 'T00:00:00');
+  const date = new Date(iso + 'T00:00:00Z');
   return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
+    timeZone: 'UTC',
   });
 }


### PR DESCRIPTION
Fixes #178

## Summary

The ColonyStory timeline's `formatMilestoneDate` function parsed ISO date strings without a UTC suffix, causing milestone dates to render incorrectly for users in non-UTC timezones. For example, a milestone dated `2026-02-01` could display as "Jan 31" for users east of UTC.

- Adds `Z` suffix to `new Date()` call to force UTC interpretation
- Adds `timeZone: 'UTC'` to `toLocaleDateString()` options for consistent output
- Adds a test verifying dates render correctly regardless of timezone

This matches the UTC-consistent pattern used by `ActivityHeatmap`'s `formatDateLabel` and the rest of the codebase.

## Checklist

- [x] All tests pass (`npm test` in the `web` directory) — 280 pass
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] Linting passes (`npm run lint`)
- [x] I have matched the existing code style and conventions