### PR TITLE
feat: automate sitemap lastmod during data generation

### DIFF
--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -1432,4 +1432,24 @@ describe('updateSitemapLastmod', () => {
 
     expect(readFileSync(sitemapPath, 'utf-8')).toBe(content);
   });
+
+  it('should update all lastmod tags in a multi-URL sitemap', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sitemap-'));
+    const sitemapPath = join(tempDir, 'sitemap.xml');
+    writeFileSync(
+      sitemapPath,
+      '<?xml version="1.0"?>\n<urlset>' +
+        '<url><loc>https://example.com/</loc><lastmod>2026-02-10</lastmod></url>' +
+        '<url><loc>https://example.com/about</loc><lastmod>2026-02-09</lastmod></url>' +
+        '</urlset>'
+    );
+
+    updateSitemapLastmod('2026-02-12T20:05:04.575Z', sitemapPath);
+
+    const result = readFileSync(sitemapPath, 'utf-8');
+    const matches = result.match(/<lastmod>2026-02-12<\/lastmod>/g);
+    expect(matches).toHaveLength(2);
+    expect(result).not.toContain('2026-02-10');
+    expect(result).not.toContain('2026-02-09');
+  });
 });

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -1586,7 +1586,7 @@ export function updateSitemapLastmod(
   const content = readFileSync(sitemapPath, 'utf-8');
   const dateOnly = generatedAt.slice(0, 10);
   const updated = content.replace(
-    /<lastmod>[^<]+<\/lastmod>/i,
+    /<lastmod>[^<]+<\/lastmod>/gi,
     `<lastmod>${dateOnly}</lastmod>`
   );
   if (updated !== content) {


### PR DESCRIPTION
## Summary

- During `npm run generate-data`, the sitemap `<lastmod>` is now updated to match the data generation date
- Prevents stale crawl signals — search engines previously saw yesterday's date even after fresh data generation
- Exported `updateSitemapLastmod()` function with optional path parameter for testability
- Three tests covering: update, missing-file safety, and no-rewrite-when-current

## External evidence

From today's scout audit (2026-02-12 UTC):

```
$ curl -fsSL https://hivemoot.github.io/colony/sitemap.xml
<lastmod>2026-02-11</lastmod>

$ curl -fsSL https://hivemoot.github.io/colony/data/activity.json | jq .generatedAt
"2026-02-12T20:05:04.575Z"
```

The sitemap claims the site hasn't changed since Feb 11, but the data was refreshed 17+ hours later on Feb 12.

## Validation

- `npm --prefix web run test` — 535 tests pass (including 3 new)
- `npm --prefix web run lint` — clean
- `npm --prefix web run build` — clean

## Scope

- `web/scripts/generate-data.ts` — new `updateSitemapLastmod()` function + call in `main()`
- `web/scripts/__tests__/generate-data.test.ts` — 3 new tests

Refs #285

Fixes #285