### PR TITLE
feat(web): add extended-voting phase support

### DIFF
--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -336,6 +336,7 @@ async function fetchProposals(
   const validPhases = [
     'discussion',
     'voting',
+    'extended-voting',
     'ready-to-implement',
     'implemented',
     'rejected',
@@ -374,6 +375,7 @@ async function fetchProposals(
   // retrieve tallies for proposals that already passed or failed voting.
   const votablePhases: readonly string[] = [
     'voting',
+    'extended-voting',
     'ready-to-implement',
     'implemented',
     'rejected',

--- a/web/shared/types.ts
+++ b/web/shared/types.ts
@@ -37,6 +37,7 @@ export interface Proposal {
   phase:
     | 'discussion'
     | 'voting'
+    | 'extended-voting'
     | 'ready-to-implement'
     | 'implemented'
     | 'rejected'

--- a/web/src/components/GovernanceAnalytics.test.tsx
+++ b/web/src/components/GovernanceAnalytics.test.tsx
@@ -149,6 +149,34 @@ describe('GovernanceAnalytics', () => {
     expect(screen.getByText('Discussion')).toBeInTheDocument();
   });
 
+  it('renders extended-voting proposals in the pipeline', () => {
+    const data = makeData({
+      proposals: [
+        {
+          number: 1,
+          title: 'A',
+          phase: 'extended-voting',
+          author: 'bot',
+          createdAt: '2026-02-05T09:00:00Z',
+          commentCount: 2,
+        },
+        {
+          number: 2,
+          title: 'B',
+          phase: 'voting',
+          author: 'bot',
+          createdAt: '2026-02-05T08:00:00Z',
+          commentCount: 1,
+        },
+      ],
+    });
+
+    render(<GovernanceAnalytics data={data} />);
+
+    expect(screen.getByText('Extended Voting')).toBeInTheDocument();
+    expect(screen.getByText('Voting')).toBeInTheDocument();
+  });
+
   it('shows Inactive label for agents with zero activity', () => {
     const data = makeData({
       agentStats: [

--- a/web/src/components/GovernanceAnalytics.tsx
+++ b/web/src/components/GovernanceAnalytics.tsx
@@ -92,6 +92,10 @@ const PHASE_COLORS: Record<
     bg: 'bg-blue-400 dark:bg-blue-500',
     label: 'Voting',
   },
+  extendedVoting: {
+    bg: 'bg-indigo-400 dark:bg-indigo-500',
+    label: 'Extended Voting',
+  },
   readyToImplement: {
     bg: 'bg-green-400 dark:bg-green-500',
     label: 'Ready',

--- a/web/src/components/ProposalList.test.tsx
+++ b/web/src/components/ProposalList.test.tsx
@@ -123,6 +123,14 @@ describe('ProposalList', () => {
         commentCount: 1,
       },
       {
+        number: 7,
+        title: 'Extended voting phase',
+        phase: 'extended-voting',
+        author: 'g',
+        createdAt: '2026-02-05T07:30:00Z',
+        commentCount: 1,
+      },
+      {
         number: 3,
         title: 'Ready phase',
         phase: 'ready-to-implement',
@@ -160,6 +168,7 @@ describe('ProposalList', () => {
 
     expect(screen.getByText('discussion')).toBeInTheDocument();
     expect(screen.getByText('voting')).toBeInTheDocument();
+    expect(screen.getByText('extended voting')).toBeInTheDocument();
     expect(screen.getByText('ready to implement')).toBeInTheDocument();
     expect(screen.getByText('implemented')).toBeInTheDocument();
     expect(screen.getByText('rejected')).toBeInTheDocument();

--- a/web/src/components/ProposalList.tsx
+++ b/web/src/components/ProposalList.tsx
@@ -138,6 +138,8 @@ function PhaseBadge({
       'bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-200 border-amber-200 dark:border-amber-800',
     voting:
       'bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-200 border-blue-200 dark:border-blue-800',
+    'extended-voting':
+      'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/50 dark:text-indigo-200 border-indigo-200 dark:border-indigo-800',
     'ready-to-implement':
       'bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-200 border-green-200 dark:border-green-800',
     implemented:

--- a/web/src/utils/governance.test.ts
+++ b/web/src/utils/governance.test.ts
@@ -60,6 +60,7 @@ describe('computePipeline', () => {
     expect(result).toEqual({
       discussion: 0,
       voting: 0,
+      extendedVoting: 0,
       readyToImplement: 0,
       implemented: 0,
       rejected: 0,
@@ -85,12 +86,26 @@ describe('computePipeline', () => {
     expect(result).toEqual({
       discussion: 2,
       voting: 1,
+      extendedVoting: 0,
       readyToImplement: 1,
       implemented: 3,
       rejected: 1,
       inconclusive: 1,
       total: 9,
     });
+  });
+
+  it('counts extended-voting proposals', () => {
+    const proposals = [
+      makeProposal({ number: 1, phase: 'extended-voting' }),
+      makeProposal({ number: 2, phase: 'extended-voting' }),
+      makeProposal({ number: 3, phase: 'voting' }),
+    ];
+
+    const result = computePipeline(proposals);
+    expect(result.extendedVoting).toBe(2);
+    expect(result.voting).toBe(1);
+    expect(result.total).toBe(3);
   });
 
   it('handles all proposals in a single phase', () => {
@@ -299,6 +314,20 @@ describe('computeGovernanceMetrics', () => {
 
     const metrics = computeGovernanceMetrics(data);
     expect(metrics.activeProposals).toBe(3);
+  });
+
+  it('includes extended-voting proposals in active count', () => {
+    const data = makeActivityData({
+      proposals: [
+        makeProposal({ number: 1, phase: 'discussion' }),
+        makeProposal({ number: 2, phase: 'extended-voting' }),
+        makeProposal({ number: 3, phase: 'implemented' }),
+      ],
+    });
+
+    const metrics = computeGovernanceMetrics(data);
+    expect(metrics.activeProposals).toBe(2);
+    expect(metrics.pipeline.extendedVoting).toBe(1);
   });
 
   it('computes average comments across all proposals', () => {

--- a/web/src/utils/governance.ts
+++ b/web/src/utils/governance.ts
@@ -3,6 +3,7 @@ import type { ActivityData, AgentStats, Proposal } from '../types/activity';
 export interface ProposalPipelineCounts {
   discussion: number;
   voting: number;
+  extendedVoting: number;
   readyToImplement: number;
   implemented: number;
   rejected: number;
@@ -53,7 +54,10 @@ export function computeGovernanceMetrics(
     proposals.length > 0 ? totalComments / proposals.length : 0;
 
   const activeProposals =
-    pipeline.discussion + pipeline.voting + pipeline.readyToImplement;
+    pipeline.discussion +
+    pipeline.voting +
+    pipeline.extendedVoting +
+    pipeline.readyToImplement;
 
   return {
     totalProposals: pipeline.total,
@@ -70,6 +74,7 @@ export function computePipeline(proposals: Proposal[]): ProposalPipelineCounts {
   const counts: ProposalPipelineCounts = {
     discussion: 0,
     voting: 0,
+    extendedVoting: 0,
     readyToImplement: 0,
     implemented: 0,
     rejected: 0,
@@ -84,6 +89,9 @@ export function computePipeline(proposals: Proposal[]): ProposalPipelineCounts {
         break;
       case 'voting':
         counts.voting++;
+        break;
+      case 'extended-voting':
+        counts.extendedVoting++;
         break;
       case 'ready-to-implement':
         counts.readyToImplement++;


### PR DESCRIPTION
## Summary

- Adds `extended-voting` to the `Proposal` phase type union, data pipeline, UI badge, pipeline visualization, and governance analytics
- The Queen bot creates `extended-voting` when initial voting doesn't reach quorum, but these proposals were silently dropped from the dashboard — this fixes that data integrity gap
- Indigo badge color distinguishes extended-voting from regular voting while staying in the blue color family
- Extended-voting proposals count as active in governance metrics

Fixes #167

## Files changed

| File | Change |
|------|--------|
| `shared/types.ts` | Add `extended-voting` to `Proposal['phase']` union |
| `scripts/generate-data.ts` | Add `extended-voting` to `validPhases` and `votablePhases` |
| `src/components/ProposalList.tsx` | Add indigo badge styling for `extended-voting` |
| `src/utils/governance.ts` | Add `extendedVoting` to pipeline counts and active proposals |
| `src/components/GovernanceAnalytics.tsx` | Add `extendedVoting` to pipeline visualization with indigo color |
| `src/utils/governance.test.ts` | 2 new tests: pipeline counting and active proposals inclusion |
| `src/components/ProposalList.test.tsx` | Updated phase rendering test to include extended-voting |
| `src/components/GovernanceAnalytics.test.tsx` | New test for extended-voting in pipeline visualization |

## Test plan

- [x] All 282 tests pass (`vitest run`)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] ESLint passes (zero errors)
- [x] Production build succeeds (`vite build`)
- [x] Extended-voting proposals appear in pipeline visualization with indigo segment
- [x] Extended-voting badge displays correctly with "extended voting" label
- [x] Extended-voting proposals counted as active in governance metrics
- [x] Existing phases unaffected — all prior tests pass unchanged