### PR TITLE
fix(ui): derive roadmap phase badge from data

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -373,6 +373,50 @@ describe('App', () => {
     });
   });
 
+  it('derives current roadmap phase from the first incomplete horizon', async () => {
+    const dataWithRoadmap: ActivityData = {
+      ...mockData,
+      roadmap: {
+        horizons: [
+          {
+            id: 1,
+            title: 'Horizon 1: Complete the Polish Cycle',
+            subtitle: 'Polish baseline',
+            status: 'Done/Ongoing',
+            items: [{ task: 'A11y pass', done: true }],
+          },
+          {
+            id: 2,
+            title: 'Horizon 2: Make Colony Useful',
+            subtitle: 'Utility',
+            status: 'Done',
+            items: [{ task: 'Proposal detail view', done: true }],
+          },
+          {
+            id: 3,
+            title: 'Horizon 3: Prove the Model Scales',
+            subtitle: 'Scale',
+            status: 'Upcoming',
+            items: [{ task: 'Cross-project instances', done: false }],
+          },
+        ],
+        currentStatus: 'Horizon 3 is now the active focus.',
+      },
+    };
+
+    mockHookReturn({
+      data: dataWithRoadmap,
+      events: mockEvents,
+      lastUpdated: new Date(),
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/current phase: horizon 3/i)).toBeInTheDocument();
+    });
+  });
+
   it('shows back-to-top button after scrolling and scrolls smoothly on click', async () => {
     const scrollToSpy = vi.fn();
     vi.stubGlobal('scrollTo', scrollToSpy);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -40,6 +40,18 @@ function App(): React.ReactElement {
     () => (data ? computeGovernanceHealth(data) : null),
     [data]
   );
+  const currentRoadmapPhase = useMemo(() => {
+    const horizons = data?.roadmap?.horizons;
+    if (!horizons || horizons.length === 0) {
+      return 'Roadmap';
+    }
+
+    const activeHorizon =
+      horizons.find((horizon) => !/done|complete(d)?/i.test(horizon.status)) ??
+      horizons[horizons.length - 1];
+    const phaseLabel = activeHorizon.title.match(/^Horizon \d+/i);
+    return phaseLabel ? phaseLabel[0] : activeHorizon.title;
+  }, [data?.roadmap?.horizons]);
 
   useEffect(() => {
     const handleScroll = (): void => {
@@ -199,7 +211,7 @@ function App(): React.ReactElement {
                   </p>
                 </div>
                 <div className="text-sm font-medium text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-neutral-900 px-3 py-1 rounded-full border border-amber-200 dark:border-neutral-800">
-                  Current Phase: Horizon 2
+                  Current Phase: {currentRoadmapPhase}
                 </div>
               </div>
               <Roadmap data={data?.roadmap} />


### PR DESCRIPTION
## Summary
- replace the hardcoded roadmap badge text with a derived phase label from `roadmap.horizons`
- treat the first non-complete horizon as active and fall back safely when roadmap data is missing
- add an App regression test that locks expected behavior when Horizon 1 and 2 are complete

## Why
The UI still showed `Current Phase: Horizon 2` even after roadmap updates moved the project into Horizon 3, which creates a visible inconsistency for observers.

## Validation
- `cd web && npm run lint`
- `cd web && npm test -- --run src/App.test.tsx`

Fixes #288
