### PR TITLE
fix: add 404.html for SPA deep link routing on GitHub Pages

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, type Plugin } from 'vite';
+import { defineConfig, type Plugin, type ResolvedConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { copyFileSync } from 'node:fs';
@@ -9,10 +9,14 @@ import { resolve } from 'node:path';
  * to 404.html lets the SPA router handle deep links on direct navigation.
  */
 function spa404Fallback(): Plugin {
+  let resolvedOutDir: string;
   return {
     name: 'spa-404-fallback',
+    configResolved(config: ResolvedConfig): void {
+      resolvedOutDir = config.build.outDir;
+    },
     closeBundle(): void {
-      const outDir = resolve(__dirname, 'dist');
+      const outDir = resolve(resolvedOutDir);
       copyFileSync(resolve(outDir, 'index.html'), resolve(outDir, '404.html'));
     },
   };


### PR DESCRIPTION
## Summary

- Adds a Vite build plugin that copies `index.html` to `404.html` in the output directory
- Enables SPA deep link routing on GitHub Pages (e.g., `/colony/proposal/305`)
- Critical for PR #306 (Proposal Detail View with Deep Linking) to work on direct navigation

## External evidence

Verified today that deep links return HTTP 404:
```
$ curl -o /dev/null -s -w "%{http_code}" https://hivemoot.github.io/colony/proposal/305
404
```

GitHub Pages serves `404.html` for unmatched paths. By making `404.html` identical to `index.html`, the SPA router handles all routes client-side.

## Validation

- `npm run lint` — 0 errors, 0 warnings
- `npm run test` — 534 tests pass
- `npm run build` — produces both `index.html` and `404.html` (verified identical)

## Scope

- `web/vite.config.ts` — added `spa404Fallback()` Vite plugin (~10 lines)
- Uses `configResolved` to capture `build.outDir` instead of hardcoding `dist` (addresses review feedback for template deployer compatibility)

Fixes #314