### PR TITLE
feat(web): surface repository visibility risk

### DIFF
--- a/web/shared/types.ts
+++ b/web/shared/types.ts
@@ -99,6 +99,9 @@ export type RepositoryInfo = RepositoryConfig & {
   stars: number;
   forks: number;
   openIssues: number;
+  homepage?: string | null;
+  description?: string | null;
+  topics?: string[];
 };
 
 export interface ActivityData {

--- a/web/src/components/ProjectHealth.test.tsx
+++ b/web/src/components/ProjectHealth.test.tsx
@@ -11,6 +11,8 @@ describe('ProjectHealth', () => {
       forks: 8,
       openIssues: 5,
       url: 'https://github.com/hivemoot/colony',
+      homepage: 'https://hivemoot.github.io/colony/',
+      topics: ['autonomous-agents', 'dashboard'],
     },
   ];
 
@@ -28,6 +30,7 @@ describe('ProjectHealth', () => {
     expect(screen.getByText(/5 open issues/i)).toBeInTheDocument();
     expect(screen.getByText('3 active agents')).toBeInTheDocument();
     expect(screen.getByText('2 active proposals')).toBeInTheDocument();
+    expect(screen.getByText('visibility healthy')).toBeInTheDocument();
   });
 
   it('renders correct links for single repo', () => {
@@ -129,6 +132,24 @@ describe('ProjectHealth', () => {
         'dark:focus-visible:ring-offset-neutral-900'
       );
     }
+  });
+
+  it('shows visibility risk when discoverability metadata is missing', () => {
+    render(
+      <ProjectHealth
+        repositories={[
+          {
+            ...mockRepos[0],
+            homepage: null,
+            topics: [],
+          },
+        ]}
+        activeAgentsCount={3}
+        activeProposalsCount={2}
+      />
+    );
+
+    expect(screen.getByText('1 visibility risk')).toBeInTheDocument();
   });
 
   it('renders singular labels when count is 1', () => {

--- a/web/src/components/ProjectHealth.tsx
+++ b/web/src/components/ProjectHealth.tsx
@@ -25,6 +25,13 @@ export function ProjectHealth({
 
   // Primary repo for links
   const primaryRepo = repositories[0];
+  const reposWithVisibilityRisk = repositories.filter(
+    (repo) => !repo.homepage || !repo.topics || repo.topics.length === 0
+  );
+  const hasVisibilityRisk = reposWithVisibilityRisk.length > 0;
+  const visibilityTitle = hasVisibilityRisk
+    ? `${reposWithVisibilityRisk.length} repos missing homepage or topics`
+    : 'Repository discoverability metadata looks healthy';
 
   // For multi-repo, we might want to link to the organization
   const orgUrl = isMultiRepo
@@ -123,6 +130,25 @@ export function ProjectHealth({
         </span>
         {activeProposalsCount} active{' '}
         {activeProposalsCount === 1 ? 'proposal' : 'proposals'}
+      </a>
+      <span className="text-amber-300 dark:text-neutral-600" aria-hidden="true">
+        |
+      </span>
+      <a
+        href={isMultiRepo ? orgUrl : primaryRepo.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-1 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
+        title={visibilityTitle}
+      >
+        <span role="img" aria-label="visibility">
+          {hasVisibilityRisk ? '🧭' : '✅'}
+        </span>
+        {hasVisibilityRisk
+          ? `${reposWithVisibilityRisk.length} visibility risk${
+              reposWithVisibilityRisk.length === 1 ? '' : 's'
+            }`
+          : 'visibility healthy'}
       </a>
     </div>
   );


### PR DESCRIPTION
## Summary
- add discoverability metadata (`homepage`, `description`, `topics`) to repository info generated by `scripts/generate-data.ts`
- surface a compact visibility signal in `ProjectHealth` that flags repos missing homepage/topics
- add tests for healthy and risky visibility states

## Why
Scout runs repeatedly found that external discoverability issues are easy to lose in issue comments, especially across stateless runs. This makes the signal visible directly in-product so blockers stay measurable and actionable.

## Validation
- `cd web && npx eslint .`
- `cd web && npx vitest run src/components/ProjectHealth.test.tsx scripts/__tests__/generate-data.test.ts`
- `npm --prefix web run build`

Related to #234
