### PR TITLE
a11y: clarify external footer link behavior

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -364,4 +364,26 @@ describe('App', () => {
       );
     });
   });
+
+  it('announces external footer links opening in a new tab', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as Response);
+
+    render(<App />);
+    await waitFor(() => {
+      const githubLink = screen.getByRole('link', {
+        name: /view on github \(opens in a new tab\)/i,
+      });
+      const hivemootLink = screen.getByRole('link', {
+        name: /learn about hivemoot \(opens in a new tab\)/i,
+      });
+
+      expect(githubLink).toHaveAttribute('target', '_blank');
+      expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer');
+      expect(hivemootLink).toHaveAttribute('target', '_blank');
+      expect(hivemootLink).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+  });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -123,6 +123,7 @@ function App(): React.ReactElement {
           href="https://github.com/hivemoot/colony"
           target="_blank"
           rel="noopener noreferrer"
+          aria-label="View on GitHub (opens in a new tab)"
           className="inline-flex items-center justify-center px-6 py-3 bg-amber-600 hover:bg-amber-700 text-white font-medium rounded-lg motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
         >
           View on GitHub
@@ -131,6 +132,7 @@ function App(): React.ReactElement {
           href="https://github.com/hivemoot/hivemoot"
           target="_blank"
           rel="noopener noreferrer"
+          aria-label="Learn About Hivemoot (opens in a new tab)"
           className="inline-flex items-center justify-center px-6 py-3 bg-amber-100 hover:bg-amber-200 dark:bg-neutral-700 dark:hover:bg-neutral-600 text-amber-900 dark:text-amber-100 font-medium rounded-lg motion-safe:transition-colors border border-amber-300 dark:border-neutral-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
         >
           Learn About Hivemoot


### PR DESCRIPTION
Fixes #224

## Summary
- add explicit accessible labels on footer external links to announce they open in a new tab
- keep existing external-link safety attributes (`target="_blank"`, `rel="noopener noreferrer"`)
- add regression coverage in `App.test.tsx` for both footer links

## Why
Screen reader users should be told when navigation opens a new tab so link behavior is predictable.

## Validation
- `npm run lint`
- `npm test -- --run`
- `npm run build`
