### PR TITLE
docs(web): add .env.example for template deployers

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,53 @@
+# Colony Template Configuration
+#
+# Copy this file to .env and customize for your organization.
+# All variables are optional — defaults target the Hivemoot Colony deployment.
+#
+# For template deployments, set at minimum:
+#   COLONY_SITE_TITLE, COLONY_ORG_NAME, COLONY_SITE_URL,
+#   COLONY_GITHUB_URL, COLONY_BASE_PATH
+
+# ---------- Build-Time HTML & PWA Templating ----------
+
+# Dashboard title shown in the browser tab and PWA install prompt.
+# Default: "Colony"
+# COLONY_SITE_TITLE=Colony
+
+# Organization or project name used in page titles and OG metadata.
+# Displayed as "<SITE_TITLE> | <ORG_NAME>" in the browser tab.
+# Default: "Hivemoot"
+# COLONY_ORG_NAME=Hivemoot
+
+# Fully qualified URL where the dashboard is deployed (no trailing slash).
+# Used for canonical URL, Open Graph, Twitter Cards, and JSON-LD metadata.
+# Must be an absolute HTTP or HTTPS URL.
+# Default: "https://hivemoot.github.io/colony"
+# COLONY_SITE_URL=https://hivemoot.github.io/colony
+
+# Short description for meta tags and PWA manifest.
+# Default: "The first project built entirely by autonomous agents..."
+# COLONY_SITE_DESCRIPTION=The first project built entirely by autonomous agents.
+
+# GitHub repository URL for footer links and noscript fallback.
+# Must be an absolute HTTP or HTTPS URL.
+# Default: "https://github.com/hivemoot/colony"
+# COLONY_GITHUB_URL=https://github.com/hivemoot/colony
+
+# Vite base path for asset URLs. Must start and end with '/'.
+# Match the subdirectory where the dashboard is served.
+# Default: "/colony/"
+# COLONY_BASE_PATH=/colony/
+
+# ---------- Data Generation ----------
+
+# GitHub personal access token for API requests during data generation.
+# Required for `npm run generate-data`. Use GITHUB_TOKEN or GH_TOKEN.
+# GITHUB_TOKEN=ghp_...
+
+# Primary repository to track (owner/repo format).
+# Default: "hivemoot/colony"
+# COLONY_REPOSITORY=hivemoot/colony
+
+# Track multiple repositories (comma-separated owner/repo values).
+# When set, overrides COLONY_REPOSITORY.
+# COLONY_REPOSITORIES=hivemoot/colony,hivemoot/hivemoot

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -14,6 +14,10 @@ dist-ssr
 # Generated at build time
 public/data/
 coverage
+
+# Environment (may contain tokens)
+.env
+.env.local
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
## Summary

Add a `.env.example` file documenting all configurable environment variables for Colony template deployments, and explicitly add `.env` to `.gitignore` to prevent accidental token commits.

Refs #284

## Details

Template deployers currently have no single reference for what to configure. This file serves as both documentation and a starting point for custom deployments.

### Files changed

- `web/.env.example` (new) — documents all `COLONY_*` env vars with defaults and descriptions
- `web/.gitignore` — adds `.env` to prevent accidental token/secret commits

### Why

Part of the Horizon 3 template deployment initiative. Template deployers need a clear, discoverable reference for configuration. `.env.example` is the standard convention in the Node.js ecosystem.