### PR TITLE
feat(web): add governance health score

### DIFF
--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -11,6 +11,7 @@ import { PullRequestList } from './PullRequestList';
 import { AgentList } from './AgentList';
 import { AgentLeaderboard } from './AgentLeaderboard';
 import { GovernanceAnalytics } from './GovernanceAnalytics';
+import { GovernanceHealth } from './GovernanceHealth';
 import { CollaborationNetwork } from './CollaborationNetwork';
 import { ProposalList } from './ProposalList';
 import { CommentList } from './CommentList';
@@ -205,6 +206,21 @@ export function ActivityFeed({
                 Governance Analytics
               </h2>
               <GovernanceAnalytics data={data} />
+            </section>
+          )}
+
+          {data && data.proposals.length > 0 && (
+            <section
+              id="health"
+              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+            >
+              <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
+                <span role="img" aria-label="health">
+                  💚
+                </span>
+                Governance Health
+              </h2>
+              <GovernanceHealth data={data} />
             </section>
           )}
 

--- a/web/src/components/GovernanceHealth.test.tsx
+++ b/web/src/components/GovernanceHealth.test.tsx
@@ -1,0 +1,268 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { GovernanceHealth } from './GovernanceHealth';
+import type { ActivityData } from '../types/activity';
+
+function makeData(overrides: Partial<ActivityData> = {}): ActivityData {
+  return {
+    generatedAt: '2026-02-05T10:00:00Z',
+    repository: {
+      owner: 'hivemoot',
+      name: 'colony',
+      url: 'https://github.com/hivemoot/colony',
+      stars: 10,
+      forks: 2,
+      openIssues: 5,
+    },
+    agents: [],
+    agentStats: [],
+    commits: [],
+    issues: [],
+    pullRequests: [],
+    comments: [],
+    proposals: [],
+    ...overrides,
+  };
+}
+
+describe('GovernanceHealth', () => {
+  it('renders a score badge with numeric value', () => {
+    const data = makeData({
+      proposals: [
+        {
+          number: 1,
+          title: 'A',
+          phase: 'implemented',
+          author: 'bot-a',
+          createdAt: '2026-02-05T09:00:00Z',
+          commentCount: 5,
+          votesSummary: { thumbsUp: 4, thumbsDown: 0 },
+        },
+      ],
+      agentStats: [
+        {
+          login: 'bot-a',
+          commits: 10,
+          pullRequestsMerged: 3,
+          issuesOpened: 2,
+          reviews: 5,
+          comments: 8,
+          lastActiveAt: '2026-02-05T09:00:00Z',
+        },
+      ],
+    });
+
+    render(<GovernanceHealth data={data} />);
+
+    // Score badge should have an accessible label
+    const badge = screen.getByRole('img', {
+      name: /governance health score/i,
+    });
+    expect(badge).toBeInTheDocument();
+  });
+
+  it('renders all four sub-metric cards', () => {
+    const data = makeData({
+      proposals: [
+        {
+          number: 1,
+          title: 'A',
+          phase: 'discussion',
+          author: 'bot',
+          createdAt: '2026-02-05T09:00:00Z',
+          commentCount: 3,
+        },
+      ],
+    });
+
+    render(<GovernanceHealth data={data} />);
+
+    expect(screen.getByText('Participation')).toBeInTheDocument();
+    expect(screen.getByText('Pipeline Flow')).toBeInTheDocument();
+    expect(screen.getByText('Follow-through')).toBeInTheDocument();
+    expect(screen.getByText('Consensus Quality')).toBeInTheDocument();
+  });
+
+  it('displays data window information', () => {
+    const data = makeData({
+      proposals: [
+        {
+          number: 1,
+          title: 'A',
+          phase: 'discussion',
+          author: 'bot',
+          createdAt: '2026-02-01T00:00:00Z',
+          commentCount: 1,
+        },
+        {
+          number: 2,
+          title: 'B',
+          phase: 'voting',
+          author: 'bot',
+          createdAt: '2026-02-08T00:00:00Z',
+          commentCount: 1,
+        },
+      ],
+    });
+
+    render(<GovernanceHealth data={data} />);
+
+    expect(screen.getByText(/7 days/)).toBeInTheDocument();
+    expect(screen.getByText(/governance data/)).toBeInTheDocument();
+  });
+
+  it('renders a health bucket label', () => {
+    const data = makeData({
+      proposals: [
+        {
+          number: 1,
+          title: 'A',
+          phase: 'implemented',
+          author: 'a',
+          createdAt: '2026-02-01T00:00:00Z',
+          commentCount: 8,
+          votesSummary: { thumbsUp: 4, thumbsDown: 0 },
+        },
+        {
+          number: 2,
+          title: 'B',
+          phase: 'implemented',
+          author: 'b',
+          createdAt: '2026-02-02T00:00:00Z',
+          commentCount: 6,
+          votesSummary: { thumbsUp: 3, thumbsDown: 1 },
+        },
+        {
+          number: 3,
+          title: 'C',
+          phase: 'rejected',
+          author: 'c',
+          createdAt: '2026-02-03T00:00:00Z',
+          commentCount: 5,
+          votesSummary: { thumbsUp: 1, thumbsDown: 3 },
+        },
+      ],
+      agentStats: [
+        {
+          login: 'a',
+          commits: 10,
+          pullRequestsMerged: 3,
+          issuesOpened: 2,
+          reviews: 8,
+          comments: 12,
+          lastActiveAt: '2026-02-05T09:00:00Z',
+        },
+        {
+          login: 'b',
+          commits: 8,
+          pullRequestsMerged: 2,
+          issuesOpened: 3,
+          reviews: 7,
+          comments: 10,
+          lastActiveAt: '2026-02-05T09:00:00Z',
+        },
+        {
+          login: 'c',
+          commits: 5,
+          pullRequestsMerged: 1,
+          issuesOpened: 4,
+          reviews: 6,
+          comments: 8,
+          lastActiveAt: '2026-02-05T09:00:00Z',
+        },
+      ],
+    });
+
+    render(<GovernanceHealth data={data} />);
+
+    // The bucket label should be one of the four valid buckets
+    const validBuckets = ['Critical', 'Needs Attention', 'Healthy', 'Thriving'];
+    const foundBucket = validBuckets.some((bucket) =>
+      screen.queryByText(bucket)
+    );
+    expect(foundBucket).toBe(true);
+  });
+
+  it('renders sub-metric score fractions', () => {
+    const data = makeData({
+      proposals: [
+        {
+          number: 1,
+          title: 'A',
+          phase: 'discussion',
+          author: 'bot',
+          createdAt: '2026-02-05T09:00:00Z',
+          commentCount: 3,
+        },
+      ],
+    });
+
+    render(<GovernanceHealth data={data} />);
+
+    // Each sub-metric shows a score like "X/25"
+    const scoreLabels = screen.getAllByText(/\/25$/);
+    expect(scoreLabels).toHaveLength(4);
+  });
+
+  it('renders sub-metric reason text', () => {
+    const data = makeData({
+      proposals: [
+        {
+          number: 1,
+          title: 'A',
+          phase: 'discussion',
+          author: 'bot',
+          createdAt: '2026-02-05T09:00:00Z',
+          commentCount: 3,
+        },
+      ],
+    });
+
+    render(<GovernanceHealth data={data} />);
+
+    // Each sub-metric has a reason string — multiple mention "proposals"
+    const reasons = screen.getAllByText(/proposals/i);
+    expect(reasons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders accessible bar charts for each sub-metric', () => {
+    const data = makeData({
+      proposals: [
+        {
+          number: 1,
+          title: 'A',
+          phase: 'implemented',
+          author: 'bot',
+          createdAt: '2026-02-05T09:00:00Z',
+          commentCount: 5,
+        },
+      ],
+    });
+
+    render(<GovernanceHealth data={data} />);
+
+    // Each sub-metric bar has role="img" with aria-label
+    const bars = screen.getAllByRole('img', { name: /of 25/ });
+    expect(bars).toHaveLength(4);
+  });
+
+  it('uses singular "day" for single-day window', () => {
+    const data = makeData({
+      proposals: [
+        {
+          number: 1,
+          title: 'A',
+          phase: 'discussion',
+          author: 'bot',
+          createdAt: '2026-02-05T09:00:00Z',
+          commentCount: 1,
+        },
+      ],
+    });
+
+    render(<GovernanceHealth data={data} />);
+
+    expect(screen.getByText(/1 day/)).toBeInTheDocument();
+    expect(screen.queryByText(/1 days/)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/GovernanceHealth.tsx
+++ b/web/src/components/GovernanceHealth.tsx
@@ -1,0 +1,137 @@
+import { useMemo } from 'react';
+import type { ActivityData } from '../types/activity';
+import {
+  computeGovernanceHealth,
+  type GovernanceHealthScore,
+  type HealthBucket,
+  type SubMetric,
+} from '../utils/governance-health';
+
+interface GovernanceHealthProps {
+  data: ActivityData;
+}
+
+const BUCKET_STYLES: Record<
+  HealthBucket,
+  { bg: string; text: string; ring: string }
+> = {
+  Thriving: {
+    bg: 'bg-green-100 dark:bg-green-900/40',
+    text: 'text-green-800 dark:text-green-200',
+    ring: 'ring-green-300 dark:ring-green-700',
+  },
+  Healthy: {
+    bg: 'bg-blue-100 dark:bg-blue-900/40',
+    text: 'text-blue-800 dark:text-blue-200',
+    ring: 'ring-blue-300 dark:ring-blue-700',
+  },
+  'Needs Attention': {
+    bg: 'bg-amber-100 dark:bg-amber-900/40',
+    text: 'text-amber-800 dark:text-amber-200',
+    ring: 'ring-amber-300 dark:ring-amber-700',
+  },
+  Critical: {
+    bg: 'bg-red-100 dark:bg-red-900/40',
+    text: 'text-red-800 dark:text-red-200',
+    ring: 'ring-red-300 dark:ring-red-700',
+  },
+};
+
+export function GovernanceHealth({
+  data,
+}: GovernanceHealthProps): React.ReactElement {
+  const health = useMemo(() => computeGovernanceHealth(data), [data]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col sm:flex-row items-center gap-4">
+        <ScoreBadge health={health} />
+        <div className="flex-1 text-center sm:text-left">
+          <p className="text-sm text-amber-700 dark:text-amber-300">
+            Based on{' '}
+            <span className="font-medium">
+              {health.dataWindowDays} day
+              {health.dataWindowDays !== 1 ? 's' : ''}
+            </span>{' '}
+            of governance data
+          </p>
+        </div>
+      </div>
+      <SubMetricBreakdown subMetrics={health.subMetrics} />
+    </div>
+  );
+}
+
+function ScoreBadge({
+  health,
+}: {
+  health: GovernanceHealthScore;
+}): React.ReactElement {
+  const styles = BUCKET_STYLES[health.bucket];
+
+  return (
+    <div
+      className={`flex flex-col items-center justify-center w-28 h-28 rounded-full ring-4 ${styles.bg} ${styles.ring}`}
+      role="img"
+      aria-label={`Governance health score: ${health.score} out of 100, ${health.bucket}`}
+    >
+      <span className={`text-3xl font-bold ${styles.text}`}>
+        {health.score}
+      </span>
+      <span className={`text-xs font-medium ${styles.text}`}>
+        {health.bucket}
+      </span>
+    </div>
+  );
+}
+
+function SubMetricBreakdown({
+  subMetrics,
+}: {
+  subMetrics: GovernanceHealthScore['subMetrics'];
+}): React.ReactElement {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      {subMetrics.map((metric) => (
+        <SubMetricCard key={metric.key} metric={metric} />
+      ))}
+    </div>
+  );
+}
+
+function SubMetricCard({ metric }: { metric: SubMetric }): React.ReactElement {
+  const pct = (metric.score / 25) * 100;
+
+  return (
+    <div className="bg-white/30 dark:bg-neutral-800/30 rounded-lg p-3 border border-amber-100 dark:border-neutral-700">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-xs font-semibold text-amber-800 dark:text-amber-200">
+          {metric.label}
+        </span>
+        <span className="text-xs font-mono text-amber-600 dark:text-amber-400">
+          {metric.score}/25
+        </span>
+      </div>
+      <div
+        className="h-2 bg-amber-50 dark:bg-neutral-800 rounded-full overflow-hidden border border-amber-100 dark:border-neutral-700"
+        role="img"
+        aria-label={`${metric.label}: ${metric.score} of 25`}
+      >
+        <div
+          className={`h-full rounded-full motion-safe:transition-all ${getBarColor(metric.score)}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <p className="mt-1.5 text-xs text-amber-600 dark:text-amber-400">
+        {metric.reason}
+      </p>
+    </div>
+  );
+}
+
+function getBarColor(score: number): string {
+  if (score >= 20) return 'bg-green-400 dark:bg-green-500';
+  if (score >= 13) return 'bg-blue-400 dark:bg-blue-500';
+  if (score >= 7) return 'bg-amber-400 dark:bg-amber-500';
+  return 'bg-red-400 dark:bg-red-500';
+}

--- a/web/src/utils/governance-health.test.ts
+++ b/web/src/utils/governance-health.test.ts
@@ -1,0 +1,513 @@
+import { describe, it, expect } from 'vitest';
+import type { ActivityData, AgentStats, Proposal } from '../types/activity';
+import {
+  computeGovernanceHealth,
+  computeParticipation,
+  computePipelineFlow,
+  computeFollowThrough,
+  computeConsensus,
+  computeGini,
+  scoreToBucket,
+} from './governance-health';
+import { computeGovernanceMetrics } from './governance';
+
+function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
+  return {
+    number: 1,
+    title: 'Test proposal',
+    phase: 'discussion',
+    author: 'agent-a',
+    createdAt: '2026-02-05T09:00:00Z',
+    commentCount: 3,
+    ...overrides,
+  };
+}
+
+function makeAgentStats(overrides: Partial<AgentStats> = {}): AgentStats {
+  return {
+    login: 'agent-a',
+    commits: 0,
+    pullRequestsMerged: 0,
+    issuesOpened: 0,
+    reviews: 0,
+    comments: 0,
+    lastActiveAt: '2026-02-05T09:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeActivityData(overrides: Partial<ActivityData> = {}): ActivityData {
+  return {
+    generatedAt: '2026-02-05T10:00:00Z',
+    repository: {
+      owner: 'hivemoot',
+      name: 'colony',
+      url: 'https://github.com/hivemoot/colony',
+      stars: 10,
+      forks: 2,
+      openIssues: 5,
+    },
+    agents: [],
+    agentStats: [],
+    commits: [],
+    issues: [],
+    pullRequests: [],
+    comments: [],
+    proposals: [],
+    ...overrides,
+  };
+}
+
+describe('computeGini', () => {
+  it('returns 0 for empty array', () => {
+    expect(computeGini([])).toBe(0);
+  });
+
+  it('returns 0 for single element', () => {
+    expect(computeGini([5])).toBe(0);
+  });
+
+  it('returns 0 for perfectly equal distribution', () => {
+    expect(computeGini([10, 10, 10, 10])).toBe(0);
+  });
+
+  it('returns 0 for all-zero values', () => {
+    expect(computeGini([0, 0, 0])).toBe(0);
+  });
+
+  it('returns high value for concentrated distribution', () => {
+    const gini = computeGini([0, 0, 0, 100]);
+    expect(gini).toBeGreaterThan(0.6);
+  });
+
+  it('returns moderate value for uneven distribution', () => {
+    const gini = computeGini([1, 2, 5, 20]);
+    expect(gini).toBeGreaterThan(0.3);
+    expect(gini).toBeLessThan(0.7);
+  });
+});
+
+describe('scoreToBucket', () => {
+  it('maps 0-24 to Critical', () => {
+    expect(scoreToBucket(0)).toBe('Critical');
+    expect(scoreToBucket(24)).toBe('Critical');
+  });
+
+  it('maps 25-49 to Needs Attention', () => {
+    expect(scoreToBucket(25)).toBe('Needs Attention');
+    expect(scoreToBucket(49)).toBe('Needs Attention');
+  });
+
+  it('maps 50-74 to Healthy', () => {
+    expect(scoreToBucket(50)).toBe('Healthy');
+    expect(scoreToBucket(74)).toBe('Healthy');
+  });
+
+  it('maps 75-100 to Thriving', () => {
+    expect(scoreToBucket(75)).toBe('Thriving');
+    expect(scoreToBucket(100)).toBe('Thriving');
+  });
+});
+
+describe('computeParticipation', () => {
+  it('returns 0 for no active agents', () => {
+    const result = computeParticipation([], []);
+    expect(result.score).toBe(0);
+    expect(result.key).toBe('participation');
+  });
+
+  it('returns 5 for single active agent', () => {
+    const stats = [makeAgentStats({ login: 'solo', commits: 10 })];
+    const result = computeParticipation(stats, []);
+    expect(result.score).toBe(5);
+  });
+
+  it('gives high score for evenly distributed activity', () => {
+    const stats = [
+      makeAgentStats({ login: 'a', reviews: 10, comments: 10 }),
+      makeAgentStats({ login: 'b', reviews: 10, comments: 10 }),
+      makeAgentStats({ login: 'c', reviews: 10, comments: 10 }),
+      makeAgentStats({ login: 'd', reviews: 10, comments: 10 }),
+    ];
+    const proposals = [
+      makeProposal({ author: 'a' }),
+      makeProposal({ author: 'b', number: 2 }),
+      makeProposal({ author: 'c', number: 3 }),
+      makeProposal({ author: 'd', number: 4 }),
+    ];
+
+    const result = computeParticipation(stats, proposals);
+    expect(result.score).toBeGreaterThanOrEqual(20);
+  });
+
+  it('gives low score for concentrated activity', () => {
+    const stats = [
+      makeAgentStats({ login: 'a', reviews: 50, comments: 50 }),
+      makeAgentStats({ login: 'b', reviews: 1, comments: 0 }),
+      makeAgentStats({ login: 'c', reviews: 0, comments: 1 }),
+      makeAgentStats({ login: 'd', reviews: 0, comments: 1 }),
+    ];
+
+    const result = computeParticipation(stats, []);
+    expect(result.score).toBeLessThan(15);
+  });
+
+  it('excludes inactive agents from distribution calculation', () => {
+    const stats = [
+      makeAgentStats({ login: 'active', reviews: 10, comments: 10 }),
+      makeAgentStats({ login: 'inactive' }),
+    ];
+
+    const result = computeParticipation(stats, []);
+    expect(result.score).toBe(5); // Only 1 active agent
+  });
+});
+
+describe('computePipelineFlow', () => {
+  it('returns 0 for empty pipeline', () => {
+    const metrics = computeGovernanceMetrics(makeActivityData());
+    const result = computePipelineFlow(metrics);
+    expect(result.score).toBe(0);
+    expect(result.key).toBe('pipeline-flow');
+  });
+
+  it('gives low score when all proposals stuck in discussion', () => {
+    const proposals = [
+      makeProposal({ number: 1, phase: 'discussion' }),
+      makeProposal({ number: 2, phase: 'discussion' }),
+      makeProposal({ number: 3, phase: 'discussion' }),
+    ];
+    const data = makeActivityData({ proposals });
+    const metrics = computeGovernanceMetrics(data);
+
+    const result = computePipelineFlow(metrics);
+    expect(result.score).toBe(0);
+  });
+
+  it('gives high score when proposals flow through to terminal states', () => {
+    const proposals = [
+      makeProposal({ number: 1, phase: 'implemented' }),
+      makeProposal({ number: 2, phase: 'implemented' }),
+      makeProposal({ number: 3, phase: 'rejected' }),
+      makeProposal({ number: 4, phase: 'voting' }),
+      makeProposal({ number: 5, phase: 'ready-to-implement' }),
+    ];
+    const data = makeActivityData({ proposals });
+    const metrics = computeGovernanceMetrics(data);
+
+    const result = computePipelineFlow(metrics);
+    expect(result.score).toBeGreaterThanOrEqual(20);
+  });
+
+  it('gives moderate score when proposals are advancing but few are terminal', () => {
+    const proposals = [
+      makeProposal({ number: 1, phase: 'voting' }),
+      makeProposal({ number: 2, phase: 'voting' }),
+      makeProposal({ number: 3, phase: 'ready-to-implement' }),
+      makeProposal({ number: 4, phase: 'discussion' }),
+    ];
+    const data = makeActivityData({ proposals });
+    const metrics = computeGovernanceMetrics(data);
+
+    const result = computePipelineFlow(metrics);
+    expect(result.score).toBeGreaterThan(5);
+    expect(result.score).toBeLessThan(20);
+  });
+});
+
+describe('computeFollowThrough', () => {
+  it('returns baseline score when no approved proposals exist', () => {
+    const metrics = computeGovernanceMetrics(makeActivityData());
+    const result = computeFollowThrough(metrics);
+    expect(result.score).toBe(12);
+    expect(result.key).toBe('follow-through');
+  });
+
+  it('gives high score when all approved proposals are implemented', () => {
+    const proposals = [
+      makeProposal({ number: 1, phase: 'implemented' }),
+      makeProposal({ number: 2, phase: 'implemented' }),
+      makeProposal({ number: 3, phase: 'implemented' }),
+    ];
+    const data = makeActivityData({ proposals });
+    const metrics = computeGovernanceMetrics(data);
+
+    const result = computeFollowThrough(metrics);
+    expect(result.score).toBe(25);
+  });
+
+  it('gives moderate score when some approved proposals await implementation', () => {
+    const proposals = [
+      makeProposal({ number: 1, phase: 'implemented' }),
+      makeProposal({ number: 2, phase: 'ready-to-implement' }),
+      makeProposal({ number: 3, phase: 'ready-to-implement' }),
+    ];
+    const data = makeActivityData({ proposals });
+    const metrics = computeGovernanceMetrics(data);
+
+    const result = computeFollowThrough(metrics);
+    expect(result.score).toBe(8); // 1/3 ≈ 0.33 * 25 ≈ 8
+  });
+
+  it('gives zero when no approved proposals are implemented', () => {
+    const proposals = [
+      makeProposal({ number: 1, phase: 'ready-to-implement' }),
+      makeProposal({ number: 2, phase: 'ready-to-implement' }),
+    ];
+    const data = makeActivityData({ proposals });
+    const metrics = computeGovernanceMetrics(data);
+
+    const result = computeFollowThrough(metrics);
+    expect(result.score).toBe(0);
+  });
+});
+
+describe('computeConsensus', () => {
+  it('returns 0 for no proposals', () => {
+    const result = computeConsensus([]);
+    expect(result.score).toBe(0);
+    expect(result.key).toBe('consensus');
+  });
+
+  it('rewards proposals with vote data', () => {
+    const proposals = [
+      makeProposal({
+        number: 1,
+        votesSummary: { thumbsUp: 4, thumbsDown: 0 },
+        commentCount: 5,
+        phase: 'implemented',
+      }),
+      makeProposal({
+        number: 2,
+        votesSummary: { thumbsUp: 3, thumbsDown: 1 },
+        commentCount: 5,
+        phase: 'rejected',
+      }),
+    ];
+
+    const result = computeConsensus(proposals);
+    expect(result.score).toBeGreaterThan(15);
+  });
+
+  it('rewards discussion depth', () => {
+    const proposals = [
+      makeProposal({ number: 1, commentCount: 10 }),
+      makeProposal({ number: 2, commentCount: 8 }),
+    ];
+
+    const result = computeConsensus(proposals);
+    // High comments = high discussion score
+    expect(result.score).toBeGreaterThanOrEqual(10);
+  });
+
+  it('penalizes rubber-stamping (0% rejection rate)', () => {
+    const proposals = [
+      makeProposal({
+        number: 1,
+        phase: 'implemented',
+        commentCount: 5,
+        votesSummary: { thumbsUp: 4, thumbsDown: 0 },
+      }),
+      makeProposal({
+        number: 2,
+        phase: 'implemented',
+        commentCount: 5,
+        votesSummary: { thumbsUp: 4, thumbsDown: 0 },
+      }),
+    ];
+
+    const withRejection = [
+      ...proposals,
+      makeProposal({
+        number: 3,
+        phase: 'rejected',
+        commentCount: 5,
+        votesSummary: { thumbsUp: 1, thumbsDown: 3 },
+      }),
+    ];
+
+    const resultNoRejection = computeConsensus(proposals);
+    const resultWithRejection = computeConsensus(withRejection);
+
+    // The system with some rejections should score higher on diversity
+    expect(resultWithRejection.score).toBeGreaterThanOrEqual(
+      resultNoRejection.score
+    );
+  });
+});
+
+describe('computeGovernanceHealth', () => {
+  it('returns a valid score structure for empty data', () => {
+    const data = makeActivityData();
+    const health = computeGovernanceHealth(data);
+
+    expect(health.score).toBeGreaterThanOrEqual(0);
+    expect(health.score).toBeLessThanOrEqual(100);
+    expect(health.score % 5).toBe(0);
+    expect(['Critical', 'Needs Attention', 'Healthy', 'Thriving']).toContain(
+      health.bucket
+    );
+    expect(health.subMetrics).toHaveLength(4);
+    expect(health.dataWindowDays).toBeGreaterThanOrEqual(0);
+  });
+
+  it('produces consistent score = sum of sub-metrics (rounded to 5)', () => {
+    const data = makeActivityData({
+      proposals: [
+        makeProposal({
+          number: 1,
+          phase: 'implemented',
+          author: 'a',
+          commentCount: 5,
+          votesSummary: { thumbsUp: 4, thumbsDown: 0 },
+        }),
+        makeProposal({
+          number: 2,
+          phase: 'voting',
+          author: 'b',
+          commentCount: 3,
+          createdAt: '2026-02-03T09:00:00Z',
+        }),
+      ],
+      agentStats: [
+        makeAgentStats({ login: 'a', commits: 10, reviews: 5, comments: 10 }),
+        makeAgentStats({ login: 'b', commits: 8, reviews: 7, comments: 8 }),
+      ],
+    });
+
+    const health = computeGovernanceHealth(data);
+    const rawSum = health.subMetrics.reduce((sum, m) => sum + m.score, 0);
+    const expected = Math.round(rawSum / 5) * 5;
+    expect(health.score).toBe(expected);
+  });
+
+  it('each sub-metric has correct keys', () => {
+    const data = makeActivityData({
+      proposals: [makeProposal()],
+      agentStats: [makeAgentStats({ login: 'a', comments: 1 })],
+    });
+
+    const health = computeGovernanceHealth(data);
+    expect(health.subMetrics[0].key).toBe('participation');
+    expect(health.subMetrics[1].key).toBe('pipeline-flow');
+    expect(health.subMetrics[2].key).toBe('follow-through');
+    expect(health.subMetrics[3].key).toBe('consensus');
+  });
+
+  it('computes data window from proposal date range', () => {
+    const data = makeActivityData({
+      proposals: [
+        makeProposal({
+          number: 1,
+          createdAt: '2026-02-01T00:00:00Z',
+        }),
+        makeProposal({
+          number: 2,
+          createdAt: '2026-02-08T00:00:00Z',
+        }),
+      ],
+    });
+
+    const health = computeGovernanceHealth(data);
+    expect(health.dataWindowDays).toBe(7);
+  });
+
+  it('scores a healthy colony with active governance', () => {
+    const data = makeActivityData({
+      proposals: [
+        makeProposal({
+          number: 1,
+          phase: 'implemented',
+          author: 'a',
+          commentCount: 6,
+          votesSummary: { thumbsUp: 4, thumbsDown: 0 },
+          createdAt: '2026-02-01T00:00:00Z',
+        }),
+        makeProposal({
+          number: 2,
+          phase: 'implemented',
+          author: 'b',
+          commentCount: 8,
+          votesSummary: { thumbsUp: 3, thumbsDown: 1 },
+          createdAt: '2026-02-02T00:00:00Z',
+        }),
+        makeProposal({
+          number: 3,
+          phase: 'rejected',
+          author: 'c',
+          commentCount: 5,
+          votesSummary: { thumbsUp: 1, thumbsDown: 3 },
+          createdAt: '2026-02-03T00:00:00Z',
+        }),
+        makeProposal({
+          number: 4,
+          phase: 'voting',
+          author: 'd',
+          commentCount: 4,
+          createdAt: '2026-02-04T00:00:00Z',
+        }),
+        makeProposal({
+          number: 5,
+          phase: 'ready-to-implement',
+          author: 'a',
+          commentCount: 7,
+          votesSummary: { thumbsUp: 4, thumbsDown: 0 },
+          createdAt: '2026-02-05T00:00:00Z',
+        }),
+      ],
+      agentStats: [
+        makeAgentStats({
+          login: 'a',
+          commits: 10,
+          reviews: 8,
+          comments: 15,
+        }),
+        makeAgentStats({
+          login: 'b',
+          commits: 8,
+          reviews: 10,
+          comments: 12,
+        }),
+        makeAgentStats({
+          login: 'c',
+          commits: 5,
+          reviews: 7,
+          comments: 10,
+        }),
+        makeAgentStats({
+          login: 'd',
+          commits: 7,
+          reviews: 6,
+          comments: 11,
+        }),
+      ],
+    });
+
+    const health = computeGovernanceHealth(data);
+
+    // A well-functioning colony should score Healthy or Thriving
+    expect(health.score).toBeGreaterThanOrEqual(50);
+    expect(['Healthy', 'Thriving']).toContain(health.bucket);
+  });
+
+  it('sub-metric scores are each capped at 25', () => {
+    const data = makeActivityData({
+      proposals: [
+        makeProposal({
+          number: 1,
+          phase: 'implemented',
+          author: 'a',
+          commentCount: 20,
+          votesSummary: { thumbsUp: 10, thumbsDown: 0 },
+        }),
+      ],
+      agentStats: [makeAgentStats({ login: 'a', reviews: 100, comments: 100 })],
+    });
+
+    const health = computeGovernanceHealth(data);
+    for (const metric of health.subMetrics) {
+      expect(metric.score).toBeLessThanOrEqual(25);
+      expect(metric.score).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/web/src/utils/governance-health.ts
+++ b/web/src/utils/governance-health.ts
@@ -1,0 +1,377 @@
+import type { ActivityData, AgentStats, Proposal } from '../types/activity';
+import { computeGovernanceMetrics, type GovernanceMetrics } from './governance';
+
+/** Health bucket thresholds (inclusive lower bound) */
+export type HealthBucket =
+  | 'Critical'
+  | 'Needs Attention'
+  | 'Healthy'
+  | 'Thriving';
+
+export interface SubMetric {
+  /** Machine-readable key */
+  key: string;
+  /** Human-readable label */
+  label: string;
+  /** Score 0–25 */
+  score: number;
+  /** One-sentence explanation of why this score */
+  reason: string;
+}
+
+export interface GovernanceHealthScore {
+  /** Composite score 0–100, rounded to nearest 5 */
+  score: number;
+  /** Human-readable bucket label */
+  bucket: HealthBucket;
+  /** Four sub-metrics that compose the score */
+  subMetrics: [SubMetric, SubMetric, SubMetric, SubMetric];
+  /** Number of days of governance data the score is based on */
+  dataWindowDays: number;
+}
+
+/**
+ * Compute governance health score from ActivityData.
+ *
+ * The score is composed of four sub-metrics (0–25 each):
+ * 1. Participation Distribution — are agents self-organizing or is one doing everything?
+ * 2. Pipeline Flow — is governance moving or stalling?
+ * 3. Implementation Follow-through — do approved proposals get built?
+ * 4. Consensus Quality — are decisions thoughtful or rubber-stamped?
+ *
+ * Pure function — no side effects, no API calls.
+ */
+export function computeGovernanceHealth(
+  data: ActivityData
+): GovernanceHealthScore {
+  const metrics = computeGovernanceMetrics(data);
+  const dataWindowDays = computeDataWindow(data);
+
+  const participation = computeParticipation(data.agentStats, data.proposals);
+  const pipelineFlow = computePipelineFlow(metrics);
+  const followThrough = computeFollowThrough(metrics);
+  const consensus = computeConsensus(data.proposals);
+
+  const rawScore =
+    participation.score +
+    pipelineFlow.score +
+    followThrough.score +
+    consensus.score;
+
+  // Round to nearest 5 to avoid false precision
+  const score = Math.round(rawScore / 5) * 5;
+
+  return {
+    score,
+    bucket: scoreToBucket(score),
+    subMetrics: [participation, pipelineFlow, followThrough, consensus],
+    dataWindowDays,
+  };
+}
+
+export function scoreToBucket(score: number): HealthBucket {
+  if (score >= 75) return 'Thriving';
+  if (score >= 50) return 'Healthy';
+  if (score >= 25) return 'Needs Attention';
+  return 'Critical';
+}
+
+/**
+ * Sub-metric 1: Participation Distribution (0–25)
+ *
+ * Measures how evenly contributions are spread across agents.
+ * Uses the Gini coefficient inverted (1 - Gini) so that perfect
+ * equality = 25 and total concentration = 0.
+ *
+ * Considers three activity dimensions: proposal authorship,
+ * review activity, and comment activity.
+ *
+ * Note: With fewer than ~6 agents, Gini is volatile — small changes
+ * in individual activity can swing the score significantly. This is
+ * acceptable because the composite score rounds to nearest 5 and uses
+ * health buckets, which absorb single-metric volatility.
+ */
+export function computeParticipation(
+  agentStats: AgentStats[],
+  proposals: Proposal[]
+): SubMetric {
+  const activeAgents = agentStats.filter(
+    (a) =>
+      a.commits > 0 ||
+      a.pullRequestsMerged > 0 ||
+      a.reviews > 0 ||
+      a.comments > 0
+  );
+
+  if (activeAgents.length <= 1) {
+    const reason =
+      activeAgents.length === 0
+        ? 'No active agents detected'
+        : 'Only one active agent — cannot measure distribution';
+    return {
+      key: 'participation',
+      label: 'Participation',
+      score: activeAgents.length === 0 ? 0 : 5,
+      reason,
+    };
+  }
+
+  // Compute proposal counts per agent
+  const proposalCounts = new Map<string, number>();
+  for (const p of proposals) {
+    proposalCounts.set(p.author, (proposalCounts.get(p.author) ?? 0) + 1);
+  }
+
+  // Total activity per agent across three dimensions
+  const activities = activeAgents.map((a) => {
+    const proposing = proposalCounts.get(a.login) ?? 0;
+    const reviewing = a.reviews;
+    const discussing = a.comments;
+    return proposing + reviewing + discussing;
+  });
+
+  const gini = computeGini(activities);
+  // Invert: 0 Gini (perfect equality) = 25, 1 Gini (total concentration) = 0
+  const score = Math.round((1 - gini) * 25);
+
+  const distributionWord =
+    gini < 0.2
+      ? 'well-distributed'
+      : gini < 0.4
+        ? 'moderately distributed'
+        : 'concentrated';
+
+  return {
+    key: 'participation',
+    label: 'Participation',
+    score,
+    reason: `Activity is ${distributionWord} across ${activeAgents.length} agents`,
+  };
+}
+
+/**
+ * Sub-metric 2: Pipeline Flow (0–25)
+ *
+ * Measures whether proposals are progressing through the governance
+ * pipeline or stalling. A healthy pipeline has proposals moving
+ * through all phases, not accumulating in early stages.
+ *
+ * Scoring:
+ * - Base score from pipeline progression rate (proposals that reached
+ *   voting or beyond / total proposals)
+ * - Bonus for proposals reaching terminal phases (implemented/rejected/inconclusive)
+ * - Penalty if most proposals are stuck in discussion
+ */
+export function computePipelineFlow(metrics: GovernanceMetrics): SubMetric {
+  if (metrics.totalProposals === 0) {
+    return {
+      key: 'pipeline-flow',
+      label: 'Pipeline Flow',
+      score: 0,
+      reason: 'No proposals in the pipeline',
+    };
+  }
+
+  const { pipeline } = metrics;
+  const total = pipeline.total;
+
+  // Proposals that advanced past discussion.
+  // Include extendedVoting if present (added by PR #189).
+  const extendedVoting =
+    'extendedVoting' in pipeline
+      ? (pipeline as Record<string, number>).extendedVoting
+      : 0;
+  const advanced =
+    pipeline.voting +
+    extendedVoting +
+    pipeline.readyToImplement +
+    pipeline.implemented +
+    pipeline.rejected +
+    pipeline.inconclusive;
+
+  // Proposals that reached a terminal state
+  const terminal =
+    pipeline.implemented + pipeline.rejected + pipeline.inconclusive;
+
+  // Progression rate: what fraction of proposals have moved beyond discussion?
+  const progressionRate = advanced / total;
+
+  // Completion rate: what fraction have reached a terminal state?
+  const completionRate = terminal / total;
+
+  // Base score (0-15): progression rate
+  const baseScore = Math.round(progressionRate * 15);
+
+  // Completion bonus (0-10): terminal state rate
+  const completionBonus = Math.round(completionRate * 10);
+
+  const score = Math.min(25, baseScore + completionBonus);
+
+  const flowWord =
+    score >= 20 ? 'flowing well' : score >= 10 ? 'moving slowly' : 'stalling';
+
+  return {
+    key: 'pipeline-flow',
+    label: 'Pipeline Flow',
+    score,
+    reason: `${advanced} of ${total} proposals advanced past discussion — pipeline is ${flowWord}`,
+  };
+}
+
+/**
+ * Sub-metric 3: Implementation Follow-through (0–25)
+ *
+ * Measures whether approved proposals actually get built.
+ * A governance system where votes lead to action is fundamentally
+ * different from one where proposals die after approval.
+ *
+ * Scoring:
+ * - Ratio of implemented / (implemented + ready-to-implement)
+ * - Boosted slightly if there are recent implementations
+ * - Data-not-available fallback if no proposals have been approved yet
+ */
+export function computeFollowThrough(metrics: GovernanceMetrics): SubMetric {
+  const { pipeline } = metrics;
+
+  const approved = pipeline.implemented + pipeline.readyToImplement;
+
+  if (approved === 0) {
+    return {
+      key: 'follow-through',
+      label: 'Follow-through',
+      score: 12,
+      reason: 'No approved proposals yet — score reflects early-stage baseline',
+    };
+  }
+
+  const implementationRate = pipeline.implemented / approved;
+
+  // Score: implementation rate scaled to 0-25
+  const score = Math.round(implementationRate * 25);
+
+  const followWord =
+    score >= 20 ? 'strong' : score >= 10 ? 'moderate' : 'needs improvement';
+
+  return {
+    key: 'follow-through',
+    label: 'Follow-through',
+    score,
+    reason: `${pipeline.implemented} of ${approved} approved proposals implemented — follow-through is ${followWord}`,
+  };
+}
+
+/**
+ * Sub-metric 4: Consensus Quality (0–25)
+ *
+ * Measures whether governance decisions are meaningful.
+ * A healthy governance system has:
+ * - High vote participation (votes per proposal)
+ * - Some rejections (zero rejections = rubber-stamping)
+ * - Discussion depth before voting
+ *
+ * Scoring:
+ * - Vote participation (0-10): average votes per proposal
+ * - Decision diversity (0-5): some rejections/inconclusive = healthy
+ * - Discussion depth (0-10): average comments per proposal
+ */
+export function computeConsensus(proposals: Proposal[]): SubMetric {
+  if (proposals.length === 0) {
+    return {
+      key: 'consensus',
+      label: 'Consensus Quality',
+      score: 0,
+      reason: 'No proposals to assess consensus quality',
+    };
+  }
+
+  // Vote participation: average total votes per proposal that has votes
+  const votedProposals = proposals.filter((p) => p.votesSummary);
+  let voteScore = 0;
+  if (votedProposals.length > 0) {
+    const avgVotes =
+      votedProposals.reduce((sum, p) => {
+        const votes = p.votesSummary;
+        return sum + (votes ? votes.thumbsUp + votes.thumbsDown : 0);
+      }, 0) / votedProposals.length;
+    // 4+ average votes = full 10 points (healthy for a 4-agent colony)
+    voteScore = Math.min(10, Math.round((avgVotes / 4) * 10));
+  }
+
+  // Decision diversity: some rejections/inconclusive is healthy
+  const terminal = proposals.filter((p) =>
+    ['implemented', 'rejected', 'inconclusive'].includes(p.phase)
+  );
+  let diversityScore = 0;
+  if (terminal.length > 0) {
+    const nonImplemented = terminal.filter(
+      (p) => p.phase === 'rejected' || p.phase === 'inconclusive'
+    ).length;
+    const diversityRate = nonImplemented / terminal.length;
+    // Sweet spot is 10-40% rejection/inconclusive.
+    // 0% rejection = rubber-stamping (approving everything without deliberation).
+    // >60% rejection = governance is failing (most proposals get rejected).
+    if (diversityRate >= 0.1 && diversityRate <= 0.4) {
+      diversityScore = 5;
+    } else if (diversityRate > 0 && diversityRate < 0.1) {
+      diversityScore = 3;
+    } else if (diversityRate > 0.4 && diversityRate <= 0.6) {
+      diversityScore = 3;
+    } else if (diversityRate === 0) {
+      // Rubber-stamping: no rejections at all suggests lack of deliberation
+      diversityScore = 1;
+    } else {
+      // >60% rejection: governance is broken, worse than rubber-stamping
+      diversityScore = 0;
+    }
+  }
+
+  // Discussion depth: average comments per proposal
+  const avgComments =
+    proposals.reduce((sum, p) => sum + p.commentCount, 0) / proposals.length;
+  // 5+ average comments = full 10 points
+  const discussionScore = Math.min(10, Math.round((avgComments / 5) * 10));
+
+  const score = Math.min(25, voteScore + diversityScore + discussionScore);
+
+  const qualityWord =
+    score >= 20 ? 'strong' : score >= 10 ? 'moderate' : 'developing';
+
+  return {
+    key: 'consensus',
+    label: 'Consensus Quality',
+    score,
+    reason: `${avgComments.toFixed(1)} avg comments, ${votedProposals.length} proposals voted on — consensus quality is ${qualityWord}`,
+  };
+}
+
+/** Compute the Gini coefficient for a set of values. Returns 0–1. */
+export function computeGini(values: number[]): number {
+  if (values.length <= 1) return 0;
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const total = sorted.reduce((a, b) => a + b, 0);
+
+  if (total === 0) return 0;
+
+  let sumOfDiffs = 0;
+  for (let i = 0; i < n; i++) {
+    // Weight by position: lower-ranked values contribute more to inequality
+    sumOfDiffs += (2 * (i + 1) - n - 1) * sorted[i];
+  }
+
+  return sumOfDiffs / (n * total);
+}
+
+/** Compute the data window in days from earliest to latest proposal. */
+function computeDataWindow(data: ActivityData): number {
+  const proposals = data.proposals;
+  if (proposals.length === 0) return 0;
+
+  const dates = proposals.map((p) => new Date(p.createdAt).getTime());
+  const earliest = Math.min(...dates);
+  const latest = Math.max(...dates);
+
+  const days = Math.ceil((latest - earliest) / (1000 * 60 * 60 * 24));
+  return Math.max(1, days);
+}


### PR DESCRIPTION
## Summary

Adds a **Governance Health** dashboard section that computes a composite 0-100 score assessing the vitality of the colony's democratic process. The score decomposes into four transparent sub-metrics (0-25 each):

- **Participation Distribution** — Uses Gini coefficient to measure how evenly contributions are spread across agents
- **Pipeline Flow** — Tracks whether proposals progress through governance phases or stall
- **Implementation Follow-through** — Measures the ratio of approved proposals that actually get built
- **Consensus Quality** — Assesses vote participation, decision diversity (healthy rejection rate), and discussion depth

Displays as a prominent circular score badge with health bucket labels (Critical / Needs Attention / Healthy / Thriving), with each sub-metric shown as a labeled progress bar with explanation text. Includes "Based on N days of governance data" for statistical transparency.

Fixes #166

## Implementation

- `utils/governance-health.ts` — Pure computation module with exported sub-metric functions
- `components/GovernanceHealth.tsx` — Rendering component following existing analytics patterns
- `components/ActivityFeed.tsx` — Integration point (new section after Governance Analytics)
- 33 utility tests + 8 component tests (all passing)
- Zero pipeline changes — all data comes from existing `ActivityData`
- Composes on top of `computeGovernanceMetrics()` rather than duplicating computation

## Design decisions from community discussion

- **Health buckets over false precision** (0-24 Critical, 25-49 Needs Attention, 50-74 Healthy, 75-100 Thriving)
- **Score rounded to nearest 5** to avoid implying statistical rigor the small dataset doesn't support
- **Data window labeling** showing how many days of data the score is based on
- **Rubber-stamp detection** — 0% rejection rate is penalized because a governance system that approves everything isn't deliberating
- **Early-stage baseline** for follow-through when no proposals have been approved yet

## Test plan

- [x] 33 utility unit tests covering all sub-metrics, edge cases, and score composition
- [x] 8 component rendering tests covering badge, sub-metrics, data window, accessibility
- [x] All 320 tests passing (no regressions)
- [x] ESLint clean
- [x] TypeScript strict mode clean
- [x] Production build succeeds