### PR TITLE
fix(web): properly encode bot handles in avatar URLs

### DIFF
--- a/web/src/components/ActivityTimeline.test.tsx
+++ b/web/src/components/ActivityTimeline.test.tsx
@@ -221,14 +221,14 @@ describe('ActivityTimeline', () => {
     expect(timeEl).toHaveAttribute('datetime', '2026-02-05T10:00:00Z');
   });
 
-  it('renders actor avatars', () => {
+  it('renders actor avatars with proper encoding', () => {
     const events: ActivityEvent[] = [
       {
         id: 'commit-1',
         type: 'commit',
         summary: 'Commit pushed',
         title: 'Test',
-        actor: 'worker',
+        actor: 'hivemoot[bot]',
         createdAt: '2026-02-05T10:00:00Z',
       },
     ];
@@ -236,7 +236,10 @@ describe('ActivityTimeline', () => {
     const { container } = render(<ActivityTimeline events={events} />);
 
     const avatar = container.querySelector('img');
-    expect(avatar).toHaveAttribute('src', 'https://github.com/worker.png');
+    expect(avatar).toHaveAttribute(
+      'src',
+      'https://github.com/hivemoot%5Bbot%5D.png'
+    );
     expect(avatar).toHaveAttribute('alt', '');
     expect(avatar).toHaveAttribute('loading', 'lazy');
   });

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -1,6 +1,6 @@
 import type { ActivityEvent, ActivityEventType } from '../types/activity';
 import { formatTimeAgo } from '../utils/time';
-import { handleAvatarError } from '../utils/avatar';
+import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
 
 interface ActivityTimelineProps {
   events: ActivityEvent[];
@@ -116,7 +116,7 @@ export function ActivityTimeline({
               )}
               <div className="flex items-center gap-1.5 mt-1">
                 <img
-                  src={`https://github.com/${event.actor}.png`}
+                  src={getGitHubAvatarUrl(event.actor)}
                   alt=""
                   loading="lazy"
                   className="w-4 h-4 rounded-full border border-amber-200 dark:border-neutral-600"

--- a/web/src/components/AgentLeaderboard.tsx
+++ b/web/src/components/AgentLeaderboard.tsx
@@ -1,6 +1,6 @@
 import type { AgentStats } from '../types/activity';
 import { formatTimeAgo } from '../utils/time';
-import { handleAvatarError } from '../utils/avatar';
+import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
 
 interface AgentLeaderboardProps {
   stats: AgentStats[];
@@ -91,10 +91,7 @@ export function AgentLeaderboard({
                       #{index + 1}
                     </span>
                     <img
-                      src={
-                        agent.avatarUrl ||
-                        `https://github.com/${agent.login}.png`
-                      }
+                      src={agent.avatarUrl || getGitHubAvatarUrl(agent.login)}
                       alt=""
                       loading="lazy"
                       className={`w-8 h-8 rounded-full border motion-safe:transition-colors ${

--- a/web/src/components/AgentList.test.tsx
+++ b/web/src/components/AgentList.test.tsx
@@ -6,6 +6,7 @@ import type { Agent } from '../types/activity';
 const agents: Agent[] = [
   { login: 'agent-1', avatarUrl: 'https://github.com/agent-1.png' },
   { login: 'agent-2' },
+  { login: 'hivemoot[bot]' },
 ];
 
 describe('AgentList', () => {
@@ -21,18 +22,22 @@ describe('AgentList', () => {
     expect(screen.getByText('agent-2')).toBeInTheDocument();
 
     const images = container.querySelectorAll('img');
-    expect(images).toHaveLength(2);
+    expect(images).toHaveLength(3);
     expect(images[0]).toHaveAttribute('src', 'https://github.com/agent-1.png');
-    expect(images[0]).toHaveAttribute('alt', '');
-    expect(images[0]).toHaveAttribute('loading', 'lazy');
     expect(images[1]).toHaveAttribute('src', 'https://github.com/agent-2.png');
-    expect(images[1]).toHaveAttribute('alt', '');
-    expect(images[1]).toHaveAttribute('loading', 'lazy');
+    expect(images[2]).toHaveAttribute(
+      'src',
+      'https://github.com/hivemoot%5Bbot%5D.png'
+    );
 
     const links = screen.getAllByRole('link');
-    expect(links).toHaveLength(2);
+    expect(links).toHaveLength(3);
     expect(links[0]).toHaveAttribute('href', 'https://github.com/agent-1');
     expect(links[1]).toHaveAttribute('href', 'https://github.com/agent-2');
+    expect(links[2]).toHaveAttribute(
+      'href',
+      'https://github.com/hivemoot[bot]'
+    );
   });
 
   it('renders interactive buttons for agent selection', () => {

--- a/web/src/components/AgentList.tsx
+++ b/web/src/components/AgentList.tsx
@@ -1,5 +1,5 @@
 import type { Agent } from '../types/activity';
-import { handleAvatarError } from '../utils/avatar';
+import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
 
 interface AgentListProps {
   agents: Agent[];
@@ -54,9 +54,7 @@ export function AgentList({
             >
               <div className="relative">
                 <img
-                  src={
-                    agent.avatarUrl || `https://github.com/${agent.login}.png`
-                  }
+                  src={agent.avatarUrl || getGitHubAvatarUrl(agent.login)}
                   alt=""
                   loading="lazy"
                   className={`w-12 h-12 rounded-full border-2 motion-safe:transition-colors ${

--- a/web/src/components/AgentProfilePanel.tsx
+++ b/web/src/components/AgentProfilePanel.tsx
@@ -11,7 +11,7 @@ import {
   type AgentRoleProfile,
 } from '../utils/governance';
 import { formatTimeAgo } from '../utils/time';
-import { handleAvatarError } from '../utils/avatar';
+import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
 import { AgentSpecialization } from './AgentSpecialization';
 
 interface AgentProfilePanelProps {
@@ -98,7 +98,7 @@ export function AgentProfilePanel({
   const avatarUrl =
     stats?.avatarUrl ??
     data.agents.find((a) => a.login === agentLogin)?.avatarUrl ??
-    `https://github.com/${agentLogin}.png`;
+    getGitHubAvatarUrl(agentLogin);
 
   return (
     <div className="space-y-6">

--- a/web/src/components/CommentList.tsx
+++ b/web/src/components/CommentList.tsx
@@ -1,6 +1,6 @@
 import type { Comment } from '../types/activity';
 import { formatTimeAgo } from '../utils/time';
-import { handleAvatarError } from '../utils/avatar';
+import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
 
 function formatCommentAction(type: Comment['type']): string {
   switch (type) {
@@ -46,7 +46,7 @@ export function CommentList({
           >
             <div className="flex items-center gap-1.5 mb-2">
               <img
-                src={`https://github.com/${comment.author}.png`}
+                src={getGitHubAvatarUrl(comment.author)}
                 alt=""
                 loading="lazy"
                 className="w-4 h-4 rounded-full border border-amber-200 dark:border-neutral-600"

--- a/web/src/components/CommitList.tsx
+++ b/web/src/components/CommitList.tsx
@@ -1,5 +1,5 @@
 import type { Commit } from '../types/activity';
-import { handleAvatarError } from '../utils/avatar';
+import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
 import { formatTimeAgo } from '../utils/time';
 
 interface CommitListProps {
@@ -42,7 +42,7 @@ export function CommitList({
             </p>
             <div className="flex items-center gap-1.5 mt-1">
               <img
-                src={`https://github.com/${commit.author}.png`}
+                src={getGitHubAvatarUrl(commit.author)}
                 alt=""
                 loading="lazy"
                 className="w-4 h-4 rounded-full border border-amber-200 dark:border-neutral-600"

--- a/web/src/components/GovernanceAnalytics.tsx
+++ b/web/src/components/GovernanceAnalytics.tsx
@@ -8,7 +8,7 @@ import {
   type ProposalPipelineCounts,
   type ThroughputMetrics,
 } from '../utils/governance';
-import { handleAvatarError } from '../utils/avatar';
+import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
 import { formatHours } from '../utils/time';
 
 interface GovernanceAnalyticsProps {
@@ -235,7 +235,7 @@ function AgentRoleBar({
     <div className="flex items-center gap-3">
       <div className="flex items-center gap-1.5 w-36 min-w-0 shrink-0">
         <img
-          src={agent.avatarUrl ?? `https://github.com/${agent.login}.png`}
+          src={agent.avatarUrl ?? getGitHubAvatarUrl(agent.login)}
           alt=""
           loading="lazy"
           className="w-5 h-5 rounded-full border border-amber-200 dark:border-neutral-600"

--- a/web/src/components/IssueList.test.tsx
+++ b/web/src/components/IssueList.test.tsx
@@ -205,14 +205,14 @@ describe('IssueList', () => {
     expect(timeEl).toHaveAttribute('datetime', closedAt);
   });
 
-  it('renders author avatar and handle', () => {
+  it('renders author avatar and handle with proper encoding', () => {
     const issues: Issue[] = [
       {
         number: 1,
         title: 'Test issue',
         state: 'open',
         labels: [],
-        author: 'scout',
+        author: 'hivemoot[bot]',
         createdAt: '2026-02-05T09:00:00Z',
       },
     ];
@@ -221,10 +221,13 @@ describe('IssueList', () => {
       <IssueList issues={issues} repoUrl={repoUrl} />
     );
 
-    expect(screen.getByText('scout')).toBeInTheDocument();
+    expect(screen.getByText('hivemoot[bot]')).toBeInTheDocument();
     const avatar = container.querySelector('img');
     expect(avatar).toBeInTheDocument();
-    expect(avatar).toHaveAttribute('src', 'https://github.com/scout.png');
+    expect(avatar).toHaveAttribute(
+      'src',
+      'https://github.com/hivemoot%5Bbot%5D.png'
+    );
     expect(avatar).toHaveAttribute('alt', '');
     expect(avatar).toHaveAttribute('loading', 'lazy');
   });

--- a/web/src/components/IssueList.tsx
+++ b/web/src/components/IssueList.tsx
@@ -1,5 +1,5 @@
 import type { Issue } from '../types/activity';
-import { handleAvatarError } from '../utils/avatar';
+import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
 import { formatTimeAgo } from '../utils/time';
 
 interface IssueListProps {
@@ -73,7 +73,7 @@ export function IssueList({
             )}
             <div className="flex items-center gap-1.5 mt-1.5">
               <img
-                src={`https://github.com/${issue.author}.png`}
+                src={getGitHubAvatarUrl(issue.author)}
                 alt=""
                 loading="lazy"
                 className="w-4 h-4 rounded-full border border-amber-200 dark:border-neutral-600"

--- a/web/src/components/ProposalList.tsx
+++ b/web/src/components/ProposalList.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import type { Proposal, PullRequest } from '../types/activity';
-import { handleAvatarError } from '../utils/avatar';
+import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
 import { formatDuration, formatTimeAgo } from '../utils/time';
 import { buildDecisionSnapshot } from '../utils/decision-explorer';
 
@@ -86,7 +86,7 @@ export function ProposalList({
                 <div className="flex items-center justify-between mt-auto pt-2 border-t border-amber-100/50 dark:border-neutral-700/50">
                   <div className="flex items-center gap-2">
                     <img
-                      src={`https://github.com/${proposal.author}.png`}
+                      src={getGitHubAvatarUrl(proposal.author)}
                       alt=""
                       loading="lazy"
                       className="w-4 h-4 rounded-full border border-amber-200 dark:border-neutral-600"

--- a/web/src/components/PullRequestList.test.tsx
+++ b/web/src/components/PullRequestList.test.tsx
@@ -57,15 +57,16 @@ describe('PullRequestList', () => {
     expect(screen.getByText('closed')).toBeInTheDocument();
   });
 
-  it('renders author avatar images', () => {
+  it('renders author avatar images with proper encoding', () => {
+    const botPR: PullRequest = { ...basePR, author: 'hivemoot[bot]' };
     const { container } = render(
-      <PullRequestList pullRequests={[basePR]} repoUrl={REPO_URL} />
+      <PullRequestList pullRequests={[botPR]} repoUrl={REPO_URL} />
     );
 
     const avatar = container.querySelector('img');
     expect(avatar).toHaveAttribute(
       'src',
-      'https://github.com/hivemoot-builder.png'
+      'https://github.com/hivemoot%5Bbot%5D.png'
     );
     expect(avatar).toHaveAttribute('alt', '');
     expect(avatar).toHaveAttribute('loading', 'lazy');

--- a/web/src/components/PullRequestList.tsx
+++ b/web/src/components/PullRequestList.tsx
@@ -1,5 +1,5 @@
 import type { PullRequest } from '../types/activity';
-import { handleAvatarError } from '../utils/avatar';
+import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
 import { formatTimeAgo } from '../utils/time';
 
 interface PullRequestListProps {
@@ -56,7 +56,7 @@ export function PullRequestList({
             </p>
             <div className="flex items-center gap-1.5 mt-1">
               <img
-                src={`https://github.com/${pr.author}.png`}
+                src={getGitHubAvatarUrl(pr.author)}
                 alt=""
                 loading="lazy"
                 className="w-4 h-4 rounded-full border border-amber-200 dark:border-neutral-600"

--- a/web/src/utils/avatar.test.ts
+++ b/web/src/utils/avatar.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { handleAvatarError, AVATAR_FALLBACK_SRC } from './avatar';
+import {
+  getGitHubAvatarUrl,
+  handleAvatarError,
+  AVATAR_FALLBACK_SRC,
+} from './avatar';
 import type React from 'react';
 
 describe('avatar utility', () => {
@@ -34,5 +38,32 @@ describe('avatar utility', () => {
     handleAvatarError(mockEvent);
 
     expect(mockImage.src).toBe(AVATAR_FALLBACK_SRC);
+  });
+});
+
+describe('getGitHubAvatarUrl', () => {
+  it('returns valid URL for normal logins', () => {
+    expect(getGitHubAvatarUrl('octocat')).toBe(
+      'https://github.com/octocat.png'
+    );
+  });
+
+  it('properly encodes logins with brackets (bots)', () => {
+    // hivemoot[bot] -> hivemoot%5Bbot%5D
+    expect(getGitHubAvatarUrl('hivemoot[bot]')).toBe(
+      'https://github.com/hivemoot%5Bbot%5D.png'
+    );
+  });
+
+  it('handles empty or null logins gracefully', () => {
+    // @ts-expect-error - testing invalid input
+    expect(getGitHubAvatarUrl(null)).toBe(AVATAR_FALLBACK_SRC);
+    expect(getGitHubAvatarUrl('')).toBe(AVATAR_FALLBACK_SRC);
+  });
+
+  it('handles special characters in logins', () => {
+    expect(getGitHubAvatarUrl('user name')).toBe(
+      'https://github.com/user%20name.png'
+    );
   });
 });

--- a/web/src/utils/avatar.ts
+++ b/web/src/utils/avatar.ts
@@ -5,6 +5,15 @@ export const AVATAR_FALLBACK_SRC =
   'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🐝</text></svg>';
 
 /**
+ * Returns a safely encoded GitHub avatar URL for a given login.
+ * Handles bot handles with brackets (e.g. hivemoot[bot]) by URI encoding.
+ */
+export function getGitHubAvatarUrl(login: string): string {
+  if (!login) return AVATAR_FALLBACK_SRC;
+  return `https://github.com/${encodeURIComponent(login)}.png`;
+}
+
+/**
  * Sets the bee fallback on avatar load error.
  *
  * Used as an onError handler for <img> elements that display agent avatars.


### PR DESCRIPTION
## Problem
Bot handles with brackets (e.g. `hivemoot[bot]`) were resulting in malformed avatar URLs and broken images in production.

## Solution
- Added `getGitHubAvatarUrl` utility in `web/src/utils/avatar.ts` that uses `encodeURIComponent`.
- Refactored all components to use this utility.
- Updated tests to verify encoding for bot handles.

## Validation
- `npm run test` (473 passing)
- `npm run lint`
- `npm run build`

Fixes #250