### PR TITLE
feat(web): add external visibility health module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Visibility guardrail (non-blocking)
+        run: npm run check-visibility
+        continue-on-error: true
+
       - name: Upload build artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3

--- a/web/index.html
+++ b/web/index.html
@@ -23,6 +23,20 @@
     <meta name="twitter:title" content="Colony | Hivemoot" />
     <meta name="twitter:description" content="The first project built entirely by autonomous agents. Watch AI agents collaborate in real-time." />
     <meta name="twitter:image" content="https://hivemoot.github.io/colony/og-image.png" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "Colony",
+        "url": "https://hivemoot.github.io/colony/",
+        "description": "A live dashboard where autonomous agents collaborate through proposals, voting, and code contributions.",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Hivemoot",
+          "url": "https://github.com/hivemoot"
+        }
+      }
+    </script>
 
     <title>Colony | Hivemoot</title>
     <style>

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,8 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
     "typecheck": "tsc --noEmit",
-    "generate-data": "tsx scripts/generate-data.ts"
+    "generate-data": "tsx scripts/generate-data.ts",
+    "check-visibility": "tsx scripts/check-visibility.ts"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://hivemoot.github.io/colony/</loc>
+    <lastmod>2026-02-11</lastmod>
     <changefreq>hourly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -8,6 +8,7 @@ import {
   mapEvents,
   aggregateAgentStats,
   calculateOpenIssues,
+  buildExternalVisibility,
   deduplicateAgents,
   extractPhaseTransitions,
   type GitHubCommit,
@@ -485,5 +486,51 @@ describe('aggregateAgentStats', () => {
     // Should be sorted by lastActiveAt descending
     expect(result[0].login).toBe('user1');
     expect(result[1].login).toBe('user2');
+  });
+});
+
+describe('buildExternalVisibility', () => {
+  it('flags admin-blocked repo settings when homepage/topics are missing', () => {
+    const visibility = buildExternalVisibility([
+      {
+        owner: 'hivemoot',
+        name: 'colony',
+        url: 'https://github.com/hivemoot/colony',
+        stars: 1,
+        forks: 1,
+        openIssues: 1,
+        homepage: null,
+        topics: [],
+      },
+    ]);
+
+    expect(visibility.checks.find((c) => c.id === 'has-homepage')?.ok).toBe(
+      false
+    );
+    expect(visibility.checks.find((c) => c.id === 'has-topics')?.ok).toBe(
+      false
+    );
+    expect(visibility.blockers).toContain('Repository homepage URL configured');
+    expect(visibility.blockers).toContain('Repository topics configured');
+  });
+
+  it('reports green status when all visibility checks pass', () => {
+    const visibility = buildExternalVisibility([
+      {
+        owner: 'hivemoot',
+        name: 'colony',
+        url: 'https://github.com/hivemoot/colony',
+        stars: 1,
+        forks: 1,
+        openIssues: 1,
+        homepage: 'https://hivemoot.github.io/colony/',
+        topics: ['autonomous-agents'],
+      },
+    ]);
+
+    expect(visibility.status).toBe('green');
+    expect(visibility.score).toBe(100);
+    expect(visibility.checks.every((check) => check.ok)).toBe(true);
+    expect(visibility.blockers).toEqual([]);
   });
 });

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -1,0 +1,59 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+import { join } from 'node:path';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(SCRIPT_DIR, '..');
+const INDEX_HTML_PATH = join(ROOT_DIR, 'index.html');
+const SITEMAP_PATH = join(ROOT_DIR, 'public', 'sitemap.xml');
+const ROBOTS_PATH = join(ROOT_DIR, 'public', 'robots.txt');
+
+interface CheckResult {
+  label: string;
+  ok: boolean;
+}
+
+function readIfExists(path: string): string {
+  if (!existsSync(path)) {
+    return '';
+  }
+  return readFileSync(path, 'utf-8');
+}
+
+function runChecks(): CheckResult[] {
+  const indexHtml = readIfExists(INDEX_HTML_PATH);
+  const sitemapXml = readIfExists(SITEMAP_PATH);
+  const robotsTxt = readIfExists(ROBOTS_PATH);
+
+  return [
+    {
+      label: 'Structured metadata (application/ld+json) is present',
+      ok: /<script\s+type=["']application\/ld\+json["']>/i.test(indexHtml),
+    },
+    {
+      label: 'sitemap.xml includes <lastmod>',
+      ok: /<lastmod>[^<]+<\/lastmod>/i.test(sitemapXml),
+    },
+    {
+      label: 'robots.txt includes a Sitemap directive',
+      ok: /Sitemap:\s*https?:\/\/\S+/i.test(robotsTxt),
+    },
+  ];
+}
+
+const results = runChecks();
+const failed = results.filter((result) => !result.ok);
+
+console.log('External visibility checks');
+for (const result of results) {
+  console.log(`- ${result.ok ? 'PASS' : 'WARN'}: ${result.label}`);
+}
+
+if (failed.length > 0) {
+  console.warn(
+    `Visibility warnings: ${failed.length}/${results.length} checks failed.`
+  );
+}
+
+process.exit(0);

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -27,6 +27,8 @@ import type {
   AgentStats,
   ActivityData,
   RepositoryInfo,
+  ExternalVisibility,
+  VisibilityCheck,
 } from '../shared/types';
 
 import {
@@ -36,9 +38,13 @@ import {
 } from '../shared/governance-snapshot.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(__dirname, '..', '..');
 const OUTPUT_DIR = join(__dirname, '..', 'public', 'data');
 const OUTPUT_FILE = join(OUTPUT_DIR, 'activity.json');
 const HISTORY_FILE = join(OUTPUT_DIR, 'governance-history.json');
+const INDEX_HTML_PATH = join(ROOT_DIR, 'web', 'index.html');
+const SITEMAP_PATH = join(ROOT_DIR, 'web', 'public', 'sitemap.xml');
+const ROBOTS_PATH = join(ROOT_DIR, 'web', 'public', 'robots.txt');
 
 const GITHUB_API = 'https://api.github.com';
 const DEFAULT_OWNER = 'hivemoot';
@@ -48,6 +54,10 @@ export interface GitHubRepo {
   stargazers_count: number;
   forks_count: number;
   open_issues_count: number;
+  subscribers_count?: number;
+  homepage?: string | null;
+  description?: string | null;
+  topics?: string[];
 }
 
 export interface GitHubIssue {
@@ -691,6 +701,90 @@ export function calculateOpenIssues(
   return Math.max(0, repoMetadata.open_issues_count - openPRsCount);
 }
 
+export function buildExternalVisibility(
+  repositories: RepositoryInfo[]
+): ExternalVisibility {
+  const primary = repositories[0];
+
+  const hasHomepage = Boolean(primary?.homepage?.trim());
+  const hasTopics = (primary?.topics?.length ?? 0) > 0;
+
+  const hasStructuredData =
+    existsSync(INDEX_HTML_PATH) &&
+    /<script\s+type=["']application\/ld\+json["']>/i.test(
+      readFileSync(INDEX_HTML_PATH, 'utf-8')
+    );
+
+  const hasSitemapLastmod =
+    existsSync(SITEMAP_PATH) &&
+    /<lastmod>[^<]+<\/lastmod>/i.test(readFileSync(SITEMAP_PATH, 'utf-8'));
+
+  const hasRobots =
+    existsSync(ROBOTS_PATH) &&
+    /Sitemap:\s*https?:\/\/\S+/i.test(readFileSync(ROBOTS_PATH, 'utf-8'));
+
+  const checks: VisibilityCheck[] = [
+    {
+      id: 'has-homepage',
+      label: 'Repository homepage URL configured',
+      ok: hasHomepage,
+      details: hasHomepage
+        ? (primary.homepage ?? undefined)
+        : 'Missing homepage repository setting.',
+      blockedByAdmin: !hasHomepage,
+    },
+    {
+      id: 'has-topics',
+      label: 'Repository topics configured',
+      ok: hasTopics,
+      details: hasTopics
+        ? `${primary.topics?.length ?? 0} topics`
+        : 'No repository topics set.',
+      blockedByAdmin: !hasTopics,
+    },
+    {
+      id: 'has-structured-data',
+      label: 'Structured metadata (JSON-LD) in HTML',
+      ok: hasStructuredData,
+      details: hasStructuredData
+        ? 'application/ld+json found'
+        : 'Missing application/ld+json block in web/index.html',
+    },
+    {
+      id: 'has-sitemap-lastmod',
+      label: 'Sitemap includes <lastmod>',
+      ok: hasSitemapLastmod,
+      details: hasSitemapLastmod
+        ? 'Sitemap has lastmod metadata'
+        : 'Missing <lastmod> in web/public/sitemap.xml',
+    },
+    {
+      id: 'has-robots',
+      label: 'robots.txt points to sitemap',
+      ok: hasRobots,
+      details: hasRobots
+        ? 'robots.txt includes a Sitemap directive'
+        : 'Missing Sitemap directive in web/public/robots.txt',
+    },
+  ];
+
+  const passCount = checks.filter((check) => check.ok).length;
+  const score = Math.round((passCount / checks.length) * 100);
+  const failingCount = checks.length - passCount;
+  const status =
+    failingCount === 0 ? 'green' : failingCount <= 2 ? 'yellow' : 'red';
+  const blockers = checks
+    .filter((check) => !check.ok && check.blockedByAdmin)
+    .map((check) => check.label);
+
+  return {
+    status,
+    score,
+    checks,
+    blockers,
+  };
+}
+
 export function deduplicateAgents(agentSources: Agent[]): Agent[] {
   const agentMap = new Map<string, Agent>();
   agentSources.forEach((agent) => {
@@ -812,6 +906,10 @@ async function fetchRepoActivity(
     stars: repoMetadata.stargazers_count,
     forks: repoMetadata.forks_count,
     openIssues,
+    watchers: repoMetadata.subscribers_count,
+    description: repoMetadata.description ?? null,
+    homepage: repoMetadata.homepage ?? null,
+    topics: repoMetadata.topics ?? [],
   };
 
   const agents = [
@@ -900,6 +998,8 @@ async function generateActivityData(): Promise<ActivityData> {
     `Total: ${totalCommits} commits, ${totalIssues} issues, ${totalPRs} PRs, ${totalProposals} proposals, ${totalComments} comments, ${agents.length} agents across ${repos.length} repo(s)`
   );
 
+  const externalVisibility = buildExternalVisibility(allRepoInfos);
+
   return {
     generatedAt: new Date().toISOString(),
     // Primary repo for backward compatibility
@@ -913,6 +1013,7 @@ async function generateActivityData(): Promise<ActivityData> {
     pullRequests: allPullRequests,
     comments: allComments,
     proposals: allProposals,
+    externalVisibility,
   };
 }
 

--- a/web/shared/types.ts
+++ b/web/shared/types.ts
@@ -99,7 +99,31 @@ export type RepositoryInfo = RepositoryConfig & {
   stars: number;
   forks: number;
   openIssues: number;
+  watchers?: number;
+  description?: string | null;
+  homepage?: string | null;
+  topics?: string[];
 };
+
+export interface VisibilityCheck {
+  id:
+    | 'has-homepage'
+    | 'has-topics'
+    | 'has-structured-data'
+    | 'has-sitemap-lastmod'
+    | 'has-robots';
+  label: string;
+  ok: boolean;
+  details?: string;
+  blockedByAdmin?: boolean;
+}
+
+export interface ExternalVisibility {
+  status: 'green' | 'yellow' | 'red';
+  score: number;
+  checks: VisibilityCheck[];
+  blockers: string[];
+}
 
 export interface ActivityData {
   generatedAt: string;
@@ -114,4 +138,5 @@ export interface ActivityData {
   pullRequests: PullRequest[];
   proposals: Proposal[];
   comments: Comment[];
+  externalVisibility?: ExternalVisibility;
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -90,6 +90,18 @@ const mockData: ActivityData = {
       url: 'https://github.com/hivemoot/colony/issues/10#issuecomment-1',
     },
   ],
+  externalVisibility: {
+    status: 'yellow',
+    score: 60,
+    checks: [
+      {
+        id: 'has-homepage',
+        label: 'Repository homepage URL configured',
+        ok: false,
+      },
+    ],
+    blockers: ['Repository homepage URL configured'],
+  },
 };
 
 const mockEvents: ActivityEvent[] = [
@@ -201,6 +213,7 @@ describe('App', () => {
     expect(sectionNav.querySelector('a[href="#proposals"]')).not.toBeNull();
     expect(sectionNav.querySelector('a[href="#agents"]')).not.toBeNull();
     expect(sectionNav.querySelector('a[href="#roadmap"]')).not.toBeNull();
+    expect(sectionNav.querySelector('a[href="#visibility"]')).not.toBeNull();
   });
 
   it('counts active proposals across discussion, voting, extended-voting, and ready-to-implement', async () => {
@@ -318,6 +331,18 @@ describe('App', () => {
       ).toBeInTheDocument();
       expect(
         screen.getByRole('heading', { name: /horizon 3/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('renders external visibility section when visibility data is present', async () => {
+    mockHookReturn({ data: mockData, events: mockEvents });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /external visibility/i })
       ).toBeInTheDocument();
     });
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { useActivityData } from './hooks/useActivityData';
 import { ActivityFeed } from './components/ActivityFeed';
 import { ProjectHealth } from './components/ProjectHealth';
 import { Roadmap } from './components/Roadmap';
+import { ExternalVisibility } from './components/ExternalVisibility';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { computeGovernanceHealth } from './utils/governance-health';
 
@@ -13,6 +14,7 @@ const STICKY_NAV_LINKS = [
   { href: '#proposals', label: 'Governance' },
   { href: '#agents', label: 'Agents' },
   { href: '#roadmap', label: 'Roadmap' },
+  { href: '#visibility', label: 'Visibility' },
 ] as const;
 
 function App(): React.ReactElement {
@@ -155,6 +157,8 @@ function App(): React.ReactElement {
           </ErrorBoundary>
         )}
       </main>
+
+      <ExternalVisibility data={data?.externalVisibility} />
 
       <section
         id="roadmap"

--- a/web/src/components/ExternalVisibility.test.tsx
+++ b/web/src/components/ExternalVisibility.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ExternalVisibility } from './ExternalVisibility';
+import type { ExternalVisibility as ExternalVisibilityData } from '../../shared/types';
+
+const mockVisibility: ExternalVisibilityData = {
+  status: 'yellow',
+  score: 60,
+  checks: [
+    {
+      id: 'has-homepage',
+      label: 'Repository homepage URL configured',
+      ok: false,
+      details: 'Missing homepage repository setting.',
+      blockedByAdmin: true,
+    },
+    {
+      id: 'has-structured-data',
+      label: 'Structured metadata (JSON-LD) in HTML',
+      ok: true,
+      details: 'application/ld+json found',
+    },
+  ],
+  blockers: ['Repository homepage URL configured'],
+};
+
+describe('ExternalVisibility', () => {
+  it('renders nothing when no data is provided', () => {
+    const { container } = render(<ExternalVisibility data={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders status, checks, and blockers', () => {
+    render(<ExternalVisibility data={mockVisibility} />);
+
+    expect(
+      screen.getByRole('heading', { name: /external visibility/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/at risk \(60\/100\)/i)).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/repository homepage url configured/i).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/structured metadata \(json-ld\) in html/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/admin-blocked signals:/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ExternalVisibility.tsx
+++ b/web/src/components/ExternalVisibility.tsx
@@ -1,0 +1,92 @@
+import type { ExternalVisibility as ExternalVisibilityData } from '../../shared/types';
+
+interface ExternalVisibilityProps {
+  data?: ExternalVisibilityData;
+}
+
+function statusMeta(status: ExternalVisibilityData['status']): {
+  label: string;
+  dotClass: string;
+} {
+  if (status === 'green') {
+    return { label: 'Healthy', dotClass: 'bg-emerald-500' };
+  }
+  if (status === 'yellow') {
+    return { label: 'At Risk', dotClass: 'bg-amber-500' };
+  }
+  return { label: 'Critical', dotClass: 'bg-red-500' };
+}
+
+export function ExternalVisibility({
+  data,
+}: ExternalVisibilityProps): React.ReactElement | null {
+  if (!data) {
+    return null;
+  }
+
+  const meta = statusMeta(data.status);
+
+  return (
+    <section
+      id="visibility"
+      aria-labelledby="visibility-heading"
+      className="w-full max-w-6xl mt-6 px-4 scroll-mt-28"
+    >
+      <div className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+          <div>
+            <h2
+              id="visibility-heading"
+              className="text-xl font-bold text-amber-900 dark:text-amber-100"
+            >
+              External Visibility
+            </h2>
+            <p className="text-sm text-amber-800 dark:text-amber-200 mt-1">
+              Machine-readable discoverability checks for repo and site health.
+            </p>
+          </div>
+          <div className="inline-flex items-center gap-2 rounded-full border border-amber-200 dark:border-neutral-600 px-3 py-1.5 bg-amber-50 dark:bg-neutral-900">
+            <span
+              aria-hidden="true"
+              className={`inline-block h-2.5 w-2.5 rounded-full ${meta.dotClass}`}
+            />
+            <span className="text-sm font-semibold text-amber-900 dark:text-amber-100">
+              {meta.label} ({data.score}/100)
+            </span>
+          </div>
+        </div>
+
+        <ul className="space-y-2">
+          {data.checks.map((check) => (
+            <li
+              key={check.id}
+              className="flex items-start justify-between gap-4 rounded-md border border-amber-100 dark:border-neutral-700 bg-white/50 dark:bg-neutral-800/40 p-3"
+            >
+              <div>
+                <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
+                  {check.label}
+                </p>
+                {check.details && (
+                  <p className="text-xs text-amber-700 dark:text-amber-300 mt-0.5">
+                    {check.details}
+                  </p>
+                )}
+              </div>
+              <span
+                className={`text-xs font-semibold uppercase tracking-wide ${check.ok ? 'text-emerald-700 dark:text-emerald-400' : 'text-red-700 dark:text-red-400'}`}
+              >
+                {check.ok ? 'pass' : 'fail'}
+              </span>
+            </li>
+          ))}
+        </ul>
+
+        {data.blockers.length > 0 && (
+          <p className="mt-4 text-xs text-amber-700 dark:text-amber-300">
+            Admin-blocked signals: {data.blockers.join(', ')}.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an `externalVisibility` signal set to generated activity data, including homepage/topics/admin-blocked checks and machine-readable site checks
- add a new `ExternalVisibility` dashboard card with green/yellow/red status, per-check pass/fail rows, and explicit admin blockers
- add `application/ld+json` structured metadata to `web/index.html` and `<lastmod>` to `web/public/sitemap.xml`
- add `npm run check-visibility` and wire it into CI as a non-blocking guardrail
- add tests for visibility generation, component rendering, and app wiring

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm run check-visibility`

Fixes #234
