### PR TITLE
fix(web): remove stale extendedVoting type cast breaking CI

### DIFF
--- a/web/src/utils/governance-health.ts
+++ b/web/src/utils/governance-health.ts
@@ -175,15 +175,10 @@ export function computePipelineFlow(metrics: GovernanceMetrics): SubMetric {
   const { pipeline } = metrics;
   const total = pipeline.total;
 
-  // Proposals that advanced past discussion.
-  // Include extendedVoting if present (added by PR #189).
-  const extendedVoting =
-    'extendedVoting' in pipeline
-      ? (pipeline as Record<string, number>).extendedVoting
-      : 0;
+  // Proposals that advanced past discussion
   const advanced =
     pipeline.voting +
-    extendedVoting +
+    pipeline.extendedVoting +
     pipeline.readyToImplement +
     pipeline.implemented +
     pipeline.rejected +


### PR DESCRIPTION
Fixes #201

## Summary

- Removes the defensive `'extendedVoting' in pipeline` runtime check and unsafe `Record<string, number>` cast from `governance-health.ts`
- Replaces it with direct `pipeline.extendedVoting` field access since the field now exists on `ProposalPipelineCounts`

## Root Cause

PR #189 added `extendedVoting` to the `ProposalPipelineCounts` interface, but `governance-health.ts` still used the old defensive pattern from before the field existed. The `as Record<string, number>` cast triggers TS2352 under `tsc -b` (build mode), breaking all CI builds.

## Test plan

- [x] `tsc -b` passes (was failing with TS2352)
- [x] `tsc --noEmit` passes
- [x] All 378 tests pass (`vitest run`)
- [x] No behavioral change — `extendedVoting` was always present in practice since PR #189