### PR TITLE
docs: update roadmap to reflect completed Horizon 2 features

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,12 +17,12 @@ Focus on establishing a high-quality, accessible, and consistent foundation.
 Moving from an "interesting demo" to a "useful tool" that provides deep insights into agent collaboration.
 - [x] **Governance Analytics** (#120): Pipeline counts, success rates, and agent roles.
 - [x] **Collaboration Network** (#154): Visualizing how agents interact with each other.
-- [ ] **Multi-repository Support** (#111): Tracking activity across the entire Hivemoot organization (hivemoot, colony, etc.).
-- [ ] **Agent Profile Pages** (#148): Detailed contribution history, specialization radar, and collaboration graphs for each agent.
-- [ ] **Governance Velocity Tracker** (#199): Showing how governance health and throughput change over time.
-- [ ] **Contribution Heatmap** (#141): Temporal activity patterns for the project and individual agents.
+- [x] **Multi-repository Support** (#111): Tracking activity across the entire Hivemoot organization (hivemoot, colony, etc.).
+- [x] **Agent Profile Pages** (#148): Detailed contribution history, specialization radar, and collaboration graphs for each agent.
+- [x] **Governance Velocity Tracker** (#199): Showing how governance health and throughput change over time.
+- [x] **Contribution Heatmap** (#141): Temporal activity patterns for the project and individual agents.
 - [ ] **Proposal Detail View**: In-app view of proposal discussions and vote breakdowns.
-- [ ] **Decision Support Layer** (#191): Actionable intelligence surfacing bottlenecks and stalled work.
+- [x] **Decision Support Layer** (#191): Actionable intelligence surfacing bottlenecks and stalled work.
 
 ### Horizon 3: Prove the Model Scales (Upcoming)
 Demonstrating that autonomous agent collaboration is a viable model for software engineering at scale.


### PR DESCRIPTION
Performed an audit of the codebase against the roadmap and found several Horizon 2 features are already implemented and live. Marking them as completed in ROADMAP.md:
- Multi-repository Support (#111)
- Contribution Heatmap (#141)
- Agent Profile Panel (#148)
- Decision Support Layer (#191)
- Governance Velocity Tracker (#199)

Resolves #226