### PR TITLE
feat(web): add sticky dashboard section nav

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -177,6 +177,41 @@ describe('App', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders sticky dashboard section navigation with hash links', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockActivityData),
+    } as Response);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('navigation', { name: /dashboard sections/i })
+      ).toBeInTheDocument();
+    });
+
+    const sectionNav = screen.getByRole('navigation', {
+      name: /dashboard sections/i,
+    });
+
+    expect(
+      sectionNav.querySelector<HTMLAnchorElement>('a[href="#main-content"]')
+    ).toHaveTextContent(/overview/i);
+    expect(
+      sectionNav.querySelector<HTMLAnchorElement>('a[href="#activity"]')
+    ).toHaveTextContent(/activity/i);
+    expect(
+      sectionNav.querySelector<HTMLAnchorElement>('a[href="#intelligence"]')
+    ).toHaveTextContent(/intelligence/i);
+    expect(
+      sectionNav.querySelector<HTMLAnchorElement>('a[href="#proposals"]')
+    ).toHaveTextContent(/governance/i);
+    expect(
+      sectionNav.querySelector<HTMLAnchorElement>('a[href="#agents"]')
+    ).toHaveTextContent(/agents/i);
+  });
+
   it('renders leaderboard with agent stats', async () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,14 @@ import { ActivityFeed } from './components/ActivityFeed';
 import { ProjectHealth } from './components/ProjectHealth';
 import { ErrorBoundary } from './components/ErrorBoundary';
 
+const STICKY_NAV_LINKS = [
+  { href: '#main-content', label: 'Overview' },
+  { href: '#activity', label: 'Activity' },
+  { href: '#intelligence', label: 'Intelligence' },
+  { href: '#proposals', label: 'Governance' },
+  { href: '#agents', label: 'Agents' },
+] as const;
+
 function App(): React.ReactElement {
   const {
     data,
@@ -60,7 +68,27 @@ function App(): React.ReactElement {
         </p>
       </header>
 
-      <main id="main-content" className="flex-1 w-full max-w-6xl">
+      <main id="main-content" className="flex-1 w-full max-w-6xl scroll-mt-28">
+        {hasActivity && !loading && (
+          <nav
+            aria-label="Dashboard sections"
+            className="sticky top-2 z-40 mb-5 rounded-xl border border-amber-200/90 dark:border-neutral-600/90 bg-white/85 dark:bg-neutral-800/85 backdrop-blur-md shadow-sm"
+          >
+            <ul className="flex items-center gap-2 overflow-x-auto px-3 py-2 sm:justify-center">
+              {STICKY_NAV_LINKS.map((link) => (
+                <li key={link.href} className="shrink-0">
+                  <a
+                    href={link.href}
+                    className="inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium text-amber-800 dark:text-amber-100 hover:bg-amber-100 dark:hover:bg-neutral-700 motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"
+                  >
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
+
         {loading && (
           <div className="text-center py-12" role="status" aria-live="polite">
             <div

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -72,8 +72,9 @@ export function ActivityFeed({
   return (
     <div className="w-full max-w-6xl mx-auto space-y-8">
       <section
+        id="activity"
         aria-labelledby="section-live-feed"
-        className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+        className="scroll-mt-28 bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
       >
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
@@ -157,7 +158,7 @@ export function ActivityFeed({
         <section
           id="agents"
           aria-labelledby="section-agents"
-          className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+          className="scroll-mt-28 bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
         >
           <h2
             id="section-agents"
@@ -215,7 +216,7 @@ export function ActivityFeed({
           {data && data.proposals.length > 0 && (
             <section
               id="intelligence"
-              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+              className="scroll-mt-28 bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
             >
               <h2 className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2">
                 <span role="img" aria-label="intelligence">
@@ -231,7 +232,7 @@ export function ActivityFeed({
             <section
               id="proposals"
               aria-labelledby="section-proposals"
-              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+              className="scroll-mt-28 bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
             >
               <h2
                 id="section-proposals"


### PR DESCRIPTION
## Summary
- Add sticky in-page section navigation for long dashboard scrolls
- Keep top-level project navigation sticky at the top
- Improve anchor target alignment with `scroll-mt` offsets

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build

Fixes #231