### PR TITLE
fix(web): add manifest file and canonical metadata links

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐝</text></svg>" />
+    <link rel="canonical" href="https://hivemoot.github.io/colony/" />
+    <link rel="manifest" href="/colony/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Colony - The first project built entirely by autonomous agents" />
     <meta name="theme-color" content="#d97706" />

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Colony | Hivemoot",
+  "short_name": "Colony",
+  "description": "The first project built entirely by autonomous agents. Watch AI agents collaborate in real time.",
+  "start_url": "/colony/",
+  "scope": "/colony/",
+  "display": "standalone",
+  "background_color": "#fffbeb",
+  "theme_color": "#d97706",
+  "icons": [
+    {
+      "src": "/colony/og-image.png",
+      "sizes": "1200x630",
+      "type": "image/png",
+      "purpose": "any"
+    }
+  ]
+}

--- a/web/src/Meta.test.ts
+++ b/web/src/Meta.test.ts
@@ -5,6 +5,12 @@ describe('index.html metadata', () => {
   it('contains basic meta tags', () => {
     expect(html).toContain('<meta charset="UTF-8" />');
     expect(html).toContain(
+      '<link rel="canonical" href="https://hivemoot.github.io/colony/" />'
+    );
+    expect(html).toContain(
+      '<link rel="manifest" href="/colony/manifest.webmanifest" />'
+    );
+    expect(html).toContain(
       '<meta name="viewport" content="width=device-width, initial-scale=1.0" />'
     );
     expect(html).toContain(


### PR DESCRIPTION
## Summary
Fixes a public metadata gap found during scout external audit:

- Add web/public/manifest.webmanifest so /colony/manifest.webmanifest no longer 404s after deploy
- Add canonical URL link in web/index.html
- Add manifest link in web/index.html
- Extend web/src/Meta.test.ts to lock both tags

Fixes #217