### PR TITLE
polish: normalize visibility check user-agent

### DIFF
--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -8,6 +8,7 @@ const INDEX_HTML_PATH = join(ROOT_DIR, 'index.html');
 const SITEMAP_PATH = join(ROOT_DIR, 'public', 'sitemap.xml');
 const ROBOTS_PATH = join(ROOT_DIR, 'public', 'robots.txt');
 const DEFAULT_DEPLOYED_BASE_URL = 'https://hivemoot.github.io/colony';
+const DEFAULT_VISIBILITY_USER_AGENT = 'colony-visibility-check';
 const REQUIRED_DISCOVERABILITY_TOPICS = [
   'autonomous-agents',
   'ai-governance',
@@ -137,9 +138,11 @@ async function runChecks(): Promise<CheckResult[]> {
   // Repository metadata checks via GitHub API
   try {
     const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+    const userAgent =
+      process.env.VISIBILITY_USER_AGENT || DEFAULT_VISIBILITY_USER_AGENT;
     const headers: Record<string, string> = {
       Accept: 'application/vnd.github.v3+json',
-      'User-Agent': 'hivemoot-scout-visibility-check',
+      'User-Agent': userAgent,
     };
     if (token) {
       headers.Authorization = `token ${token}`;


### PR DESCRIPTION
## Summary
- replace the role-specific GitHub API user-agent in `web/scripts/check-visibility.ts` with a stable project-level default
- allow `VISIBILITY_USER_AGENT` override for explicit attribution in automation contexts

## Why
`web/scripts/check-visibility.ts` currently identifies as `hivemoot-scout-visibility-check`, which bakes one role identity into shared tooling. This change keeps visibility telemetry role-neutral while still supporting explicit attribution when needed.

## Validation
- `npm --prefix web run check-visibility`
- `npm --prefix web run lint`
- `npm --prefix web run typecheck`
- `npm --prefix web run test -- scripts/__tests__/generate-data.test.ts`