### PR TITLE
fix(web): add missing extended-voting badge to AgentProfilePanel

### DIFF
--- a/web/src/components/AgentProfilePanel.test.tsx
+++ b/web/src/components/AgentProfilePanel.test.tsx
@@ -243,6 +243,32 @@ describe('AgentProfilePanel', () => {
     expect(screen.getByText('voting')).toBeInTheDocument();
   });
 
+  it('renders extended-voting phase badge with indigo styling', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData({
+          proposals: [
+            {
+              number: 102,
+              title: 'Extended voting proposal',
+              phase: 'extended-voting',
+              author: 'builder',
+              createdAt: '2026-02-04T10:00:00Z',
+              commentCount: 7,
+            },
+          ],
+        })}
+        events={makeEvents()}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    const badge = screen.getByText('extended-voting');
+    expect(badge).toBeInTheDocument();
+    expect(badge.className).toContain('bg-indigo-100');
+  });
+
   it('renders recent activity filtered to the agent', () => {
     render(
       <AgentProfilePanel

--- a/web/src/components/AgentProfilePanel.tsx
+++ b/web/src/components/AgentProfilePanel.tsx
@@ -31,6 +31,8 @@ const PHASE_BADGE: Record<string, string> = {
   discussion:
     'bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-200',
   voting: 'bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-200',
+  'extended-voting':
+    'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/50 dark:text-indigo-200',
   'ready-to-implement':
     'bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-200',
   implemented:

--- a/web/src/utils/governance-health.ts
+++ b/web/src/utils/governance-health.ts
@@ -175,15 +175,10 @@ export function computePipelineFlow(metrics: GovernanceMetrics): SubMetric {
   const { pipeline } = metrics;
   const total = pipeline.total;
 
-  // Proposals that advanced past discussion.
-  // Include extendedVoting if present (added by PR #189).
-  const extendedVoting =
-    'extendedVoting' in pipeline
-      ? (pipeline as Record<string, number>).extendedVoting
-      : 0;
+  // Proposals that advanced past discussion
   const advanced =
     pipeline.voting +
-    extendedVoting +
+    pipeline.extendedVoting +
     pipeline.readyToImplement +
     pipeline.implemented +
     pipeline.rejected +


### PR DESCRIPTION
Fixes #203

## Summary

- Adds the missing `extended-voting` entry to the `PHASE_BADGE` map in `AgentProfilePanel.tsx`
- Proposals in the extended-voting phase now display with an indigo badge instead of falling through to the generic grey fallback
- Styling matches the existing `extended-voting` badge in `ProposalList.tsx` for consistency
- Also includes the governance-health.ts TS2352 fix (#201) since it's required for CI on main

## Test plan

- [x] New test verifies extended-voting badge renders with indigo styling
- [x] All 379 tests pass (`vitest run`)
- [x] `tsc -b` passes
- [x] No behavioral changes to other components