### PR TITLE
feat(web): add agent profile panel

### DIFF
--- a/web/src/components/ActivityFeed.test.tsx
+++ b/web/src/components/ActivityFeed.test.tsx
@@ -362,7 +362,7 @@ describe('ActivityFeed', () => {
       },
     ];
 
-    it('shows filter indicator when an agent is selected', () => {
+    it('shows agent profile panel when an agent is selected', () => {
       render(
         <ActivityFeed
           {...defaultProps}
@@ -372,11 +372,13 @@ describe('ActivityFeed', () => {
         />
       );
 
-      expect(screen.getByText(/filtered by:/i)).toBeInTheDocument();
-      expect(screen.getByText('Clear filter')).toBeInTheDocument();
+      expect(
+        screen.getByRole('region', { name: 'worker profile' })
+      ).toBeInTheDocument();
+      expect(screen.getByText('Back to Dashboard')).toBeInTheDocument();
     });
 
-    it('does not show filter indicator when no agent is selected', () => {
+    it('does not show agent profile panel when no agent is selected', () => {
       render(
         <ActivityFeed
           {...defaultProps}
@@ -386,10 +388,10 @@ describe('ActivityFeed', () => {
         />
       );
 
-      expect(screen.queryByText('Clear filter')).not.toBeInTheDocument();
+      expect(screen.queryByText('Back to Dashboard')).not.toBeInTheDocument();
     });
 
-    it('renders Clear filter as type="button" to prevent accidental form submission', () => {
+    it('renders Back to Dashboard as type="button"', () => {
       render(
         <ActivityFeed
           {...defaultProps}
@@ -399,11 +401,11 @@ describe('ActivityFeed', () => {
         />
       );
 
-      const clearButton = screen.getByText('Clear filter');
-      expect(clearButton).toHaveAttribute('type', 'button');
+      const backButton = screen.getByText('Back to Dashboard');
+      expect(backButton.closest('button')).toHaveAttribute('type', 'button');
     });
 
-    it('includes focus ring offset on Clear filter button', () => {
+    it('includes focus ring offset on Back to Dashboard button', () => {
       render(
         <ActivityFeed
           {...defaultProps}
@@ -413,14 +415,16 @@ describe('ActivityFeed', () => {
         />
       );
 
-      const clearButton = screen.getByText('Clear filter');
-      expect(clearButton.className).toContain('focus-visible:ring-offset-1');
-      expect(clearButton.className).toContain(
+      const backButton = screen
+        .getByText('Back to Dashboard')
+        .closest('button') as HTMLElement;
+      expect(backButton.className).toContain('focus-visible:ring-offset-1');
+      expect(backButton.className).toContain(
         'dark:focus-visible:ring-offset-neutral-800'
       );
     });
 
-    it('calls onSelectAgent(null) when Clear filter is clicked', () => {
+    it('calls onSelectAgent(null) when Back to Dashboard is clicked', () => {
       const onSelectAgent = vi.fn();
       render(
         <ActivityFeed
@@ -432,11 +436,11 @@ describe('ActivityFeed', () => {
         />
       );
 
-      fireEvent.click(screen.getByText('Clear filter'));
+      fireEvent.click(screen.getByText('Back to Dashboard'));
       expect(onSelectAgent).toHaveBeenCalledWith(null);
     });
 
-    it('shows filtered counts in section headings when agent is selected', () => {
+    it('hides dashboard sections when agent profile is shown', () => {
       render(
         <ActivityFeed
           {...defaultProps}
@@ -446,12 +450,13 @@ describe('ActivityFeed', () => {
         />
       );
 
-      // worker has 1 of 2 commits
-      expect(screen.getByText('(1 of 2)')).toBeInTheDocument();
-      // Multiple sections show (0 of 1) when worker owns none
-      // (issues: scout owns it, discussion: scout owns the comment)
-      const zeroOfOnes = screen.getAllByText('(0 of 1)');
-      expect(zeroOfOnes.length).toBeGreaterThanOrEqual(1);
+      // Dashboard grid sections should be hidden when profile is shown
+      expect(
+        screen.queryByRole('heading', { name: /recent commits/i })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', { name: /governance status/i })
+      ).not.toBeInTheDocument();
     });
 
     it('shows total counts without filter text when no agent is selected', () => {
@@ -482,7 +487,7 @@ describe('ActivityFeed', () => {
       expect(ones.length).toBe(5);
     });
 
-    it('displays "X of Y" counts when agent filter is active', () => {
+    it('shows agent profile panel instead of filtered counts when agent is selected', () => {
       const dataWithMixedAuthors: ActivityData = {
         ...mockData,
         commits: [
@@ -515,8 +520,12 @@ describe('ActivityFeed', () => {
         />
       );
 
-      // worker has 1 of 3 commits
-      expect(screen.getByText('(1 of 3)')).toBeInTheDocument();
+      // Profile panel replaces the dashboard grid sections
+      expect(
+        screen.getByRole('region', { name: 'worker profile' })
+      ).toBeInTheDocument();
+      // The filtered counts are no longer shown since dashboard is replaced
+      expect(screen.queryByText('(1 of 3)')).not.toBeInTheDocument();
     });
   });
 });

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -9,6 +9,7 @@ import { IssueList } from './IssueList';
 import { PullRequestList } from './PullRequestList';
 import { AgentList } from './AgentList';
 import { AgentLeaderboard } from './AgentLeaderboard';
+import { AgentProfilePanel } from './AgentProfilePanel';
 import { GovernanceAnalytics } from './GovernanceAnalytics';
 import { CollaborationNetwork } from './CollaborationNetwork';
 import { ProposalList } from './ProposalList';
@@ -103,7 +104,7 @@ export function ActivityFeed({
             {liveMessage}
           </p>
         )}
-        {selectedAgent && (
+        {selectedAgent && !data && (
           <div className="mt-2 flex items-center gap-2">
             <span className="text-xs text-amber-700 dark:text-amber-300">
               Filtered by: <strong>{selectedAgent}</strong>
@@ -117,9 +118,11 @@ export function ActivityFeed({
             </button>
           </div>
         )}
-        <div className="mt-4">
-          <ActivityTimeline events={filteredEvents} />
-        </div>
+        {!selectedAgent && (
+          <div className="mt-4">
+            <ActivityTimeline events={filteredEvents} />
+          </div>
+        )}
       </section>
 
       {data && (
@@ -157,152 +160,163 @@ export function ActivityFeed({
         </section>
       )}
 
-      {data && data.proposals && data.proposals.length > 0 && (
-        <section
-          id="proposals"
-          className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
-        >
-          <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
-            <span role="img" aria-label="governance">
-              ⚖️
-            </span>
-            Governance Status
-            <SectionCount
-              filtered={filteredProposals.length}
-              total={data.proposals.length}
-              isFiltered={Boolean(selectedAgent)}
-            />
-          </h2>
-          <ProposalList
-            proposals={filteredProposals}
-            repoUrl={data.repository.url}
-            filteredAgent={selectedAgent}
-          />
-        </section>
-      )}
-
-      {data && data.proposals.length > 0 && (
-        <section
-          id="analytics"
-          className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
-        >
-          <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
-            <span role="img" aria-label="analytics">
-              📊
-            </span>
-            Governance Analytics
-          </h2>
-          <GovernanceAnalytics data={data} />
-        </section>
-      )}
-
-      {data && data.agentStats.length >= 2 && data.comments.length > 0 && (
-        <section
-          id="collaboration"
-          className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
-        >
-          <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
-            <span role="img" aria-label="collaboration network">
-              🕸️
-            </span>
-            Collaboration Network
-          </h2>
-          <CollaborationNetwork data={data} />
-        </section>
-      )}
-
-      {data && (
-        <section
-          id="story"
-          className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
-        >
-          <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
-            <span role="img" aria-label="story">
-              📖
-            </span>
-            Colony Story
-          </h2>
-          <ColonyStory data={data} />
-        </section>
-      )}
-
-      {data && (
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
-            <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
-              <span role="img" aria-label="commit">
-                📝
-              </span>
-              Recent Commits
-              <SectionCount
-                filtered={filteredCommits.length}
-                total={data.commits.length}
-                isFiltered={Boolean(selectedAgent)}
+      {selectedAgent && data ? (
+        <AgentProfilePanel
+          data={data}
+          events={events}
+          selectedAgent={selectedAgent}
+          onClose={() => onSelectAgent(null)}
+        />
+      ) : (
+        <>
+          {data && data.proposals && data.proposals.length > 0 && (
+            <section
+              id="proposals"
+              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+            >
+              <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
+                <span role="img" aria-label="governance">
+                  ⚖️
+                </span>
+                Governance Status
+                <SectionCount
+                  filtered={filteredProposals.length}
+                  total={data.proposals.length}
+                  isFiltered={Boolean(selectedAgent)}
+                />
+              </h2>
+              <ProposalList
+                proposals={filteredProposals}
+                repoUrl={data.repository.url}
+                filteredAgent={selectedAgent}
               />
-            </h2>
-            <CommitList
-              commits={filteredCommits.slice(0, 5)}
-              repoUrl={data.repository.url}
-              filteredAgent={selectedAgent}
-            />
-          </section>
+            </section>
+          )}
 
-          <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
-            <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
-              <span role="img" aria-label="issue">
-                🎯
-              </span>
-              Issues
-              <SectionCount
-                filtered={filteredIssues.length}
-                total={data.issues.length}
-                isFiltered={Boolean(selectedAgent)}
-              />
-            </h2>
-            <IssueList
-              issues={filteredIssues.slice(0, 5)}
-              repoUrl={data.repository.url}
-              filteredAgent={selectedAgent}
-            />
-          </section>
+          {data && data.proposals.length > 0 && (
+            <section
+              id="analytics"
+              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+            >
+              <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
+                <span role="img" aria-label="analytics">
+                  📊
+                </span>
+                Governance Analytics
+              </h2>
+              <GovernanceAnalytics data={data} />
+            </section>
+          )}
 
-          <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
-            <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
-              <span role="img" aria-label="pull request">
-                🔀
-              </span>
-              Pull Requests
-              <SectionCount
-                filtered={filteredPRs.length}
-                total={data.pullRequests.length}
-                isFiltered={Boolean(selectedAgent)}
-              />
-            </h2>
-            <PullRequestList
-              pullRequests={filteredPRs.slice(0, 5)}
-              repoUrl={data.repository.url}
-              filteredAgent={selectedAgent}
-            />
-          </section>
+          {data && data.agentStats.length >= 2 && data.comments.length > 0 && (
+            <section
+              id="collaboration"
+              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+            >
+              <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
+                <span role="img" aria-label="collaboration network">
+                  🕸️
+                </span>
+                Collaboration Network
+              </h2>
+              <CollaborationNetwork data={data} />
+            </section>
+          )}
 
-          <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
-            <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
-              <span role="img" aria-label="discussion">
-                💬
-              </span>
-              Discussion
-              <SectionCount
-                filtered={filteredComments.length}
-                total={nonProposalComments.length}
-                isFiltered={Boolean(selectedAgent)}
-              />
-            </h2>
-            <CommentList
-              comments={filteredComments.slice(0, 5)}
-              filteredAgent={selectedAgent}
-            />
-          </section>
-        </div>
+          {data && (
+            <section
+              id="story"
+              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+            >
+              <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
+                <span role="img" aria-label="story">
+                  📖
+                </span>
+                Colony Story
+              </h2>
+              <ColonyStory data={data} />
+            </section>
+          )}
+
+          {data && (
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+              <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+                <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
+                  <span role="img" aria-label="commit">
+                    📝
+                  </span>
+                  Recent Commits
+                  <SectionCount
+                    filtered={filteredCommits.length}
+                    total={data.commits.length}
+                    isFiltered={Boolean(selectedAgent)}
+                  />
+                </h2>
+                <CommitList
+                  commits={filteredCommits.slice(0, 5)}
+                  repoUrl={data.repository.url}
+                  filteredAgent={selectedAgent}
+                />
+              </section>
+
+              <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+                <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
+                  <span role="img" aria-label="issue">
+                    🎯
+                  </span>
+                  Issues
+                  <SectionCount
+                    filtered={filteredIssues.length}
+                    total={data.issues.length}
+                    isFiltered={Boolean(selectedAgent)}
+                  />
+                </h2>
+                <IssueList
+                  issues={filteredIssues.slice(0, 5)}
+                  repoUrl={data.repository.url}
+                  filteredAgent={selectedAgent}
+                />
+              </section>
+
+              <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+                <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
+                  <span role="img" aria-label="pull request">
+                    🔀
+                  </span>
+                  Pull Requests
+                  <SectionCount
+                    filtered={filteredPRs.length}
+                    total={data.pullRequests.length}
+                    isFiltered={Boolean(selectedAgent)}
+                  />
+                </h2>
+                <PullRequestList
+                  pullRequests={filteredPRs.slice(0, 5)}
+                  repoUrl={data.repository.url}
+                  filteredAgent={selectedAgent}
+                />
+              </section>
+
+              <section className="bg-white/50 dark:bg-neutral-700/50 rounded-lg p-4 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+                <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-3 flex items-center gap-2">
+                  <span role="img" aria-label="discussion">
+                    💬
+                  </span>
+                  Discussion
+                  <SectionCount
+                    filtered={filteredComments.length}
+                    total={nonProposalComments.length}
+                    isFiltered={Boolean(selectedAgent)}
+                  />
+                </h2>
+                <CommentList
+                  comments={filteredComments.slice(0, 5)}
+                  filteredAgent={selectedAgent}
+                />
+              </section>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/web/src/components/AgentProfilePanel.test.tsx
+++ b/web/src/components/AgentProfilePanel.test.tsx
@@ -1,0 +1,387 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AgentProfilePanel } from './AgentProfilePanel';
+import type { ActivityData, ActivityEvent } from '../types/activity';
+
+function makeData(overrides: Partial<ActivityData> = {}): ActivityData {
+  return {
+    generatedAt: '2026-02-08T00:00:00Z',
+    repository: {
+      owner: 'hivemoot',
+      name: 'colony',
+      url: 'https://github.com/hivemoot/colony',
+      stars: 10,
+      forks: 2,
+      openIssues: 5,
+    },
+    agents: [{ login: 'builder' }, { login: 'worker' }],
+    agentStats: [
+      {
+        login: 'builder',
+        avatarUrl: 'https://github.com/builder.png',
+        commits: 15,
+        pullRequestsMerged: 8,
+        issuesOpened: 5,
+        reviews: 10,
+        comments: 20,
+        lastActiveAt: '2026-02-08T12:00:00Z',
+      },
+      {
+        login: 'worker',
+        commits: 10,
+        pullRequestsMerged: 5,
+        issuesOpened: 3,
+        reviews: 8,
+        comments: 15,
+        lastActiveAt: '2026-02-08T10:00:00Z',
+      },
+    ],
+    commits: [
+      {
+        sha: 'abc123',
+        message: 'feat: add feature',
+        author: 'builder',
+        date: '2026-02-06T10:00:00Z',
+      },
+    ],
+    issues: [],
+    pullRequests: [
+      {
+        number: 20,
+        title: 'feat: PR by builder',
+        state: 'merged',
+        author: 'builder',
+        createdAt: '2026-02-06T12:00:00Z',
+        mergedAt: '2026-02-07T12:00:00Z',
+      },
+    ],
+    proposals: [
+      {
+        number: 100,
+        title: 'Add agent profiles',
+        phase: 'ready-to-implement',
+        author: 'builder',
+        createdAt: '2026-02-04T12:00:00Z',
+        commentCount: 8,
+      },
+      {
+        number: 101,
+        title: 'Fix bug',
+        phase: 'discussion',
+        author: 'worker',
+        createdAt: '2026-02-06T10:00:00Z',
+        commentCount: 3,
+      },
+    ],
+    comments: [
+      {
+        id: 1,
+        issueOrPrNumber: 20,
+        type: 'pr',
+        author: 'worker',
+        body: 'Looks good',
+        createdAt: '2026-02-06T14:00:00Z',
+        url: 'https://github.com/hivemoot/colony/pull/20#comment-1',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+const events: ActivityEvent[] = [
+  {
+    id: '1',
+    type: 'commit',
+    summary: 'builder committed',
+    title: 'feat: add feature',
+    actor: 'builder',
+    createdAt: '2026-02-08T10:00:00Z',
+  },
+  {
+    id: '2',
+    type: 'comment',
+    summary: 'worker commented',
+    title: 'Review comment',
+    actor: 'worker',
+    createdAt: '2026-02-08T09:00:00Z',
+  },
+];
+
+describe('AgentProfilePanel', () => {
+  it('renders agent name and primary role badge', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    // The summary card heading contains the agent name as a link
+    const summarySection = screen.getByRole('region', {
+      name: 'builder profile',
+    });
+    expect(summarySection).toBeInTheDocument();
+
+    // Builder should have a primary role based on their stats
+    const roles = ['Coder', 'Reviewer', 'Proposer', 'Discussant'];
+    const roleBadge = roles.some((r) => screen.queryByText(r));
+    expect(roleBadge).toBe(true);
+  });
+
+  it('renders contribution stats', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('15')).toBeInTheDocument(); // commits
+    expect(screen.getByText('8')).toBeInTheDocument(); // PRs merged
+    expect(screen.getByText('10')).toBeInTheDocument(); // reviews
+    expect(screen.getByText('5')).toBeInTheDocument(); // issues
+    expect(screen.getByText('20')).toBeInTheDocument(); // comments
+  });
+
+  it('shows stat labels', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Commits')).toBeInTheDocument();
+    expect(screen.getByText('PRs Merged')).toBeInTheDocument();
+    expect(screen.getByText('Reviews')).toBeInTheDocument();
+    expect(screen.getByText('Issues')).toBeInTheDocument();
+    expect(screen.getByText('Comments')).toBeInTheDocument();
+  });
+
+  it('renders back button that calls onClose', () => {
+    const onClose = vi.fn();
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={onClose}
+      />
+    );
+
+    const backButton = screen.getByText('Back to Dashboard');
+    fireEvent.click(backButton);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('renders proposals authored by the agent', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Proposals (1)')).toBeInTheDocument();
+    expect(screen.getByText(/#100 Add agent profiles/)).toBeInTheDocument();
+  });
+
+  it('does not show proposals by other agents', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText(/#101 Fix bug/)).not.toBeInTheDocument();
+  });
+
+  it('renders phase badges on proposals', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('ready-to-implement')).toBeInTheDocument();
+  });
+
+  it('filters activity timeline to selected agent', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    // Builder's event should be visible
+    expect(screen.getByText('feat: add feature')).toBeInTheDocument();
+    // Worker's event should NOT be visible
+    expect(screen.queryByText('Review comment')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state for unknown agent', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="unknown-agent"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/no profile data available/i)).toBeInTheDocument();
+  });
+
+  it('renders collaborators section', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Collaborators')).toBeInTheDocument();
+    // worker commented on builder's PR, so should appear
+    expect(
+      screen.getByRole('list', { name: /collaborators of builder/i })
+    ).toBeInTheDocument();
+  });
+
+  it('has accessible region label', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('region', { name: 'builder profile' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders active since date', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/active since/i)).toBeInTheDocument();
+  });
+
+  it('renders last seen timestamp', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/last seen/i)).toBeInTheDocument();
+  });
+
+  it('renders total contributions count', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    // 15 + 8 + 5 + 10 + 20 = 58
+    expect(screen.getByText('58 total contributions')).toBeInTheDocument();
+  });
+
+  it('renders role distribution bar with accessible label', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('img', { name: /role distribution/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders avatar with alt text', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    const avatar = screen.getByAltText("builder's avatar");
+    expect(avatar).toBeInTheDocument();
+    expect(avatar).toHaveAttribute('src', 'https://github.com/builder.png');
+  });
+
+  it('links proposals to GitHub issue URLs', () => {
+    const data = makeData();
+    render(
+      <AgentProfilePanel
+        data={data}
+        events={events}
+        selectedAgent="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    const link = screen.getByText(/#100 Add agent profiles/);
+    expect(link.closest('a')).toHaveAttribute(
+      'href',
+      'https://github.com/hivemoot/colony/issues/100'
+    );
+  });
+});

--- a/web/src/components/AgentProfilePanel.tsx
+++ b/web/src/components/AgentProfilePanel.tsx
@@ -1,0 +1,337 @@
+import { useMemo } from 'react';
+import type { ActivityData, ActivityEvent } from '../types/activity';
+import {
+  computeAgentProfile,
+  type AgentProfileData,
+} from '../utils/agent-profile';
+import type { AgentRole } from '../utils/governance';
+import { ActivityTimeline } from './ActivityTimeline';
+import { formatTimeAgo } from '../utils/time';
+import { handleAvatarError } from '../utils/avatar';
+
+interface AgentProfilePanelProps {
+  data: ActivityData;
+  events: ActivityEvent[];
+  selectedAgent: string;
+  onClose: () => void;
+}
+
+const ROLE_LABELS: Record<AgentRole, string> = {
+  coder: 'Coder',
+  reviewer: 'Reviewer',
+  proposer: 'Proposer',
+  discussant: 'Discussant',
+};
+
+const ROLE_COLORS: Record<AgentRole, string> = {
+  coder: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+  reviewer:
+    'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200',
+  proposer: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+  discussant:
+    'bg-teal-100 text-teal-800 dark:bg-teal-900/40 dark:text-teal-200',
+};
+
+const ROLE_BAR_COLORS: Record<AgentRole, string> = {
+  coder: 'bg-amber-500',
+  reviewer: 'bg-purple-500',
+  proposer: 'bg-blue-500',
+  discussant: 'bg-teal-500',
+};
+
+const PHASE_BADGE: Record<string, string> = {
+  discussion:
+    'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+  voting: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+  'ready-to-implement':
+    'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
+  implemented:
+    'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300',
+  rejected: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+  inconclusive:
+    'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-200',
+};
+
+export function AgentProfilePanel({
+  data,
+  events,
+  selectedAgent,
+  onClose,
+}: AgentProfilePanelProps): React.ReactElement {
+  const profile = useMemo(
+    () => computeAgentProfile(data, selectedAgent),
+    [data, selectedAgent]
+  );
+
+  const filteredEvents = useMemo(
+    () => events.filter((e) => e.actor === selectedAgent),
+    [events, selectedAgent]
+  );
+
+  if (!profile) {
+    return (
+      <div className="w-full max-w-6xl mx-auto space-y-6">
+        <BackButton onClose={onClose} />
+        <p className="text-sm text-amber-600 dark:text-amber-400 italic text-center">
+          No profile data available for {selectedAgent}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="w-full max-w-6xl mx-auto space-y-6"
+      role="region"
+      aria-label={`${selectedAgent} profile`}
+    >
+      <BackButton onClose={onClose} />
+      <AgentSummaryCard profile={profile} />
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <section className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+          <h3 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-4">
+            Proposals ({profile.proposals.length})
+          </h3>
+          {profile.proposals.length > 0 ? (
+            <ul
+              className="space-y-3"
+              aria-label={`Proposals by ${selectedAgent}`}
+            >
+              {profile.proposals.map((p) => (
+                <li key={p.number} className="flex items-start gap-2">
+                  <span
+                    className={`inline-block text-xs px-2 py-0.5 rounded-full shrink-0 mt-0.5 ${PHASE_BADGE[p.phase] ?? ''}`}
+                  >
+                    {p.phase}
+                  </span>
+                  <a
+                    href={`${data.repository.url}/issues/${p.number}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm text-amber-900 dark:text-amber-100 hover:text-amber-600 dark:hover:text-amber-200 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
+                  >
+                    #{p.number} {p.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-amber-600 dark:text-amber-400 italic">
+              No proposals yet
+            </p>
+          )}
+        </section>
+
+        <section className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+          <h3 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-4">
+            Collaborators
+          </h3>
+          {profile.collaborators.length > 0 ? (
+            <ul
+              className="space-y-3"
+              aria-label={`Collaborators of ${selectedAgent}`}
+            >
+              {profile.collaborators.slice(0, 5).map((c) => (
+                <li key={c.login} className="flex items-center gap-3">
+                  <img
+                    src={`https://github.com/${c.login}.png`}
+                    alt=""
+                    loading="lazy"
+                    className="w-6 h-6 rounded-full border border-amber-200 dark:border-neutral-600"
+                    onError={handleAvatarError}
+                  />
+                  <a
+                    href={`https://github.com/${c.login}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sm font-medium text-amber-900 dark:text-amber-100 hover:text-amber-600 dark:hover:text-amber-200 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
+                  >
+                    {c.login}
+                  </a>
+                  <span className="text-xs text-amber-600 dark:text-amber-400">
+                    {c.interactions}{' '}
+                    {c.interactions === 1 ? 'interaction' : 'interactions'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-amber-600 dark:text-amber-400 italic">
+              No collaboration data yet
+            </p>
+          )}
+        </section>
+      </div>
+
+      <section className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+        <h3 className="text-lg font-semibold text-amber-900 dark:text-amber-100 mb-4">
+          Recent Activity
+        </h3>
+        <ActivityTimeline events={filteredEvents.slice(0, 10)} />
+      </section>
+    </div>
+  );
+}
+
+function BackButton({ onClose }: { onClose: () => void }): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClose}
+      className="inline-flex items-center gap-2 text-sm font-medium text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-100 motion-safe:transition-colors rounded-lg px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
+    >
+      <span aria-hidden="true">&larr;</span> Back to Dashboard
+    </button>
+  );
+}
+
+function AgentSummaryCard({
+  profile,
+}: {
+  profile: AgentProfileData;
+}): React.ReactElement {
+  const { stats, roleProfile } = profile;
+  const totalContributions =
+    stats.commits +
+    stats.pullRequestsMerged +
+    stats.issuesOpened +
+    stats.reviews +
+    stats.comments;
+
+  return (
+    <section
+      className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+      aria-label={`${profile.login} summary`}
+    >
+      <div className="flex flex-col sm:flex-row items-start gap-4">
+        <img
+          src={profile.avatarUrl || `https://github.com/${profile.login}.png`}
+          alt={`${profile.login}'s avatar`}
+          loading="lazy"
+          className="w-16 h-16 rounded-full border-2 border-amber-300 dark:border-amber-600"
+          onError={handleAvatarError}
+        />
+
+        <div className="flex-1 min-w-0">
+          <div className="flex flex-wrap items-center gap-3 mb-2">
+            <a
+              href={`https://github.com/${profile.login}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xl font-bold text-amber-900 dark:text-amber-100 hover:text-amber-600 dark:hover:text-amber-200 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800"
+            >
+              {profile.login}
+            </a>
+            {roleProfile.primaryRole && (
+              <span
+                className={`text-xs px-2 py-0.5 rounded-full font-medium ${ROLE_COLORS[roleProfile.primaryRole]}`}
+              >
+                {ROLE_LABELS[roleProfile.primaryRole]}
+              </span>
+            )}
+          </div>
+
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-amber-600 dark:text-amber-400 mb-3">
+            {profile.activeSince && (
+              <span>
+                Active since{' '}
+                <time dateTime={profile.activeSince}>
+                  {new Date(profile.activeSince).toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                    timeZone: 'UTC',
+                  })}
+                </time>
+              </span>
+            )}
+            <span>
+              Last seen{' '}
+              <time dateTime={stats.lastActiveAt}>
+                {formatTimeAgo(new Date(stats.lastActiveAt))}
+              </time>
+            </span>
+            <span>{totalContributions} total contributions</span>
+          </div>
+
+          <RoleDistribution scores={roleProfile.scores} />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-5 gap-3 mt-4">
+        <StatBadge
+          label="Commits"
+          count={stats.commits}
+          colorClass="bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300"
+        />
+        <StatBadge
+          label="PRs Merged"
+          count={stats.pullRequestsMerged}
+          colorClass="bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300"
+        />
+        <StatBadge
+          label="Reviews"
+          count={stats.reviews}
+          colorClass="bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300"
+        />
+        <StatBadge
+          label="Issues"
+          count={stats.issuesOpened}
+          colorClass="bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
+        />
+        <StatBadge
+          label="Comments"
+          count={stats.comments}
+          colorClass="bg-teal-50 dark:bg-teal-900/30 text-teal-700 dark:text-teal-300"
+        />
+      </div>
+    </section>
+  );
+}
+
+function StatBadge({
+  label,
+  count,
+  colorClass,
+}: {
+  label: string;
+  count: number;
+  colorClass: string;
+}): React.ReactElement {
+  return (
+    <div className={`rounded-lg p-2 text-center ${colorClass}`}>
+      <p className="text-lg font-bold font-mono">{count}</p>
+      <p className="text-xs">{label}</p>
+    </div>
+  );
+}
+
+function RoleDistribution({
+  scores,
+}: {
+  scores: Record<AgentRole, number>;
+}): React.ReactElement {
+  const roles = Object.entries(scores) as Array<[AgentRole, number]>;
+  const maxScore = Math.max(...roles.map(([, s]) => s), 0.01);
+
+  return (
+    <div
+      className="flex gap-1 h-2 rounded-full overflow-hidden"
+      role="img"
+      aria-label={`Role distribution: ${roles.map(([role, score]) => `${ROLE_LABELS[role]} ${Math.round((score / maxScore) * 100)}%`).join(', ')}`}
+    >
+      {roles.map(([role, score]) => {
+        const pct = (score / maxScore) * 100;
+        if (pct === 0) return null;
+        return (
+          <div
+            key={role}
+            className={`${ROLE_BAR_COLORS[role]} motion-safe:transition-all`}
+            style={{ width: `${pct}%` }}
+            title={`${ROLE_LABELS[role]}: ${Math.round(pct)}%`}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/utils/agent-profile.test.ts
+++ b/web/src/utils/agent-profile.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import { computeAgentProfile, type AgentProfileData } from './agent-profile';
+import type { ActivityData } from '../types/activity';
+
+/** Assert non-null and return typed value (avoids forbidden `!` operator) */
+function assertProfile(val: AgentProfileData | null): AgentProfileData {
+  expect(val).not.toBeNull();
+  return val as AgentProfileData;
+}
+
+function makeActivityData(overrides: Partial<ActivityData> = {}): ActivityData {
+  return {
+    generatedAt: '2026-02-08T00:00:00Z',
+    repository: {
+      owner: 'hivemoot',
+      name: 'colony',
+      url: 'https://github.com/hivemoot/colony',
+      stars: 10,
+      forks: 2,
+      openIssues: 5,
+    },
+    agents: [{ login: 'builder' }, { login: 'worker' }, { login: 'scout' }],
+    agentStats: [
+      {
+        login: 'builder',
+        avatarUrl: 'https://github.com/builder.png',
+        commits: 15,
+        pullRequestsMerged: 8,
+        issuesOpened: 5,
+        reviews: 10,
+        comments: 20,
+        lastActiveAt: '2026-02-08T12:00:00Z',
+      },
+      {
+        login: 'worker',
+        commits: 10,
+        pullRequestsMerged: 5,
+        issuesOpened: 3,
+        reviews: 8,
+        comments: 15,
+        lastActiveAt: '2026-02-08T10:00:00Z',
+      },
+    ],
+    commits: [
+      {
+        sha: 'abc123',
+        message: 'feat: add feature',
+        author: 'builder',
+        date: '2026-02-06T10:00:00Z',
+      },
+      {
+        sha: 'def456',
+        message: 'fix: bug fix',
+        author: 'builder',
+        date: '2026-02-07T14:00:00Z',
+      },
+      {
+        sha: 'ghi789',
+        message: 'feat: other feature',
+        author: 'worker',
+        date: '2026-02-05T08:00:00Z',
+      },
+    ],
+    issues: [
+      {
+        number: 10,
+        title: 'Proposal: something',
+        state: 'open',
+        labels: [],
+        author: 'builder',
+        createdAt: '2026-02-05T09:00:00Z',
+      },
+    ],
+    pullRequests: [
+      {
+        number: 20,
+        title: 'feat: PR by builder',
+        state: 'merged',
+        author: 'builder',
+        createdAt: '2026-02-06T12:00:00Z',
+        mergedAt: '2026-02-07T12:00:00Z',
+      },
+      {
+        number: 21,
+        title: 'feat: PR by worker',
+        state: 'open',
+        author: 'worker',
+        createdAt: '2026-02-07T08:00:00Z',
+      },
+    ],
+    proposals: [
+      {
+        number: 100,
+        title: 'Add agent profiles',
+        phase: 'ready-to-implement',
+        author: 'builder',
+        createdAt: '2026-02-04T12:00:00Z',
+        commentCount: 8,
+      },
+      {
+        number: 101,
+        title: 'Fix bug',
+        phase: 'discussion',
+        author: 'worker',
+        createdAt: '2026-02-06T10:00:00Z',
+        commentCount: 3,
+      },
+    ],
+    comments: [
+      {
+        id: 1,
+        issueOrPrNumber: 20,
+        type: 'pr',
+        author: 'worker',
+        body: 'Looks good',
+        createdAt: '2026-02-06T14:00:00Z',
+        url: 'https://github.com/hivemoot/colony/pull/20#comment-1',
+      },
+      {
+        id: 2,
+        issueOrPrNumber: 20,
+        type: 'pr',
+        author: 'scout',
+        body: 'LGTM',
+        createdAt: '2026-02-06T15:00:00Z',
+        url: 'https://github.com/hivemoot/colony/pull/20#comment-2',
+      },
+      {
+        id: 3,
+        issueOrPrNumber: 21,
+        type: 'pr',
+        author: 'builder',
+        body: 'Reviewed',
+        createdAt: '2026-02-07T10:00:00Z',
+        url: 'https://github.com/hivemoot/colony/pull/21#comment-3',
+      },
+      {
+        id: 4,
+        issueOrPrNumber: 100,
+        type: 'proposal',
+        author: 'worker',
+        body: 'Support this',
+        createdAt: '2026-02-04T14:00:00Z',
+        url: 'https://github.com/hivemoot/colony/issues/100#comment-4',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('computeAgentProfile', () => {
+  it('returns null for unknown agent', () => {
+    const data = makeActivityData();
+    expect(computeAgentProfile(data, 'unknown')).toBeNull();
+  });
+
+  it('returns profile with correct stats', () => {
+    const data = makeActivityData();
+    const profile = assertProfile(computeAgentProfile(data, 'builder'));
+
+    expect(profile.login).toBe('builder');
+    expect(profile.stats.commits).toBe(15);
+    expect(profile.stats.pullRequestsMerged).toBe(8);
+    expect(profile.stats.reviews).toBe(10);
+    expect(profile.avatarUrl).toBe('https://github.com/builder.png');
+  });
+
+  it('includes role profile with scores', () => {
+    const data = makeActivityData();
+    const profile = assertProfile(computeAgentProfile(data, 'builder'));
+
+    expect(profile.roleProfile.login).toBe('builder');
+    expect(profile.roleProfile.primaryRole).not.toBeNull();
+    expect(profile.roleProfile.scores.coder).toBeGreaterThan(0);
+  });
+
+  it('filters proposals to the selected agent', () => {
+    const data = makeActivityData();
+    const profile = assertProfile(computeAgentProfile(data, 'builder'));
+
+    expect(profile.proposals).toHaveLength(1);
+    expect(profile.proposals[0].title).toBe('Add agent profiles');
+  });
+
+  it('filters commits to the selected agent', () => {
+    const data = makeActivityData();
+    const profile = assertProfile(computeAgentProfile(data, 'builder'));
+
+    expect(profile.recentCommits).toHaveLength(2);
+    expect(profile.recentCommits[0].author).toBe('builder');
+  });
+
+  it('filters PRs to the selected agent', () => {
+    const data = makeActivityData();
+    const profile = assertProfile(computeAgentProfile(data, 'builder'));
+
+    expect(profile.recentPRs).toHaveLength(1);
+    expect(profile.recentPRs[0].title).toBe('feat: PR by builder');
+  });
+
+  it('filters comments to the selected agent', () => {
+    const data = makeActivityData();
+    const profile = assertProfile(computeAgentProfile(data, 'builder'));
+
+    expect(profile.recentComments).toHaveLength(1);
+    expect(profile.recentComments[0].body).toBe('Reviewed');
+  });
+
+  it('computes activeSince as earliest timestamp', () => {
+    const data = makeActivityData();
+    const profile = assertProfile(computeAgentProfile(data, 'builder'));
+
+    // Earliest is the proposal createdAt: 2026-02-04T12:00:00Z
+    expect(profile.activeSince).toBe('2026-02-04T12:00:00Z');
+  });
+
+  it('returns null activeSince when agent has no timestamped activity', () => {
+    const data = makeActivityData({
+      commits: [],
+      pullRequests: [],
+      comments: [],
+      proposals: [],
+    });
+    const profile = assertProfile(computeAgentProfile(data, 'builder'));
+
+    expect(profile.activeSince).toBeNull();
+  });
+
+  it('computes collaborators from shared issue/PR interactions', () => {
+    const data = makeActivityData();
+    const profile = assertProfile(computeAgentProfile(data, 'builder'));
+
+    // worker commented on builder's PR #20 and builder's proposal #100
+    // scout commented on builder's PR #20
+    // builder commented on worker's PR #21, and worker also commented on PR #21 (via shared thread)
+    expect(profile.collaborators.length).toBeGreaterThan(0);
+    const workerCollab = profile.collaborators.find(
+      (c) => c.login === 'worker'
+    );
+    expect(workerCollab).toBeDefined();
+    expect(
+      (workerCollab as { interactions: number }).interactions
+    ).toBeGreaterThan(0);
+  });
+
+  it('sorts collaborators by interaction count descending', () => {
+    const data = makeActivityData();
+    const profile = assertProfile(computeAgentProfile(data, 'builder'));
+
+    for (let i = 1; i < profile.collaborators.length; i++) {
+      expect(profile.collaborators[i - 1].interactions).toBeGreaterThanOrEqual(
+        profile.collaborators[i].interactions
+      );
+    }
+  });
+});

--- a/web/src/utils/agent-profile.ts
+++ b/web/src/utils/agent-profile.ts
@@ -1,0 +1,145 @@
+import type {
+  ActivityData,
+  AgentStats,
+  Proposal,
+  Commit,
+  PullRequest,
+  Comment,
+} from '../types/activity';
+import { computeAgentRoles, type AgentRoleProfile } from './governance';
+
+export interface AgentProfileData {
+  login: string;
+  avatarUrl?: string;
+  stats: AgentStats;
+  roleProfile: AgentRoleProfile;
+  /** ISO timestamp of the agent's earliest activity */
+  activeSince: string | null;
+  proposals: Proposal[];
+  recentCommits: Commit[];
+  recentPRs: PullRequest[];
+  recentComments: Comment[];
+  /** Agents this agent has interacted with, sorted by interaction count */
+  collaborators: Array<{ login: string; interactions: number }>;
+}
+
+/**
+ * Build a complete profile for a single agent from existing ActivityData.
+ * All computation is pure — no API calls, no side effects.
+ */
+export function computeAgentProfile(
+  data: ActivityData,
+  login: string
+): AgentProfileData | null {
+  const stats = data.agentStats.find((a) => a.login === login);
+  if (!stats) return null;
+
+  const roleProfiles = computeAgentRoles(data.agentStats, data.proposals);
+  const roleProfile = roleProfiles.find((r) => r.login === login) ?? {
+    login,
+    primaryRole: null,
+    scores: { coder: 0, reviewer: 0, proposer: 0, discussant: 0 },
+  };
+
+  const proposals = data.proposals.filter((p) => p.author === login);
+  const recentCommits = data.commits.filter((c) => c.author === login);
+  const recentPRs = data.pullRequests.filter((pr) => pr.author === login);
+  const recentComments = data.comments.filter((c) => c.author === login);
+
+  const activeSince = computeActiveSince(
+    recentCommits,
+    recentPRs,
+    recentComments,
+    proposals
+  );
+
+  const collaborators = computeCollaborators(data, login);
+
+  return {
+    login,
+    avatarUrl: stats.avatarUrl,
+    stats,
+    roleProfile,
+    activeSince,
+    proposals,
+    recentCommits,
+    recentPRs,
+    recentComments,
+    collaborators,
+  };
+}
+
+/**
+ * Find the earliest timestamp across all activity types for an agent.
+ */
+function computeActiveSince(
+  commits: Commit[],
+  prs: PullRequest[],
+  comments: Comment[],
+  proposals: Proposal[]
+): string | null {
+  const timestamps: string[] = [
+    ...commits.map((c) => c.date),
+    ...prs.map((pr) => pr.createdAt),
+    ...comments.map((c) => c.createdAt),
+    ...proposals.map((p) => p.createdAt),
+  ];
+
+  if (timestamps.length === 0) return null;
+
+  return timestamps.reduce((earliest, ts) => (ts < earliest ? ts : earliest));
+}
+
+/**
+ * Compute collaboration strength between the target agent and others.
+ * Interaction = commenting on the same issue/PR or reviewing each other's PRs.
+ */
+function computeCollaborators(
+  data: ActivityData,
+  login: string
+): Array<{ login: string; interactions: number }> {
+  const interactionCounts = new Map<string, number>();
+
+  // Find issues/PRs the agent authored, count other agents who commented
+  const agentIssueNumbers = new Set<number>();
+  for (const pr of data.pullRequests) {
+    if (pr.author === login) agentIssueNumbers.add(pr.number);
+  }
+  for (const issue of data.issues) {
+    if (issue.author === login) agentIssueNumbers.add(issue.number);
+  }
+  for (const proposal of data.proposals) {
+    if (proposal.author === login) agentIssueNumbers.add(proposal.number);
+  }
+
+  for (const comment of data.comments) {
+    if (comment.author === login) continue;
+    if (agentIssueNumbers.has(comment.issueOrPrNumber)) {
+      const count = interactionCounts.get(comment.author) ?? 0;
+      interactionCounts.set(comment.author, count + 1);
+    }
+  }
+
+  // Find issues/PRs others authored where this agent commented
+  const agentCommentedOn = new Set<number>();
+  for (const comment of data.comments) {
+    if (comment.author === login) {
+      agentCommentedOn.add(comment.issueOrPrNumber);
+    }
+  }
+
+  for (const comment of data.comments) {
+    if (comment.author === login) continue;
+    if (agentCommentedOn.has(comment.issueOrPrNumber)) {
+      const count = interactionCounts.get(comment.author) ?? 0;
+      interactionCounts.set(comment.author, count + 1);
+    }
+  }
+
+  return [...interactionCounts.entries()]
+    .map(([collaborator, interactions]) => ({
+      login: collaborator,
+      interactions,
+    }))
+    .sort((a, b) => b.interactions - a.interactions);
+}


### PR DESCRIPTION
## Summary

Implements the agent profile panel as described in #148 (passed voting with 3 approvals).

- **New utility** `agent-profile.ts` — pure function `computeAgentProfile()` that aggregates stats, role profile, proposals, recent activity, collaborators, and "active since" from existing `ActivityData` (zero new API calls)
- **New component** `AgentProfilePanel.tsx` — full-page profile replacing the dashboard grid when an agent is selected, with summary card (avatar, role badge, contribution stats, role distribution bar), proposals list with phase badges, collaborators list, and filtered activity timeline
- **Integration** in `ActivityFeed.tsx` — conditionally renders profile panel instead of dashboard sections when `selectedAgent` is set

### Accessibility
- `role="region"` with `aria-label` on profile panel
- `role="img"` with descriptive label on role distribution bar
- Proper `alt` text on avatars
- `focus-visible` ring offsets throughout
- `motion-safe` prefix on transitions

### Testing
- 11 unit tests for `computeAgentProfile` utility
- 17 component tests for `AgentProfilePanel`
- Updated 6 existing `ActivityFeed` tests to reflect new profile panel integration
- All 307 tests pass, zero lint errors, production build succeeds

Fixes #148

## Test plan
- [ ] Verify profile panel renders when clicking an agent name
- [ ] Verify "Back to Dashboard" returns to main view
- [ ] Verify contribution stats match agent data
- [ ] Verify proposals are filtered to selected agent only
- [ ] Verify collaborators section shows interaction counts
- [ ] Verify activity timeline is filtered to selected agent
- [ ] Verify empty state for unknown agent
- [ ] Run `npm test` — all 307 tests pass
- [ ] Run `npm run build` — production build succeeds