### PR TITLE
polish(web): bump text-[10px] to text-xs across dashboard

### DIFF
--- a/web/src/components/AgentList.tsx
+++ b/web/src/components/AgentList.tsx
@@ -62,7 +62,7 @@ export function AgentList({
                   onError={handleAvatarError}
                 />
                 <div
-                  className="absolute -bottom-1 -right-1 bg-amber-500 text-white text-[10px] px-1 rounded-full border border-white dark:border-neutral-800"
+                  className="absolute -bottom-1 -right-1 bg-amber-500 text-white text-xs px-1 rounded-full border border-white dark:border-neutral-800"
                   aria-hidden="true"
                 >
                   🐝

--- a/web/src/components/CommentList.tsx
+++ b/web/src/components/CommentList.tsx
@@ -55,7 +55,7 @@ export function CommentList({
               <span className="text-xs font-bold text-amber-900 dark:text-amber-100">
                 {comment.author}
               </span>
-              <span className="text-[10px] text-amber-600 dark:text-amber-400 font-medium uppercase tracking-tight">
+              <span className="text-xs text-amber-600 dark:text-amber-400 font-medium uppercase tracking-tight">
                 {formatCommentAction(comment.type)} #{comment.issueOrPrNumber}
               </span>
             </div>
@@ -64,7 +64,7 @@ export function CommentList({
             </p>
             <time
               dateTime={comment.createdAt}
-              className="block mt-1.5 text-[10px] text-amber-500 dark:text-amber-400"
+              className="block mt-1.5 text-xs text-amber-500 dark:text-amber-400"
             >
               {formatTimeAgo(new Date(comment.createdAt))}
             </time>

--- a/web/src/components/CommitList.tsx
+++ b/web/src/components/CommitList.tsx
@@ -54,7 +54,7 @@ export function CommitList({
             </div>
             <time
               dateTime={commit.date}
-              className="text-[10px] text-amber-500 dark:text-amber-400 block mt-0.5"
+              className="text-xs text-amber-500 dark:text-amber-400 block mt-0.5"
             >
               {formatTimeAgo(new Date(commit.date))}
             </time>

--- a/web/src/components/GovernanceAnalytics.tsx
+++ b/web/src/components/GovernanceAnalytics.tsx
@@ -255,7 +255,7 @@ function AgentRoleBar({
               />
             ))}
       </div>
-      <span className="text-[10px] font-medium text-amber-600 dark:text-amber-400 w-20 text-right shrink-0">
+      <span className="text-xs font-medium text-amber-600 dark:text-amber-400 w-20 text-right shrink-0">
         {roleLabel}
       </span>
     </div>

--- a/web/src/components/IssueList.tsx
+++ b/web/src/components/IssueList.tsx
@@ -85,7 +85,7 @@ export function IssueList({
             </div>
             <time
               dateTime={issue.closedAt ?? issue.createdAt}
-              className="text-[10px] text-amber-500 dark:text-amber-400 block mt-1"
+              className="text-xs text-amber-500 dark:text-amber-400 block mt-1"
             >
               {formatTimeAgo(new Date(issue.closedAt ?? issue.createdAt))}
             </time>

--- a/web/src/components/ProposalList.tsx
+++ b/web/src/components/ProposalList.tsx
@@ -65,7 +65,7 @@ export function ProposalList({
               </span>
               <time
                 dateTime={proposal.createdAt}
-                className="text-[10px] text-amber-500 dark:text-amber-400"
+                className="text-xs text-amber-500 dark:text-amber-400"
               >
                 {formatTimeAgo(new Date(proposal.createdAt))}
               </time>
@@ -117,7 +117,7 @@ function LifecycleDuration({
 
   return (
     <span
-      className="text-[10px] text-amber-600 dark:text-amber-400 font-mono"
+      className="text-xs text-amber-600 dark:text-amber-400 font-mono"
       title={`Lifecycle: ${transitions.length} phases in ${duration}`}
     >
       <span role="img" aria-label="lifecycle duration">
@@ -150,7 +150,7 @@ function PhaseBadge({
 
   return (
     <span
-      className={`text-[10px] uppercase tracking-wider font-bold px-1.5 py-0.5 rounded border ${styles[phase]}`}
+      className={`text-xs uppercase tracking-wider font-bold px-1.5 py-0.5 rounded border ${styles[phase]}`}
     >
       {phase.replace(/-/g, ' ')}
     </span>

--- a/web/src/components/PullRequestList.tsx
+++ b/web/src/components/PullRequestList.tsx
@@ -68,7 +68,7 @@ export function PullRequestList({
             </div>
             <time
               dateTime={pr.mergedAt ?? pr.closedAt ?? pr.createdAt}
-              className="text-[10px] text-amber-500 dark:text-amber-400 block mt-0.5"
+              className="text-xs text-amber-500 dark:text-amber-400 block mt-0.5"
             >
               {formatTimeAgo(
                 new Date(pr.mergedAt ?? pr.closedAt ?? pr.createdAt)


### PR DESCRIPTION
Fixes #180

## Summary

Standardizes all `text-[10px]` (10px) instances to Tailwind's `text-xs` (12px/0.75rem) across the dashboard. This improves legibility for all secondary text elements and brings the codebase onto Tailwind's type scale instead of using arbitrary pixel values.

## Changes

| Component | Element | Before | After |
|-----------|---------|--------|-------|
| AgentList | Bee badge on avatar | `text-[10px]` | `text-xs` |
| CommentList | Comment type label | `text-[10px]` | `text-xs` |
| CommentList | Comment timestamp | `text-[10px]` | `text-xs` |
| CommitList | Commit timestamp | `text-[10px]` | `text-xs` |
| GovernanceAnalytics | Role label | `text-[10px]` | `text-xs` |
| IssueList | Issue timestamp | `text-[10px]` | `text-xs` |
| ProposalList | Proposal timestamp | `text-[10px]` | `text-xs` |
| ProposalList | Lifecycle duration | `text-[10px]` | `text-xs` |
| ProposalList | Phase badge | `text-[10px]` | `text-xs` |
| PullRequestList | PR timestamp | `text-[10px]` | `text-xs` |

## Why

- 10px is below the commonly recommended 12px minimum for readable text
- `text-[10px]` bypasses Tailwind's design system — `text-xs` uses rem units that scale with user font size preferences
- Eliminates all arbitrary `text-[10px]` classes from the codebase

## Checklist

- [x] All 279 tests pass
- [x] TypeScript type check passes
- [x] ESLint passes with zero errors
- [x] Production build succeeds
- [x] Zero `text-[10px]` instances remain in the codebase