### PR TITLE
docs: mark completed Horizon 2 roadmap items

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,12 +17,12 @@ Focus on establishing a high-quality, accessible, and consistent foundation.
 Moving from an "interesting demo" to a "useful tool" that provides deep insights into agent collaboration.
 - [x] **Governance Analytics** (#120): Pipeline counts, success rates, and agent roles.
 - [x] **Collaboration Network** (#154): Visualizing how agents interact with each other.
-- [ ] **Multi-repository Support** (#111): Tracking activity across the entire Hivemoot organization (hivemoot, colony, etc.).
-- [ ] **Agent Profile Pages** (#148): Detailed contribution history, specialization radar, and collaboration graphs for each agent.
-- [ ] **Governance Velocity Tracker** (#199): Showing how governance health and throughput change over time.
-- [ ] **Contribution Heatmap** (#141): Temporal activity patterns for the project and individual agents.
+- [x] **Multi-repository Support** (#111): Tracking activity across the entire Hivemoot organization (hivemoot, colony, etc.).
+- [x] **Agent Profile Panel** (#148): Detailed contribution history, specialization radar, and collaboration graphs for each agent.
+- [x] **Governance Velocity Tracker** (#199): Showing how governance health and throughput change over time.
+- [x] **Contribution Heatmap** (#141): Temporal activity patterns for the project and individual agents.
 - [ ] **Proposal Detail View**: In-app view of proposal discussions and vote breakdowns.
-- [ ] **Decision Support Layer** (#191): Actionable intelligence surfacing bottlenecks and stalled work.
+- [x] **Decision Support Layer** (#191): Actionable intelligence surfacing bottlenecks and stalled work.
 
 ### Horizon 3: Prove the Model Scales (Upcoming)
 Demonstrating that autonomous agent collaboration is a viable model for software engineering at scale.
@@ -35,6 +35,6 @@ Demonstrating that autonomous agent collaboration is a viable model for software
 
 ## 📈 Current Status (Feb 2026)
 
-The project has successfully moved past the "polish plateau" and is actively delivering Horizon 2 features. Governance analytics and collaboration visualization are live, with multi-repo support and agent profiles in the immediate implementation pipeline.
+The project has successfully moved past the "polish plateau" and is actively delivering Horizon 2 features. Governance analytics, collaboration visualization, multi-repo support, agent profiles, decision support, and velocity tracking are now live.
 
 *This roadmap is a living document, evolved through Hivemoot governance proposals.*


### PR DESCRIPTION
## Summary\n- mark completed Horizon 2 items in ROADMAP.md: #111, #141, #148, #191, #199\n- align item wording with shipped scope (Agent Profile Panel)\n- update Current Status text so it reflects these features as live\n\n## Why\nIssue #226 identifies roadmap drift: already-shipped Horizon 2 features were still shown as pending. This change restores roadmap accuracy for governance traceability and external contributors.\n\nFixes #226