### PR TITLE
feat(web): add agent profile panel for individual contributions

### DIFF
--- a/web/src/components/ActivityFeed.test.tsx
+++ b/web/src/components/ActivityFeed.test.tsx
@@ -436,7 +436,7 @@ describe('ActivityFeed', () => {
       expect(onSelectAgent).toHaveBeenCalledWith(null);
     });
 
-    it('shows filtered counts in section headings when agent is selected', () => {
+    it('shows agent profile panel when agent is selected', () => {
       render(
         <ActivityFeed
           {...defaultProps}
@@ -446,12 +446,13 @@ describe('ActivityFeed', () => {
         />
       );
 
-      // worker has 1 of 2 commits
-      expect(screen.getByText('(1 of 2)')).toBeInTheDocument();
-      // Multiple sections show (0 of 1) when worker owns none
-      // (issues: scout owns it, discussion: scout owns the comment)
-      const zeroOfOnes = screen.getAllByText('(0 of 1)');
-      expect(zeroOfOnes.length).toBeGreaterThanOrEqual(1);
+      // Profile panel replaces content sections
+      expect(screen.getByText('Agent Profile')).toBeInTheDocument();
+      expect(screen.getByText('Back to dashboard')).toBeInTheDocument();
+      // Content sections should not be visible
+      expect(
+        screen.queryByRole('heading', { name: /recent commits/i })
+      ).not.toBeInTheDocument();
     });
 
     it('shows total counts without filter text when no agent is selected', () => {
@@ -482,7 +483,7 @@ describe('ActivityFeed', () => {
       expect(ones.length).toBe(5);
     });
 
-    it('displays "X of Y" counts when agent filter is active', () => {
+    it('shows profile panel instead of grid sections when agent is selected', () => {
       const dataWithMixedAuthors: ActivityData = {
         ...mockData,
         commits: [
@@ -515,8 +516,10 @@ describe('ActivityFeed', () => {
         />
       );
 
-      // worker has 1 of 3 commits
-      expect(screen.getByText('(1 of 3)')).toBeInTheDocument();
+      // Profile panel renders instead of grid sections
+      expect(screen.getByText('Agent Profile')).toBeInTheDocument();
+      // Grid sections with counts are not rendered
+      expect(screen.queryByText('(1 of 3)')).not.toBeInTheDocument();
     });
   });
 });

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -4,6 +4,7 @@ import type {
   ActivityMode,
 } from '../types/activity';
 import { ActivityTimeline } from './ActivityTimeline';
+import { AgentProfilePanel } from './AgentProfilePanel';
 import { CommitList } from './CommitList';
 import { IssueList } from './IssueList';
 import { PullRequestList } from './PullRequestList';
@@ -157,152 +158,165 @@ export function ActivityFeed({
         </section>
       )}
 
-      {data && data.proposals && data.proposals.length > 0 && (
-        <section
-          id="proposals"
-          className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
-        >
-          <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
-            <span role="img" aria-label="governance">
-              ⚖️
-            </span>
-            Governance Status
-            <SectionCount
-              filtered={filteredProposals.length}
-              total={data.proposals.length}
-              isFiltered={Boolean(selectedAgent)}
-            />
-          </h2>
-          <ProposalList
-            proposals={filteredProposals}
-            repoUrl={data.repository.url}
-            filteredAgent={selectedAgent}
+      {data && selectedAgent ? (
+        <section className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+          <AgentProfilePanel
+            data={data}
+            events={events}
+            agentLogin={selectedAgent}
+            onClose={() => onSelectAgent(null)}
           />
         </section>
-      )}
-
-      {data && data.proposals.length > 0 && (
-        <section
-          id="analytics"
-          className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
-        >
-          <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
-            <span role="img" aria-label="analytics">
-              📊
-            </span>
-            Governance Analytics
-          </h2>
-          <GovernanceAnalytics data={data} />
-        </section>
-      )}
-
-      {data && data.agentStats.length >= 2 && data.comments.length > 0 && (
-        <section
-          id="collaboration"
-          className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
-        >
-          <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
-            <span role="img" aria-label="collaboration network">
-              🕸️
-            </span>
-            Collaboration Network
-          </h2>
-          <CollaborationNetwork data={data} />
-        </section>
-      )}
-
-      {data && (
-        <section
-          id="story"
-          className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
-        >
-          <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
-            <span role="img" aria-label="story">
-              📖
-            </span>
-            Colony Story
-          </h2>
-          <ColonyStory data={data} />
-        </section>
-      )}
-
-      {data && (
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
-            <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
-              <span role="img" aria-label="commit">
-                📝
-              </span>
-              Recent Commits
-              <SectionCount
-                filtered={filteredCommits.length}
-                total={data.commits.length}
-                isFiltered={Boolean(selectedAgent)}
+      ) : (
+        <>
+          {data && data.proposals && data.proposals.length > 0 && (
+            <section
+              id="proposals"
+              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+            >
+              <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
+                <span role="img" aria-label="governance">
+                  ⚖️
+                </span>
+                Governance Status
+                <SectionCount
+                  filtered={filteredProposals.length}
+                  total={data.proposals.length}
+                  isFiltered={Boolean(selectedAgent)}
+                />
+              </h2>
+              <ProposalList
+                proposals={filteredProposals}
+                repoUrl={data.repository.url}
+                filteredAgent={selectedAgent}
               />
-            </h2>
-            <CommitList
-              commits={filteredCommits.slice(0, 5)}
-              repoUrl={data.repository.url}
-              filteredAgent={selectedAgent}
-            />
-          </section>
+            </section>
+          )}
 
-          <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
-            <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
-              <span role="img" aria-label="issue">
-                🎯
-              </span>
-              Issues
-              <SectionCount
-                filtered={filteredIssues.length}
-                total={data.issues.length}
-                isFiltered={Boolean(selectedAgent)}
-              />
-            </h2>
-            <IssueList
-              issues={filteredIssues.slice(0, 5)}
-              repoUrl={data.repository.url}
-              filteredAgent={selectedAgent}
-            />
-          </section>
+          {data && data.proposals.length > 0 && (
+            <section
+              id="analytics"
+              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+            >
+              <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
+                <span role="img" aria-label="analytics">
+                  📊
+                </span>
+                Governance Analytics
+              </h2>
+              <GovernanceAnalytics data={data} />
+            </section>
+          )}
 
-          <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
-            <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
-              <span role="img" aria-label="pull request">
-                🔀
-              </span>
-              Pull Requests
-              <SectionCount
-                filtered={filteredPRs.length}
-                total={data.pullRequests.length}
-                isFiltered={Boolean(selectedAgent)}
-              />
-            </h2>
-            <PullRequestList
-              pullRequests={filteredPRs.slice(0, 5)}
-              repoUrl={data.repository.url}
-              filteredAgent={selectedAgent}
-            />
-          </section>
+          {data && data.agentStats.length >= 2 && data.comments.length > 0 && (
+            <section
+              id="collaboration"
+              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+            >
+              <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
+                <span role="img" aria-label="collaboration network">
+                  🕸️
+                </span>
+                Collaboration Network
+              </h2>
+              <CollaborationNetwork data={data} />
+            </section>
+          )}
 
-          <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
-            <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
-              <span role="img" aria-label="discussion">
-                💬
-              </span>
-              Discussion
-              <SectionCount
-                filtered={filteredComments.length}
-                total={nonProposalComments.length}
-                isFiltered={Boolean(selectedAgent)}
-              />
-            </h2>
-            <CommentList
-              comments={filteredComments.slice(0, 5)}
-              filteredAgent={selectedAgent}
-            />
-          </section>
-        </div>
+          {data && (
+            <section
+              id="story"
+              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+            >
+              <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
+                <span role="img" aria-label="story">
+                  📖
+                </span>
+                Colony Story
+              </h2>
+              <ColonyStory data={data} />
+            </section>
+          )}
+
+          {data && (
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+              <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+                <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
+                  <span role="img" aria-label="commit">
+                    📝
+                  </span>
+                  Recent Commits
+                  <SectionCount
+                    filtered={filteredCommits.length}
+                    total={data.commits.length}
+                    isFiltered={Boolean(selectedAgent)}
+                  />
+                </h2>
+                <CommitList
+                  commits={filteredCommits.slice(0, 5)}
+                  repoUrl={data.repository.url}
+                  filteredAgent={selectedAgent}
+                />
+              </section>
+
+              <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+                <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
+                  <span role="img" aria-label="issue">
+                    🎯
+                  </span>
+                  Issues
+                  <SectionCount
+                    filtered={filteredIssues.length}
+                    total={data.issues.length}
+                    isFiltered={Boolean(selectedAgent)}
+                  />
+                </h2>
+                <IssueList
+                  issues={filteredIssues.slice(0, 5)}
+                  repoUrl={data.repository.url}
+                  filteredAgent={selectedAgent}
+                />
+              </section>
+
+              <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+                <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
+                  <span role="img" aria-label="pull request">
+                    🔀
+                  </span>
+                  Pull Requests
+                  <SectionCount
+                    filtered={filteredPRs.length}
+                    total={data.pullRequests.length}
+                    isFiltered={Boolean(selectedAgent)}
+                  />
+                </h2>
+                <PullRequestList
+                  pullRequests={filteredPRs.slice(0, 5)}
+                  repoUrl={data.repository.url}
+                  filteredAgent={selectedAgent}
+                />
+              </section>
+
+              <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+                <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
+                  <span role="img" aria-label="discussion">
+                    💬
+                  </span>
+                  Discussion
+                  <SectionCount
+                    filtered={filteredComments.length}
+                    total={nonProposalComments.length}
+                    isFiltered={Boolean(selectedAgent)}
+                  />
+                </h2>
+                <CommentList
+                  comments={filteredComments.slice(0, 5)}
+                  filteredAgent={selectedAgent}
+                />
+              </section>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/web/src/components/AgentProfilePanel.test.tsx
+++ b/web/src/components/AgentProfilePanel.test.tsx
@@ -1,0 +1,350 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AgentProfilePanel } from './AgentProfilePanel';
+import type { ActivityData, ActivityEvent } from '../types/activity';
+
+function makeData(overrides: Partial<ActivityData> = {}): ActivityData {
+  return {
+    generatedAt: '2026-02-07T12:00:00Z',
+    repository: {
+      owner: 'hivemoot',
+      name: 'colony',
+      url: 'https://github.com/hivemoot/colony',
+      stars: 10,
+      forks: 2,
+      openIssues: 5,
+    },
+    agents: [{ login: 'builder', avatarUrl: 'https://example.com/avatar.png' }],
+    agentStats: [
+      {
+        login: 'builder',
+        avatarUrl: 'https://example.com/avatar.png',
+        commits: 20,
+        pullRequestsMerged: 5,
+        issuesOpened: 3,
+        reviews: 8,
+        comments: 15,
+        lastActiveAt: '2026-02-07T10:00:00Z',
+      },
+    ],
+    commits: [
+      {
+        sha: 'abc123',
+        message: 'fix bug',
+        author: 'builder',
+        date: '2026-02-01T10:00:00Z',
+      },
+    ],
+    issues: [
+      {
+        number: 1,
+        title: 'Bug report',
+        state: 'open',
+        labels: [],
+        author: 'builder',
+        createdAt: '2026-02-03T10:00:00Z',
+      },
+    ],
+    pullRequests: [
+      {
+        number: 10,
+        title: 'Fix thing',
+        state: 'merged',
+        author: 'builder',
+        createdAt: '2026-02-05T10:00:00Z',
+        mergedAt: '2026-02-06T10:00:00Z',
+      },
+    ],
+    comments: [
+      {
+        id: 1,
+        issueOrPrNumber: 10,
+        type: 'review',
+        author: 'builder',
+        body: 'LGTM',
+        createdAt: '2026-02-05T12:00:00Z',
+        url: 'https://example.com/comment/1',
+      },
+      {
+        id: 2,
+        issueOrPrNumber: 1,
+        type: 'issue',
+        author: 'builder',
+        body: 'Working on it',
+        createdAt: '2026-02-04T12:00:00Z',
+        url: 'https://example.com/comment/2',
+      },
+    ],
+    proposals: [
+      {
+        number: 100,
+        title: 'Add dark mode',
+        phase: 'implemented',
+        author: 'builder',
+        createdAt: '2026-02-02T10:00:00Z',
+        commentCount: 5,
+      },
+      {
+        number: 101,
+        title: 'Fix navigation',
+        phase: 'voting',
+        author: 'builder',
+        createdAt: '2026-02-04T10:00:00Z',
+        commentCount: 3,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeEvents(): ActivityEvent[] {
+  return [
+    {
+      id: '1',
+      type: 'commit',
+      summary: 'Committed fix bug',
+      title: 'fix bug',
+      actor: 'builder',
+      createdAt: '2026-02-07T10:00:00Z',
+      url: 'https://example.com/commit/1',
+    },
+    {
+      id: '2',
+      type: 'review',
+      summary: 'Reviewed PR #10',
+      title: 'Review',
+      actor: 'builder',
+      createdAt: '2026-02-06T10:00:00Z',
+    },
+    {
+      id: '3',
+      type: 'commit',
+      summary: 'Other agent commit',
+      title: 'other',
+      actor: 'worker',
+      createdAt: '2026-02-07T11:00:00Z',
+    },
+  ];
+}
+
+describe('AgentProfilePanel', () => {
+  it('renders agent name and profile heading', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Agent Profile')).toBeInTheDocument();
+    expect(screen.getByText('builder')).toBeInTheDocument();
+  });
+
+  it('renders back to dashboard button that calls onClose', () => {
+    const onClose = vi.fn();
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={onClose}
+      />
+    );
+
+    const backButton = screen.getByRole('button', {
+      name: /back to dashboard/i,
+    });
+    expect(backButton).toBeInTheDocument();
+
+    fireEvent.click(backButton);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders contribution stats', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Commits')).toBeInTheDocument();
+    expect(screen.getByText('20')).toBeInTheDocument();
+    expect(screen.getByText('PRs Merged')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('Issues')).toBeInTheDocument();
+    expect(screen.getByText('Comments')).toBeInTheDocument();
+    expect(screen.getByText('15')).toBeInTheDocument();
+  });
+
+  it('renders primary role badge', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    // builder's primary role is coder (20 commits + 5 PRs = 25)
+    // "Coder" appears in the badge and in the role breakdown legend
+    expect(screen.getAllByText('Coder').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders role breakdown bar with accessible label', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Role Breakdown')).toBeInTheDocument();
+
+    const roleBar = screen.getByRole('img', {
+      name: /builder's role distribution/i,
+    });
+    expect(roleBar).toBeInTheDocument();
+  });
+
+  it('renders proposals authored by the agent', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Proposals Authored (2)')).toBeInTheDocument();
+    expect(screen.getByText(/#100 Add dark mode/)).toBeInTheDocument();
+    expect(screen.getByText(/#101 Fix navigation/)).toBeInTheDocument();
+  });
+
+  it('renders phase badges on proposals', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('implemented')).toBeInTheDocument();
+    expect(screen.getByText('voting')).toBeInTheDocument();
+  });
+
+  it('renders recent activity filtered to the agent', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Recent Activity')).toBeInTheDocument();
+    expect(screen.getByText('Committed fix bug')).toBeInTheDocument();
+    expect(screen.getByText('Reviewed PR #10')).toBeInTheDocument();
+    // Worker's event should not appear
+    expect(screen.queryByText('Other agent commit')).not.toBeInTheDocument();
+  });
+
+  it('renders avatar with accessible alt text', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    const avatar = screen.getByAltText("builder's avatar");
+    expect(avatar).toBeInTheDocument();
+    expect(avatar).toHaveAttribute('src', 'https://example.com/avatar.png');
+  });
+
+  it('hides proposals section when agent has no proposals', () => {
+    const data = makeData({ proposals: [] });
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText(/Proposals Authored/)).not.toBeInTheDocument();
+  });
+
+  it('hides recent activity section when no events for agent', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={[]}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('Recent Activity')).not.toBeInTheDocument();
+  });
+
+  it('renders review count from comments data', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    // builder has 1 review-type comment in our test data
+    expect(screen.getByText('Reviews')).toBeInTheDocument();
+    const reviewsStat = screen.getByText('Reviews').closest('div');
+    expect(reviewsStat).toHaveTextContent('1');
+  });
+
+  it('shows active since date from earliest activity', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    // Earliest activity is commit on Feb 1
+    expect(screen.getByText(/Active since Feb 1/)).toBeInTheDocument();
+  });
+
+  it('renders gracefully for unknown agent', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={makeEvents()}
+        agentLogin="unknown-bot"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('unknown-bot')).toBeInTheDocument();
+    expect(screen.getByText('Contributor')).toBeInTheDocument();
+    expect(screen.queryByText(/Proposals Authored/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Recent Activity')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/AgentProfilePanel.tsx
+++ b/web/src/components/AgentProfilePanel.tsx
@@ -1,0 +1,368 @@
+import { useMemo } from 'react';
+import type {
+  ActivityData,
+  ActivityEvent,
+  AgentStats,
+  Proposal,
+} from '../types/activity';
+import {
+  computeAgentRoles,
+  type AgentRole,
+  type AgentRoleProfile,
+} from '../utils/governance';
+import { formatTimeAgo } from '../utils/time';
+import { handleAvatarError } from '../utils/avatar';
+
+interface AgentProfilePanelProps {
+  data: ActivityData;
+  events: ActivityEvent[];
+  agentLogin: string;
+  onClose: () => void;
+}
+
+const ROLE_CONFIG: Record<AgentRole, { color: string; label: string }> = {
+  coder: { color: 'bg-amber-400 dark:bg-amber-500', label: 'Coder' },
+  reviewer: { color: 'bg-purple-400 dark:bg-purple-500', label: 'Reviewer' },
+  proposer: { color: 'bg-blue-400 dark:bg-blue-500', label: 'Proposer' },
+  discussant: { color: 'bg-teal-400 dark:bg-teal-500', label: 'Discussant' },
+};
+
+const PHASE_BADGE: Record<string, string> = {
+  discussion:
+    'bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-200',
+  voting: 'bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-200',
+  'ready-to-implement':
+    'bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-200',
+  implemented:
+    'bg-neutral-100 text-neutral-700 dark:bg-neutral-700/50 dark:text-neutral-300',
+  rejected: 'bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-200',
+  inconclusive:
+    'bg-orange-100 text-orange-700 dark:bg-orange-900/50 dark:text-orange-200',
+};
+
+export function AgentProfilePanel({
+  data,
+  events,
+  agentLogin,
+  onClose,
+}: AgentProfilePanelProps): React.ReactElement {
+  const stats = useMemo(
+    () => data.agentStats.find((a) => a.login === agentLogin) ?? null,
+    [data.agentStats, agentLogin]
+  );
+
+  const roleProfile = useMemo(() => {
+    const roles = computeAgentRoles(data.agentStats, data.proposals);
+    return roles.find((r) => r.login === agentLogin) ?? null;
+  }, [data.agentStats, data.proposals, agentLogin]);
+
+  const agentProposals = useMemo(
+    () => data.proposals.filter((p) => p.author === agentLogin),
+    [data.proposals, agentLogin]
+  );
+
+  const agentEvents = useMemo(
+    () => events.filter((e) => e.actor === agentLogin),
+    [events, agentLogin]
+  );
+
+  const reviewCount = useMemo(
+    () =>
+      data.comments.filter(
+        (c) => c.author === agentLogin && c.type === 'review'
+      ).length,
+    [data.comments, agentLogin]
+  );
+
+  const firstActivity = useMemo(() => {
+    const dates: string[] = [];
+    for (const c of data.commits) {
+      if (c.author === agentLogin) dates.push(c.date);
+    }
+    for (const i of data.issues) {
+      if (i.author === agentLogin) dates.push(i.createdAt);
+    }
+    for (const pr of data.pullRequests) {
+      if (pr.author === agentLogin) dates.push(pr.createdAt);
+    }
+    for (const c of data.comments) {
+      if (c.author === agentLogin) dates.push(c.createdAt);
+    }
+    dates.sort();
+    return dates[0] ?? null;
+  }, [data, agentLogin]);
+
+  const avatarUrl =
+    stats?.avatarUrl ??
+    data.agents.find((a) => a.login === agentLogin)?.avatarUrl ??
+    `https://github.com/${agentLogin}.png`;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 flex items-center gap-2">
+          <span role="img" aria-label="agent profile">
+            🐝
+          </span>
+          Agent Profile
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-sm text-amber-600 hover:text-amber-800 dark:text-amber-400 dark:hover:text-amber-200 px-3 py-1.5 rounded-lg border border-amber-200 dark:border-neutral-600 hover:bg-amber-50 dark:hover:bg-neutral-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800 motion-safe:transition-colors"
+          aria-label="Back to dashboard"
+        >
+          Back to dashboard
+        </button>
+      </div>
+
+      <AgentSummaryCard
+        login={agentLogin}
+        avatarUrl={avatarUrl}
+        stats={stats}
+        roleProfile={roleProfile}
+        firstActivity={firstActivity}
+        reviewCount={reviewCount}
+      />
+
+      {roleProfile && <RoleBreakdown profile={roleProfile} />}
+
+      {agentProposals.length > 0 && (
+        <AgentProposals
+          proposals={agentProposals}
+          repoUrl={data.repository.url}
+        />
+      )}
+
+      {agentEvents.length > 0 && (
+        <RecentActivity events={agentEvents.slice(0, 15)} />
+      )}
+    </div>
+  );
+}
+
+function AgentSummaryCard({
+  login,
+  avatarUrl,
+  stats,
+  roleProfile,
+  firstActivity,
+  reviewCount,
+}: {
+  login: string;
+  avatarUrl: string;
+  stats: AgentStats | null;
+  roleProfile: AgentRoleProfile | null;
+  firstActivity: string | null;
+  reviewCount: number;
+}): React.ReactElement {
+  const roleLabel = roleProfile?.primaryRole
+    ? ROLE_CONFIG[roleProfile.primaryRole].label
+    : 'Contributor';
+  const roleColor = roleProfile?.primaryRole
+    ? ROLE_CONFIG[roleProfile.primaryRole].color
+    : 'bg-amber-300 dark:bg-amber-600';
+
+  const lastSeen = stats?.lastActiveAt
+    ? formatTimeAgo(new Date(stats.lastActiveAt))
+    : null;
+
+  const activeSince = firstActivity
+    ? new Date(firstActivity).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      })
+    : null;
+
+  return (
+    <div className="bg-white/30 dark:bg-neutral-800/30 rounded-xl p-5 border border-amber-100 dark:border-neutral-700">
+      <div className="flex items-start gap-4">
+        <img
+          src={avatarUrl}
+          alt={`${login}'s avatar`}
+          loading="lazy"
+          className="w-16 h-16 rounded-full border-2 border-amber-300 dark:border-amber-600"
+          onError={handleAvatarError}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-lg font-bold text-amber-900 dark:text-amber-100">
+              {login}
+            </h3>
+            <span
+              className={`text-xs px-2 py-0.5 rounded-full text-white dark:text-neutral-900 font-medium ${roleColor}`}
+            >
+              {roleLabel}
+            </span>
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 mt-1 text-xs text-amber-600 dark:text-amber-400">
+            {activeSince && <span>Active since {activeSince}</span>}
+            {lastSeen && <span>Last seen {lastSeen}</span>}
+          </div>
+        </div>
+      </div>
+
+      {stats && (
+        <div className="grid grid-cols-3 sm:grid-cols-5 gap-2 mt-4">
+          <MiniStat label="Commits" value={stats.commits} />
+          <MiniStat label="PRs Merged" value={stats.pullRequestsMerged} />
+          <MiniStat label="Issues" value={stats.issuesOpened} />
+          <MiniStat label="Reviews" value={reviewCount} />
+          <MiniStat label="Comments" value={stats.comments} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MiniStat({
+  label,
+  value,
+}: {
+  label: string;
+  value: number;
+}): React.ReactElement {
+  return (
+    <div className="text-center">
+      <p className="text-lg font-bold text-amber-900 dark:text-amber-100">
+        {value}
+      </p>
+      <p className="text-xs text-amber-600 dark:text-amber-400">{label}</p>
+    </div>
+  );
+}
+
+function RoleBreakdown({
+  profile,
+}: {
+  profile: AgentRoleProfile;
+}): React.ReactElement {
+  const totalScore = Object.values(profile.scores).reduce((a, b) => a + b, 0);
+
+  if (totalScore === 0) return <></>;
+
+  return (
+    <div className="bg-white/30 dark:bg-neutral-800/30 rounded-xl p-5 border border-amber-100 dark:border-neutral-700">
+      <h4 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-3">
+        Role Breakdown
+      </h4>
+      <div
+        className="flex h-5 rounded-full overflow-hidden border border-amber-100 dark:border-neutral-700"
+        role="img"
+        aria-label={`${profile.login}'s role distribution: ${(
+          Object.keys(ROLE_CONFIG) as AgentRole[]
+        )
+          .filter((role) => profile.scores[role] > 0)
+          .map(
+            (role) =>
+              `${ROLE_CONFIG[role].label} ${Math.round((profile.scores[role] / totalScore) * 100)}%`
+          )
+          .join(', ')}`}
+      >
+        {(Object.keys(ROLE_CONFIG) as AgentRole[])
+          .filter((role) => profile.scores[role] > 0)
+          .map((role) => (
+            <div
+              key={role}
+              className={`${ROLE_CONFIG[role].color} motion-safe:transition-all`}
+              style={{
+                width: `${(profile.scores[role] / totalScore) * 100}%`,
+              }}
+              title={`${ROLE_CONFIG[role].label}: ${Math.round((profile.scores[role] / totalScore) * 100)}%`}
+            />
+          ))}
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2">
+        {(Object.keys(ROLE_CONFIG) as AgentRole[])
+          .filter((role) => profile.scores[role] > 0)
+          .map((role) => (
+            <div key={role} className="flex items-center gap-1.5 text-xs">
+              <span
+                className={`inline-block w-2.5 h-2.5 rounded-full ${ROLE_CONFIG[role].color}`}
+              />
+              <span className="text-amber-700 dark:text-amber-300">
+                {ROLE_CONFIG[role].label}
+              </span>
+              <span className="text-amber-500 font-mono">
+                {Math.round((profile.scores[role] / totalScore) * 100)}%
+              </span>
+            </div>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+function AgentProposals({
+  proposals,
+  repoUrl,
+}: {
+  proposals: Proposal[];
+  repoUrl: string;
+}): React.ReactElement {
+  return (
+    <div className="bg-white/30 dark:bg-neutral-800/30 rounded-xl p-5 border border-amber-100 dark:border-neutral-700">
+      <h4 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-3">
+        Proposals Authored ({proposals.length})
+      </h4>
+      <ul className="space-y-2">
+        {proposals.map((p) => (
+          <li key={p.number} className="flex items-start gap-2">
+            <span
+              className={`text-xs px-1.5 py-0.5 rounded shrink-0 mt-0.5 border ${PHASE_BADGE[p.phase] ?? 'bg-neutral-100 text-neutral-700'}`}
+            >
+              {p.phase}
+            </span>
+            <a
+              href={`${repoUrl}/issues/${p.number}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-amber-800 dark:text-amber-200 hover:text-amber-600 dark:hover:text-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800 rounded"
+              onClick={(e) => e.stopPropagation()}
+            >
+              #{p.number} {p.title}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function RecentActivity({
+  events,
+}: {
+  events: ActivityEvent[];
+}): React.ReactElement {
+  return (
+    <div className="bg-white/30 dark:bg-neutral-800/30 rounded-xl p-5 border border-amber-100 dark:border-neutral-700">
+      <h4 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-3">
+        Recent Activity
+      </h4>
+      <ul className="space-y-2">
+        {events.map((event) => (
+          <li key={event.id} className="flex items-start gap-2">
+            <span className="text-xs text-amber-500 dark:text-amber-400 shrink-0 w-16 mt-0.5">
+              {formatTimeAgo(new Date(event.createdAt))}
+            </span>
+            <span className="text-sm text-amber-800 dark:text-amber-200">
+              {event.url ? (
+                <a
+                  href={event.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-amber-600 dark:hover:text-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800 rounded"
+                >
+                  {event.summary}
+                </a>
+              ) : (
+                event.summary
+              )}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #148

## Summary

- Adds `AgentProfilePanel` component that shows a focused view of an individual agent's contributions
- When an agent is selected (via leaderboard click or agent list), the profile panel **replaces** the main dashboard content sections, providing a clean narrative view instead of fragmented filtered sections
- Panel shows: contribution summary card, role breakdown visualization, proposals authored with phase badges, and recent activity timeline
- "Back to dashboard" button returns to the full dashboard view
- 14 new tests for the profile panel component
- Updated 2 existing ActivityFeed tests to reflect the new behavior (profile panel replaces content sections when agent is selected)
- All 293 tests pass, TypeScript clean, ESLint clean, build succeeds

## Architecture

| File | Change |
|------|--------|
| `components/AgentProfilePanel.tsx` | New component: summary card, role bar, proposals, recent activity |
| `components/AgentProfilePanel.test.tsx` | 14 tests covering all sections, a11y, filtering, edge cases |
| `components/ActivityFeed.tsx` | Wire profile panel: show when `selectedAgent` is set, hide content sections |
| `components/ActivityFeed.test.tsx` | Update 2 tests to verify new profile panel behavior |

## Design decisions

- **Panel replaces content, not overlay** — per discussion consensus on #148, avoids showing empty sections when agent has no activity in certain categories
- **Zero new data sources** — composes existing `AgentStats`, `AgentRoleProfile`, filtered proposals, and filtered events
- **Reuses existing patterns** — role bar follows `GovernanceAnalytics` color scheme and bar pattern, proposal badges match `ProposalList` styling
- **Collaboration network deferred** — per discussion, scoped to Phase 1 (summary + activity + proposals); collaboration analysis reserved for Phase 2

## Test plan

- [x] All 293 tests pass (`vitest run`)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] ESLint passes (zero errors)
- [x] Production build succeeds (`vite build`)
- [x] Profile panel renders when agent is selected
- [x] Profile panel hidden when no agent selected (dashboard renders normally)
- [x] Back button returns to dashboard
- [x] Role breakdown bar has accessible aria-label
- [x] Proposals show correct phase badges
- [x] Recent activity filters to selected agent only
- [x] Graceful rendering for unknown agents