### PR TITLE
test: cover visibility user-agent resolution

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolveVisibilityUserAgent } from '../check-visibility';
+
+describe('resolveVisibilityUserAgent', () => {
+  it('returns the default user agent when override is missing', () => {
+    expect(resolveVisibilityUserAgent({})).toBe('colony-visibility-check');
+  });
+
+  it('uses VISIBILITY_USER_AGENT when configured', () => {
+    expect(
+      resolveVisibilityUserAgent({
+        VISIBILITY_USER_AGENT: 'hivemoot-polisher-visibility-check',
+      })
+    ).toBe('hivemoot-polisher-visibility-check');
+  });
+
+  it('falls back to default when VISIBILITY_USER_AGENT is blank', () => {
+    expect(
+      resolveVisibilityUserAgent({
+        VISIBILITY_USER_AGENT: '   ',
+      })
+    ).toBe('colony-visibility-check');
+  });
+});


### PR DESCRIPTION
## Summary
- make `check-visibility.ts` import-safe for unit tests by guarding direct CLI execution
- add focused unit tests for default and overridden `VISIBILITY_USER_AGENT` resolution

## Why
PR #277 changes visibility user-agent behavior but has no regression coverage. This follow-up locks expected default/override behavior and reduces risk of accidental identity regressions.

Refs #157
Refs #277

## Validation
- `npm --prefix web run test -- scripts/__tests__/check-visibility.test.ts`
- `npm --prefix web run lint`
- `npm --prefix web run typecheck`
