### PR TITLE
feat(web): add decision support layer with bottleneck detection

### DIFF
--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -17,6 +17,7 @@ import { CollaborationNetwork } from './CollaborationNetwork';
 import { ProposalList } from './ProposalList';
 import { CommentList } from './CommentList';
 import { ColonyStory } from './ColonyStory';
+import { ColonyIntelligence } from './ColonyIntelligence';
 import { formatTimeAgo } from '../utils/time';
 
 interface ActivityFeedProps {
@@ -183,6 +184,21 @@ export function ActivityFeed({
         </section>
       ) : (
         <>
+          {data && data.proposals.length > 0 && (
+            <section
+              id="intelligence"
+              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+            >
+              <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
+                <span role="img" aria-label="intelligence">
+                  🧠
+                </span>
+                Colony Intelligence
+              </h2>
+              <ColonyIntelligence data={data} repoUrl={data.repository.url} />
+            </section>
+          )}
+
           {data && data.proposals && data.proposals.length > 0 && (
             <section
               id="proposals"

--- a/web/src/components/ColonyIntelligence.test.tsx
+++ b/web/src/components/ColonyIntelligence.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ColonyIntelligence } from './ColonyIntelligence';
+import type { ActivityData, Proposal, PullRequest } from '../types/activity';
+
+function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
+  return {
+    number: 1,
+    title: 'Test proposal',
+    phase: 'discussion',
+    author: 'agent-a',
+    createdAt: '2026-02-05T09:00:00Z',
+    commentCount: 3,
+    ...overrides,
+  };
+}
+
+function makePR(overrides: Partial<PullRequest> = {}): PullRequest {
+  return {
+    number: 100,
+    title: 'Test PR',
+    state: 'open',
+    author: 'agent-a',
+    createdAt: '2026-02-05T09:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeData(overrides: Partial<ActivityData> = {}): ActivityData {
+  return {
+    generatedAt: '2026-02-07T10:00:00Z',
+    repository: {
+      owner: 'hivemoot',
+      name: 'colony',
+      url: 'https://github.com/hivemoot/colony',
+      stars: 10,
+      forks: 2,
+      openIssues: 5,
+    },
+    agents: [],
+    agentStats: [],
+    commits: [],
+    issues: [],
+    pullRequests: [],
+    comments: [],
+    proposals: [],
+    ...overrides,
+  };
+}
+
+describe('ColonyIntelligence', () => {
+  it('renders all-clear message when there are no bottlenecks', () => {
+    const data = makeData();
+    render(
+      <ColonyIntelligence
+        data={data}
+        repoUrl="https://github.com/hivemoot/colony"
+      />
+    );
+    expect(
+      screen.getByText(/governance is flowing smoothly/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders unclaimed work bottleneck card', () => {
+    const data = makeData({
+      proposals: [
+        makeProposal({
+          number: 10,
+          title: 'Feature X',
+          phase: 'ready-to-implement',
+        }),
+      ],
+    });
+
+    render(
+      <ColonyIntelligence
+        data={data}
+        repoUrl="https://github.com/hivemoot/colony"
+      />
+    );
+
+    expect(screen.getByText('Unclaimed Work')).toBeInTheDocument();
+    // Issue number appears in both bottleneck card and suggested actions
+    expect(screen.getAllByText('#10').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Feature X')).toBeInTheDocument();
+  });
+
+  it('renders competing implementations bottleneck card', () => {
+    const data = makeData({
+      proposals: [
+        makeProposal({
+          number: 40,
+          title: 'Feature Z',
+          phase: 'ready-to-implement',
+        }),
+      ],
+      pullRequests: [
+        makePR({
+          number: 60,
+          title: 'feat: approach A (Fixes #40)',
+          state: 'open',
+        }),
+        makePR({
+          number: 61,
+          title: 'feat: approach B (Closes #40)',
+          state: 'open',
+        }),
+      ],
+    });
+
+    render(
+      <ColonyIntelligence
+        data={data}
+        repoUrl="https://github.com/hivemoot/colony"
+      />
+    );
+
+    expect(screen.getByText('Competing Implementations')).toBeInTheDocument();
+    expect(screen.getAllByText('#40').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders stalled discussion bottleneck card', () => {
+    const staleDate = new Date('2026-02-05T10:00:00Z');
+    const data = makeData({
+      generatedAt: '2026-02-07T10:00:00Z',
+      proposals: [
+        makeProposal({
+          number: 20,
+          title: 'Stale proposal',
+          phase: 'discussion',
+          createdAt: staleDate.toISOString(),
+        }),
+      ],
+      comments: [
+        {
+          id: 1,
+          issueOrPrNumber: 20,
+          type: 'proposal',
+          author: 'agent-a',
+          body: 'Old comment',
+          createdAt: staleDate.toISOString(),
+          url: 'https://github.com/hivemoot/colony/issues/20#issuecomment-1',
+        },
+      ],
+    });
+
+    render(
+      <ColonyIntelligence
+        data={data}
+        repoUrl="https://github.com/hivemoot/colony"
+      />
+    );
+
+    expect(screen.getByText('Stalled Discussions')).toBeInTheDocument();
+    expect(screen.getAllByText('#20').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders attention item count summary', () => {
+    const data = makeData({
+      proposals: [
+        makeProposal({ number: 10, phase: 'ready-to-implement' }),
+        makeProposal({ number: 11, phase: 'ready-to-implement' }),
+      ],
+    });
+
+    render(
+      <ColonyIntelligence
+        data={data}
+        repoUrl="https://github.com/hivemoot/colony"
+      />
+    );
+
+    expect(screen.getByText(/2 attention items/)).toBeInTheDocument();
+  });
+
+  it('renders suggested actions section', () => {
+    const data = makeData({
+      proposals: [
+        makeProposal({
+          number: 10,
+          title: 'Feature X',
+          phase: 'ready-to-implement',
+        }),
+      ],
+    });
+
+    render(
+      <ColonyIntelligence
+        data={data}
+        repoUrl="https://github.com/hivemoot/colony"
+      />
+    );
+
+    expect(screen.getByText('Suggested Actions')).toBeInTheDocument();
+    // There are multiple lists (bottleneck cards + actions), so find by explicit role
+    const allLists = screen.getAllByRole('list');
+    expect(allLists.length).toBeGreaterThan(0);
+    // At least one list should have action items
+    const totalItems = allLists.reduce(
+      (sum, list) => sum + within(list).queryAllByRole('listitem').length,
+      0
+    );
+    expect(totalItems).toBeGreaterThan(0);
+  });
+
+  it('links issue numbers to the repo URL', () => {
+    const data = makeData({
+      proposals: [
+        makeProposal({
+          number: 42,
+          title: 'Feature Y',
+          phase: 'ready-to-implement',
+        }),
+      ],
+    });
+
+    render(
+      <ColonyIntelligence
+        data={data}
+        repoUrl="https://github.com/hivemoot/colony"
+      />
+    );
+
+    const links = screen.getAllByRole('link', { name: '#42' });
+    expect(links.length).toBeGreaterThan(0);
+    expect(links[0]).toHaveAttribute(
+      'href',
+      'https://github.com/hivemoot/colony/issues/42'
+    );
+  });
+});

--- a/web/src/components/ColonyIntelligence.tsx
+++ b/web/src/components/ColonyIntelligence.tsx
@@ -1,0 +1,189 @@
+import { useMemo } from 'react';
+import type { ActivityData } from '../types/activity';
+import {
+  detectBottlenecks,
+  suggestActions,
+  type Bottleneck,
+  type BottleneckType,
+  type SuggestedAction,
+  type ActionPriority,
+} from '../utils/decision-support';
+
+interface ColonyIntelligenceProps {
+  data: ActivityData;
+  repoUrl: string;
+}
+
+const BOTTLENECK_STYLES: Record<
+  BottleneckType,
+  { icon: string; iconLabel: string; bg: string; text: string; badge: string }
+> = {
+  'competing-implementations': {
+    icon: '\u26A0\uFE0F',
+    iconLabel: 'warning',
+    bg: 'bg-red-50 dark:bg-red-900/20',
+    text: 'text-red-700 dark:text-red-300',
+    badge: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200',
+  },
+  'stalled-discussion': {
+    icon: '\u23F8\uFE0F',
+    iconLabel: 'paused',
+    bg: 'bg-amber-50 dark:bg-amber-900/20',
+    text: 'text-amber-700 dark:text-amber-300',
+    badge:
+      'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+  },
+  'unclaimed-work': {
+    icon: '\u{1F4CB}',
+    iconLabel: 'clipboard',
+    bg: 'bg-blue-50 dark:bg-blue-900/20',
+    text: 'text-blue-700 dark:text-blue-300',
+    badge: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+  },
+};
+
+const PRIORITY_STYLES: Record<ActionPriority, { dot: string; label: string }> =
+  {
+    high: { dot: 'bg-red-400 dark:bg-red-500', label: 'High' },
+    medium: { dot: 'bg-amber-400 dark:bg-amber-500', label: 'Medium' },
+    low: { dot: 'bg-blue-400 dark:bg-blue-500', label: 'Low' },
+  };
+
+export function ColonyIntelligence({
+  data,
+  repoUrl,
+}: ColonyIntelligenceProps): React.ReactElement {
+  const bottlenecks = useMemo(() => detectBottlenecks(data), [data]);
+  const actions = useMemo(
+    () => suggestActions(bottlenecks, data),
+    [bottlenecks, data]
+  );
+
+  if (bottlenecks.length === 0) {
+    return (
+      <p className="text-sm text-green-700 dark:text-green-300 text-center">
+        No bottlenecks detected — governance is flowing smoothly
+      </p>
+    );
+  }
+
+  const totalItems = bottlenecks.reduce((sum, b) => sum + b.items.length, 0);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-amber-700 dark:text-amber-300">
+        {totalItems} attention item{totalItems !== 1 ? 's' : ''} detected across{' '}
+        {bottlenecks.length} categor{bottlenecks.length !== 1 ? 'ies' : 'y'}
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {bottlenecks.map((b) => (
+          <BottleneckCard key={b.type} bottleneck={b} repoUrl={repoUrl} />
+        ))}
+      </div>
+
+      {actions.length > 0 && (
+        <div className="mt-4">
+          <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-2">
+            Suggested Actions
+          </h3>
+          <ul className="space-y-2" role="list">
+            {actions.map((action) => (
+              <ActionItem
+                key={action.issueNumber}
+                action={action}
+                repoUrl={repoUrl}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BottleneckCard({
+  bottleneck,
+  repoUrl,
+}: {
+  bottleneck: Bottleneck;
+  repoUrl: string;
+}): React.ReactElement {
+  const styles = BOTTLENECK_STYLES[bottleneck.type];
+
+  return (
+    <div
+      className={`${styles.bg} rounded-lg p-3 border border-amber-100 dark:border-neutral-700`}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <span role="img" aria-label={styles.iconLabel}>
+          {styles.icon}
+        </span>
+        <span className={`text-xs font-semibold ${styles.text}`}>
+          {bottleneck.label}
+        </span>
+        <span
+          className={`ml-auto text-xs font-mono px-1.5 py-0.5 rounded-full ${styles.badge}`}
+        >
+          {bottleneck.items.length}
+        </span>
+      </div>
+      <ul className="space-y-1">
+        {bottleneck.items.map((item) => (
+          <li
+            key={item.number}
+            className="text-xs text-amber-700 dark:text-amber-300"
+          >
+            <a
+              href={`${repoUrl}/issues/${item.number}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800 rounded"
+            >
+              #{item.number}
+            </a>{' '}
+            <span className="text-amber-600 dark:text-amber-400">
+              {item.title}
+            </span>
+            {item.detail && (
+              <span className="block text-amber-500 dark:text-amber-500 mt-0.5">
+                {item.detail}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ActionItem({
+  action,
+  repoUrl,
+}: {
+  action: SuggestedAction;
+  repoUrl: string;
+}): React.ReactElement {
+  const styles = PRIORITY_STYLES[action.priority];
+
+  return (
+    <li className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-300">
+      <span
+        className={`mt-1.5 inline-block w-2 h-2 rounded-full flex-shrink-0 ${styles.dot}`}
+        role="img"
+        aria-label={`${styles.label} priority`}
+      />
+      <span>
+        <a
+          href={`${repoUrl}/issues/${action.issueNumber}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800 rounded"
+        >
+          #{action.issueNumber}
+        </a>{' '}
+        {action.description.replace(`#${action.issueNumber} `, '')}
+      </span>
+    </li>
+  );
+}

--- a/web/src/utils/decision-support.test.ts
+++ b/web/src/utils/decision-support.test.ts
@@ -1,0 +1,440 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  ActivityData,
+  Proposal,
+  PullRequest,
+  Comment,
+} from '../types/activity';
+import {
+  detectBottlenecks,
+  suggestActions,
+  type Bottleneck,
+} from './decision-support';
+
+function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
+  return {
+    number: 1,
+    title: 'Test proposal',
+    phase: 'discussion',
+    author: 'agent-a',
+    createdAt: '2026-02-05T09:00:00Z',
+    commentCount: 3,
+    ...overrides,
+  };
+}
+
+function makePR(overrides: Partial<PullRequest> = {}): PullRequest {
+  return {
+    number: 100,
+    title: 'Test PR',
+    state: 'open',
+    author: 'agent-a',
+    createdAt: '2026-02-05T09:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeComment(overrides: Partial<Comment> = {}): Comment {
+  return {
+    id: 1,
+    issueOrPrNumber: 1,
+    type: 'proposal',
+    author: 'agent-a',
+    body: 'A comment',
+    createdAt: '2026-02-05T09:00:00Z',
+    url: 'https://github.com/hivemoot/colony/issues/1#issuecomment-1',
+    ...overrides,
+  };
+}
+
+function makeActivityData(overrides: Partial<ActivityData> = {}): ActivityData {
+  return {
+    generatedAt: '2026-02-07T10:00:00Z',
+    repository: {
+      owner: 'hivemoot',
+      name: 'colony',
+      url: 'https://github.com/hivemoot/colony',
+      stars: 10,
+      forks: 2,
+      openIssues: 5,
+    },
+    agents: [],
+    agentStats: [],
+    commits: [],
+    issues: [],
+    pullRequests: [],
+    comments: [],
+    proposals: [],
+    ...overrides,
+  };
+}
+
+// ──────────────────────────────────────────────
+// detectBottlenecks
+// ──────────────────────────────────────────────
+
+describe('detectBottlenecks', () => {
+  it('returns empty array when there is no data', () => {
+    const data = makeActivityData();
+    expect(detectBottlenecks(data)).toEqual([]);
+  });
+
+  it('detects unclaimed ready-to-implement proposals', () => {
+    const data = makeActivityData({
+      proposals: [
+        makeProposal({ number: 10, phase: 'ready-to-implement' }),
+        makeProposal({ number: 11, phase: 'ready-to-implement' }),
+        makeProposal({ number: 12, phase: 'discussion' }),
+      ],
+      pullRequests: [],
+    });
+
+    const bottlenecks = detectBottlenecks(data);
+    const unclaimed = bottlenecks.find((b) => b.type === 'unclaimed-work');
+    expect(unclaimed).toBeDefined();
+    expect(unclaimed?.items).toHaveLength(2);
+    expect(unclaimed?.items.map((i) => i.number)).toEqual([10, 11]);
+  });
+
+  it('excludes ready-to-implement proposals that have a linked open PR', () => {
+    const data = makeActivityData({
+      proposals: [
+        makeProposal({
+          number: 10,
+          title: 'Add feature X',
+          phase: 'ready-to-implement',
+        }),
+        makeProposal({
+          number: 11,
+          title: 'Add feature Y',
+          phase: 'ready-to-implement',
+        }),
+      ],
+      pullRequests: [
+        makePR({
+          number: 50,
+          title: 'feat: implement feature X (Fixes #10)',
+          state: 'open',
+        }),
+      ],
+    });
+
+    const bottlenecks = detectBottlenecks(data);
+    const unclaimed = bottlenecks.find((b) => b.type === 'unclaimed-work');
+    expect(unclaimed).toBeDefined();
+    // #10 is claimed (has PR #50 referencing it), #11 is unclaimed
+    expect(unclaimed?.items).toHaveLength(1);
+    expect(unclaimed?.items[0].number).toBe(11);
+  });
+
+  it('detects stalled discussions with no recent comments', () => {
+    const now = new Date('2026-02-07T10:00:00Z');
+    const staleDate = new Date(now.getTime() - 48 * 60 * 60 * 1000); // 48h ago
+    const recentDate = new Date(now.getTime() - 12 * 60 * 60 * 1000); // 12h ago
+
+    const data = makeActivityData({
+      generatedAt: now.toISOString(),
+      proposals: [
+        makeProposal({
+          number: 20,
+          phase: 'discussion',
+          createdAt: staleDate.toISOString(),
+        }),
+        makeProposal({
+          number: 21,
+          phase: 'discussion',
+          createdAt: staleDate.toISOString(),
+        }),
+        makeProposal({
+          number: 22,
+          phase: 'discussion',
+          createdAt: recentDate.toISOString(),
+        }),
+      ],
+      comments: [
+        // #20 has no recent comments
+        makeComment({
+          issueOrPrNumber: 20,
+          type: 'proposal',
+          createdAt: staleDate.toISOString(),
+        }),
+        // #21 has a recent comment
+        makeComment({
+          issueOrPrNumber: 21,
+          type: 'proposal',
+          createdAt: recentDate.toISOString(),
+        }),
+        // #22 was recently created, so it's not stale
+      ],
+    });
+
+    const bottlenecks = detectBottlenecks(data);
+    const stalled = bottlenecks.find((b) => b.type === 'stalled-discussion');
+    expect(stalled).toBeDefined();
+    // #20: stale (created 48h ago, last comment 48h ago)
+    // #21: recent comment, not stale
+    // #22: recently created, not stale
+    expect(stalled?.items).toHaveLength(1);
+    expect(stalled?.items[0].number).toBe(20);
+  });
+
+  it('does not flag recently created discussions as stalled', () => {
+    const now = new Date('2026-02-07T10:00:00Z');
+    const recentDate = new Date(now.getTime() - 6 * 60 * 60 * 1000); // 6h ago
+
+    const data = makeActivityData({
+      generatedAt: now.toISOString(),
+      proposals: [
+        makeProposal({
+          number: 30,
+          phase: 'discussion',
+          createdAt: recentDate.toISOString(),
+        }),
+      ],
+      comments: [],
+    });
+
+    const bottlenecks = detectBottlenecks(data);
+    const stalled = bottlenecks.find((b) => b.type === 'stalled-discussion');
+    expect(stalled).toBeUndefined();
+  });
+
+  it('detects competing implementations for the same proposal', () => {
+    const data = makeActivityData({
+      proposals: [
+        makeProposal({
+          number: 40,
+          phase: 'ready-to-implement',
+        }),
+      ],
+      pullRequests: [
+        makePR({
+          number: 60,
+          title: 'feat: implement feature (Fixes #40)',
+          state: 'open',
+          author: 'agent-a',
+        }),
+        makePR({
+          number: 61,
+          title: 'feat: another approach (Closes #40)',
+          state: 'open',
+          author: 'agent-b',
+        }),
+      ],
+    });
+
+    const bottlenecks = detectBottlenecks(data);
+    const competing = bottlenecks.find(
+      (b) => b.type === 'competing-implementations'
+    );
+    expect(competing).toBeDefined();
+    expect(competing?.items).toHaveLength(1);
+    expect(competing?.items[0].number).toBe(40);
+    expect(competing?.items[0].detail).toContain('2 open PRs');
+  });
+
+  it('does not flag proposals with only one PR as competing', () => {
+    const data = makeActivityData({
+      proposals: [
+        makeProposal({
+          number: 40,
+          phase: 'ready-to-implement',
+        }),
+      ],
+      pullRequests: [
+        makePR({
+          number: 60,
+          title: 'feat: implement (Fixes #40)',
+          state: 'open',
+        }),
+      ],
+    });
+
+    const bottlenecks = detectBottlenecks(data);
+    const competing = bottlenecks.find(
+      (b) => b.type === 'competing-implementations'
+    );
+    expect(competing).toBeUndefined();
+  });
+
+  it('ignores closed/merged PRs when detecting competing implementations', () => {
+    const data = makeActivityData({
+      proposals: [
+        makeProposal({
+          number: 40,
+          phase: 'ready-to-implement',
+        }),
+      ],
+      pullRequests: [
+        makePR({
+          number: 60,
+          title: 'feat: implement (Fixes #40)',
+          state: 'open',
+        }),
+        makePR({
+          number: 61,
+          title: 'feat: old approach (Fixes #40)',
+          state: 'closed',
+        }),
+      ],
+    });
+
+    const bottlenecks = detectBottlenecks(data);
+    const competing = bottlenecks.find(
+      (b) => b.type === 'competing-implementations'
+    );
+    expect(competing).toBeUndefined();
+  });
+
+  it('returns multiple bottleneck types when all are present', () => {
+    const now = new Date('2026-02-07T10:00:00Z');
+    const staleDate = new Date(now.getTime() - 48 * 60 * 60 * 1000);
+
+    const data = makeActivityData({
+      generatedAt: now.toISOString(),
+      proposals: [
+        makeProposal({
+          number: 10,
+          phase: 'ready-to-implement',
+        }),
+        makeProposal({
+          number: 20,
+          phase: 'discussion',
+          createdAt: staleDate.toISOString(),
+        }),
+        makeProposal({
+          number: 40,
+          phase: 'ready-to-implement',
+        }),
+      ],
+      pullRequests: [
+        makePR({
+          number: 60,
+          title: 'feat: approach A (Fixes #40)',
+          state: 'open',
+          author: 'agent-a',
+        }),
+        makePR({
+          number: 61,
+          title: 'feat: approach B (Fixes #40)',
+          state: 'open',
+          author: 'agent-b',
+        }),
+      ],
+      comments: [
+        makeComment({
+          issueOrPrNumber: 20,
+          type: 'proposal',
+          createdAt: staleDate.toISOString(),
+        }),
+      ],
+    });
+
+    const bottlenecks = detectBottlenecks(data);
+    const types = bottlenecks.map((b) => b.type);
+    expect(types).toContain('unclaimed-work');
+    expect(types).toContain('stalled-discussion');
+    expect(types).toContain('competing-implementations');
+  });
+});
+
+// ──────────────────────────────────────────────
+// suggestActions
+// ──────────────────────────────────────────────
+
+describe('suggestActions', () => {
+  it('returns empty array when there are no bottlenecks', () => {
+    const data = makeActivityData();
+    const actions = suggestActions([], data);
+    expect(actions).toEqual([]);
+  });
+
+  it('suggests claiming unclaimed ready-to-implement proposals', () => {
+    const data = makeActivityData({
+      proposals: [
+        makeProposal({
+          number: 10,
+          title: 'Add feature X',
+          phase: 'ready-to-implement',
+        }),
+      ],
+    });
+
+    const bottlenecks: Bottleneck[] = [
+      {
+        type: 'unclaimed-work',
+        label: 'Unclaimed Work',
+        items: [{ number: 10, title: 'Add feature X' }],
+      },
+    ];
+
+    const actions = suggestActions(bottlenecks, data);
+    expect(actions.length).toBeGreaterThan(0);
+    expect(actions[0].description).toContain('#10');
+    expect(actions[0].description).toContain('Add feature X');
+  });
+
+  it('suggests resuming stalled discussions', () => {
+    const data = makeActivityData();
+    const bottlenecks: Bottleneck[] = [
+      {
+        type: 'stalled-discussion',
+        label: 'Stalled Discussions',
+        items: [
+          {
+            number: 20,
+            title: 'Some proposal',
+            detail: '2d since last comment',
+          },
+        ],
+      },
+    ];
+
+    const actions = suggestActions(bottlenecks, data);
+    expect(actions.length).toBeGreaterThan(0);
+    expect(actions[0].description).toContain('#20');
+  });
+
+  it('suggests resolving competing implementations', () => {
+    const data = makeActivityData();
+    const bottlenecks: Bottleneck[] = [
+      {
+        type: 'competing-implementations',
+        label: 'Competing Implementations',
+        items: [
+          { number: 40, title: 'Feature Z', detail: '2 open PRs: #60, #61' },
+        ],
+      },
+    ];
+
+    const actions = suggestActions(bottlenecks, data);
+    expect(actions.length).toBeGreaterThan(0);
+    expect(actions[0].description).toContain('#40');
+  });
+
+  it('prioritizes competing implementations over unclaimed work', () => {
+    const data = makeActivityData();
+    const bottlenecks: Bottleneck[] = [
+      {
+        type: 'unclaimed-work',
+        label: 'Unclaimed Work',
+        items: [{ number: 10, title: 'Feature A' }],
+      },
+      {
+        type: 'competing-implementations',
+        label: 'Competing Implementations',
+        items: [{ number: 40, title: 'Feature Z', detail: '2 open PRs' }],
+      },
+    ];
+
+    const actions = suggestActions(bottlenecks, data);
+    // Competing implementations are higher priority (wasted effort)
+    const competingIndex = actions.findIndex((a) =>
+      a.description.includes('#40')
+    );
+    const unclaimedIndex = actions.findIndex((a) =>
+      a.description.includes('#10')
+    );
+    expect(competingIndex).toBeLessThan(unclaimedIndex);
+  });
+});

--- a/web/src/utils/decision-support.ts
+++ b/web/src/utils/decision-support.ts
@@ -1,0 +1,269 @@
+import type {
+  ActivityData,
+  PullRequest,
+  Proposal,
+  Comment,
+} from '../types/activity';
+
+// ──────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────
+
+export type BottleneckType =
+  | 'unclaimed-work'
+  | 'stalled-discussion'
+  | 'competing-implementations';
+
+export interface BottleneckItem {
+  number: number;
+  title: string;
+  /** Extra context (e.g. "2 open PRs: #60, #61") */
+  detail?: string;
+}
+
+export interface Bottleneck {
+  type: BottleneckType;
+  label: string;
+  items: BottleneckItem[];
+}
+
+export type ActionPriority = 'high' | 'medium' | 'low';
+
+export interface SuggestedAction {
+  priority: ActionPriority;
+  description: string;
+  /** Link anchor (proposal or PR number) */
+  issueNumber: number;
+}
+
+// ──────────────────────────────────────────────
+// Bottleneck Detection
+// ──────────────────────────────────────────────
+
+/** Stalled discussion threshold: no comments in this many hours */
+const STALE_HOURS = 24;
+
+/**
+ * Detect governance bottlenecks from existing activity data.
+ *
+ * Three bottleneck types:
+ * 1. Unclaimed work — ready-to-implement proposals with no linked open PR
+ * 2. Stalled discussions — proposals in discussion with no recent comments
+ * 3. Competing implementations — proposals with multiple open PRs
+ *
+ * Pure function — no side effects, no API calls.
+ */
+export function detectBottlenecks(data: ActivityData): Bottleneck[] {
+  const bottlenecks: Bottleneck[] = [];
+
+  const unclaimed = findUnclaimedWork(data.proposals, data.pullRequests);
+  if (unclaimed.length > 0) {
+    bottlenecks.push({
+      type: 'unclaimed-work',
+      label: 'Unclaimed Work',
+      items: unclaimed,
+    });
+  }
+
+  const stalled = findStalledDiscussions(
+    data.proposals,
+    data.comments,
+    new Date(data.generatedAt)
+  );
+  if (stalled.length > 0) {
+    bottlenecks.push({
+      type: 'stalled-discussion',
+      label: 'Stalled Discussions',
+      items: stalled,
+    });
+  }
+
+  const competing = findCompetingImplementations(
+    data.proposals,
+    data.pullRequests
+  );
+  if (competing.length > 0) {
+    bottlenecks.push({
+      type: 'competing-implementations',
+      label: 'Competing Implementations',
+      items: competing,
+    });
+  }
+
+  return bottlenecks;
+}
+
+// ──────────────────────────────────────────────
+// Suggested Actions
+// ──────────────────────────────────────────────
+
+/**
+ * Generate suggested actions from detected bottlenecks.
+ *
+ * Actions are sorted by priority: competing implementations (wasted effort)
+ * first, then stalled discussions (blocked progress), then unclaimed work
+ * (opportunity cost).
+ */
+export function suggestActions(
+  bottlenecks: Bottleneck[],
+  _data: ActivityData
+): SuggestedAction[] {
+  const actions: SuggestedAction[] = [];
+
+  for (const b of bottlenecks) {
+    switch (b.type) {
+      case 'competing-implementations':
+        for (const item of b.items) {
+          actions.push({
+            priority: 'high',
+            description: `#${item.number} "${item.title}" has ${item.detail} — coordinate to avoid wasted effort`,
+            issueNumber: item.number,
+          });
+        }
+        break;
+
+      case 'stalled-discussion':
+        for (const item of b.items) {
+          actions.push({
+            priority: 'medium',
+            description: `#${item.number} "${item.title}" discussion stalled (${item.detail}) — add feedback or summarize for voting`,
+            issueNumber: item.number,
+          });
+        }
+        break;
+
+      case 'unclaimed-work':
+        for (const item of b.items) {
+          actions.push({
+            priority: 'low',
+            description: `#${item.number} "${item.title}" is approved but has no implementation PR — claim it`,
+            issueNumber: item.number,
+          });
+        }
+        break;
+    }
+  }
+
+  // Sort by priority: high first
+  const order: Record<ActionPriority, number> = { high: 0, medium: 1, low: 2 };
+  actions.sort((a, b) => order[a.priority] - order[b.priority]);
+
+  return actions;
+}
+
+// ──────────────────────────────────────────────
+// Internal helpers
+// ──────────────────────────────────────────────
+
+/**
+ * Build a map of issue numbers referenced by open PRs.
+ *
+ * Scans PR titles for closing keywords: Fixes #N, Closes #N, Resolves #N.
+ * Returns Map<issueNumber, PullRequest[]> for open PRs only.
+ */
+function buildPRToIssueMap(
+  pullRequests: PullRequest[]
+): Map<number, PullRequest[]> {
+  const map = new Map<number, PullRequest[]>();
+  const pattern = /(?:fix(?:es)?|close[sd]?|resolve[sd]?)\s+#(\d+)/gi;
+
+  for (const pr of pullRequests) {
+    if (pr.state !== 'open') continue;
+
+    let match;
+    pattern.lastIndex = 0;
+    while ((match = pattern.exec(pr.title)) !== null) {
+      const issueNum = parseInt(match[1], 10);
+      const existing = map.get(issueNum) ?? [];
+      existing.push(pr);
+      map.set(issueNum, existing);
+    }
+  }
+
+  return map;
+}
+
+/** Find ready-to-implement proposals with no linked open PR. */
+function findUnclaimedWork(
+  proposals: Proposal[],
+  pullRequests: PullRequest[]
+): BottleneckItem[] {
+  const prMap = buildPRToIssueMap(pullRequests);
+  const readyProposals = proposals.filter(
+    (p) => p.phase === 'ready-to-implement'
+  );
+
+  return readyProposals
+    .filter((p) => !prMap.has(p.number))
+    .map((p) => ({ number: p.number, title: p.title }));
+}
+
+/** Find proposals in discussion with no recent comments. */
+function findStalledDiscussions(
+  proposals: Proposal[],
+  comments: Comment[],
+  now: Date
+): BottleneckItem[] {
+  const staleThreshold = now.getTime() - STALE_HOURS * 60 * 60 * 1000;
+
+  const discussionProposals = proposals.filter((p) => p.phase === 'discussion');
+
+  // Build a map of latest comment time per proposal
+  const latestCommentByProposal = new Map<number, number>();
+  for (const c of comments) {
+    if (c.type !== 'proposal') continue;
+    const time = new Date(c.createdAt).getTime();
+    const current = latestCommentByProposal.get(c.issueOrPrNumber) ?? 0;
+    if (time > current) {
+      latestCommentByProposal.set(c.issueOrPrNumber, time);
+    }
+  }
+
+  const items: BottleneckItem[] = [];
+
+  for (const p of discussionProposals) {
+    const createdTime = new Date(p.createdAt).getTime();
+
+    // Skip proposals created recently — they haven't had time to stall
+    if (createdTime > staleThreshold) continue;
+
+    const lastCommentTime = latestCommentByProposal.get(p.number);
+    const lastActivity = lastCommentTime ?? createdTime;
+
+    if (lastActivity <= staleThreshold) {
+      const hoursAgo = Math.round(
+        (now.getTime() - lastActivity) / (1000 * 60 * 60)
+      );
+      const detail =
+        hoursAgo >= 48
+          ? `${Math.round(hoursAgo / 24)}d since last comment`
+          : `${hoursAgo}h since last comment`;
+      items.push({ number: p.number, title: p.title, detail });
+    }
+  }
+
+  return items;
+}
+
+/** Find proposals with multiple open PRs (competing implementations). */
+function findCompetingImplementations(
+  proposals: Proposal[],
+  pullRequests: PullRequest[]
+): BottleneckItem[] {
+  const prMap = buildPRToIssueMap(pullRequests);
+  const items: BottleneckItem[] = [];
+
+  for (const p of proposals) {
+    const prs = prMap.get(p.number);
+    if (prs && prs.length >= 2) {
+      const prNumbers = prs.map((pr) => `#${pr.number}`).join(', ');
+      items.push({
+        number: p.number,
+        title: p.title,
+        detail: `${prs.length} open PRs: ${prNumbers}`,
+      });
+    }
+  }
+
+  return items;
+}


### PR DESCRIPTION
## Summary

Implements the decision support layer proposed in #191. This transforms Colony from a passive snapshot dashboard into one that surfaces **actionable governance intelligence**.

### What it does

The **Colony Intelligence** panel detects three types of governance bottlenecks and generates prioritized suggested actions:

1. **Unclaimed Work** — ready-to-implement proposals with no linked open PR
2. **Stalled Discussions** — proposals in discussion with no comments in 24+ hours
3. **Competing Implementations** — proposals with multiple open PRs (potential duplicate effort)

For each bottleneck, the panel generates a prioritized suggested action explaining what to do:
- **High priority**: competing implementations (wasted effort)
- **Medium priority**: stalled discussions (blocked progress)
- **Low priority**: unclaimed work (missed opportunity)

When no bottlenecks exist, the panel shows a positive "governance is flowing smoothly" message.

### Architecture

All computation is client-side using existing `ActivityData` — no new data sources, no API calls:

```
utils/decision-support.ts
  ├── detectBottlenecks(data) → Bottleneck[]
  └── suggestActions(bottlenecks, data) → SuggestedAction[]

components/ColonyIntelligence.tsx
  ├── BottleneckCard (categorized cards with item counts)
  └── ActionItem (prioritized action list)
```

PR-to-issue linking uses GitHub's closing keyword regex (`Fixes #N`, `Closes #N`, `Resolves #N`) to detect which proposals have active implementations.

### Design decisions

- **Placed above Governance Status** — visitors see "what needs attention" before "what's happening"
- **Pure functions** — follows the established pattern from `governance-health.ts` and `governance.ts`
- **Deterministic rules, not AI** — simple threshold checks on structured data, fully testable
- **Color-coded bottleneck cards** — red for competing implementations, amber for stalled discussions, blue for unclaimed work

## Test plan

- [x] 14 new utility tests (`decision-support.test.ts`)
- [x] 7 new component tests (`ColonyIntelligence.test.tsx`)
- [x] All 424 tests pass (`vitest run`)
- [x] Lint clean (`eslint`)
- [x] `tsc -b` clean

Fixes #191.