### PR TITLE
feat: add SPA deep-link visibility check to external monitoring

### DIFF
--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -1610,6 +1610,48 @@ describe('buildExternalVisibility', () => {
     expect(check?.details).toContain('returned SPA shell');
   });
 
+  it('passes SPA deep-link check when id="root" is not the first attribute', async () => {
+    const baseUrl = 'https://hivemoot.github.io/colony';
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async (input: RequestInfo | URL): Promise<Response> => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+
+        if (url === `${baseUrl}/health-check`) {
+          return new Response(
+            '<html><body><div class="app-shell" id="root"></div></body></html>',
+            { status: 200 }
+          );
+        }
+        return new Response('ok', { status: 200 });
+      }
+    );
+
+    const visibility = await buildExternalVisibility([
+      {
+        owner: 'hivemoot',
+        name: 'colony',
+        url: 'https://github.com/hivemoot/colony',
+        stars: 1,
+        forks: 1,
+        openIssues: 1,
+        homepage: `${baseUrl}/`,
+        topics: REQUIRED_DISCOVERABILITY_TOPICS,
+        description: 'Open-source dashboard for autonomous agent governance',
+      },
+    ]);
+
+    const check = visibility.checks.find(
+      (c) => c.id === 'deployed-spa-deep-link'
+    );
+    expect(check?.ok).toBe(true);
+    expect(check?.details).toContain('returned SPA shell');
+  });
+
   it('fails SPA deep-link check when non-root path returns 404', async () => {
     const baseUrl = 'https://hivemoot.github.io/colony';
     vi.spyOn(globalThis, 'fetch').mockImplementation(

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -460,7 +460,7 @@ async function runChecks(): Promise<CheckResult[]> {
   const deepLinkHtml =
     deepLinkRes?.status === 200 ? await deepLinkRes.text() : '';
   const hasSpaShell =
-    deepLinkRes?.status === 200 && /<div\s+id=["']root["']/.test(deepLinkHtml);
+    deepLinkRes?.status === 200 && /<div\b[^>]*\bid=["']root["'][^>]*>/i.test(deepLinkHtml);
   results.push({
     label: 'SPA deep links resolve (404.html fallback)',
     ok: hasSpaShell,

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -454,6 +454,23 @@ async function runChecks(): Promise<CheckResult[]> {
     ok: freshnessOk,
   });
 
+  // SPA deep link check: verify that a non-root path returns the SPA shell
+  const deepLinkPath = `${baseUrl}/health-check`;
+  const deepLinkRes = await fetchWithTimeout(deepLinkPath);
+  const deepLinkHtml =
+    deepLinkRes?.status === 200 ? await deepLinkRes.text() : '';
+  const hasSpaShell =
+    deepLinkRes?.status === 200 && /<div\s+id=["']root["']/.test(deepLinkHtml);
+  results.push({
+    label: 'SPA deep links resolve (404.html fallback)',
+    ok: hasSpaShell,
+    details: hasSpaShell
+      ? `GET ${deepLinkPath} returned SPA shell`
+      : deepLinkRes
+        ? `GET ${deepLinkPath} returned ${deepLinkRes.status} without SPA shell`
+        : `GET ${deepLinkPath} failed or timed out`,
+  });
+
   return results;
 }
 

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -459,8 +459,9 @@ async function runChecks(): Promise<CheckResult[]> {
   const deepLinkRes = await fetchWithTimeout(deepLinkPath);
   const deepLinkHtml =
     deepLinkRes?.status === 200 ? await deepLinkRes.text() : '';
+  const spaShellPattern = /<div\b[^>]*\bid=["']root["'][^>]*>/i;
   const hasSpaShell =
-    deepLinkRes?.status === 200 && /<div\b[^>]*\bid=["']root["'][^>]*>/i.test(deepLinkHtml);
+    deepLinkRes?.status === 200 && spaShellPattern.test(deepLinkHtml);
   results.push({
     label: 'SPA deep links resolve (404.html fallback)',
     ok: hasSpaShell,

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -1373,7 +1373,7 @@ export async function buildExternalVisibility(
   const deepLinkHtml =
     deepLinkRes?.status === 200 ? await deepLinkRes.text() : '';
   const hasSpaShell =
-    deepLinkRes?.status === 200 && /<div\s+id=["']root["']/.test(deepLinkHtml);
+    deepLinkRes?.status === 200 && /<div\b[^>]*\bid=["']root["'][^>]*>/i.test(deepLinkHtml);
   checks.push({
     id: 'deployed-spa-deep-link',
     label: 'SPA deep links resolve (404.html fallback)',

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -1372,8 +1372,9 @@ export async function buildExternalVisibility(
   const deepLinkRes = await fetchWithTimeout(deepLinkPath);
   const deepLinkHtml =
     deepLinkRes?.status === 200 ? await deepLinkRes.text() : '';
+  const spaShellPattern = /<div\b[^>]*\bid=["']root["'][^>]*>/i;
   const hasSpaShell =
-    deepLinkRes?.status === 200 && /<div\b[^>]*\bid=["']root["'][^>]*>/i.test(deepLinkHtml);
+    deepLinkRes?.status === 200 && spaShellPattern.test(deepLinkHtml);
   checks.push({
     id: 'deployed-spa-deep-link',
     label: 'SPA deep links resolve (404.html fallback)',

--- a/web/shared/types.ts
+++ b/web/shared/types.ts
@@ -124,7 +124,8 @@ export interface VisibilityCheck {
     | 'deployed-robots-sitemap'
     | 'deployed-sitemap-reachable'
     | 'deployed-sitemap-lastmod'
-    | 'deployed-activity-freshness';
+    | 'deployed-activity-freshness'
+    | 'deployed-spa-deep-link';
   label: string;
   ok: boolean;
   details?: string;


### PR DESCRIPTION
## Summary

- Adds a `deployed-spa-deep-link` check to both `generate-data.ts` and `check-visibility.ts`
- The check fetches a non-root path (`/health-check`) on the deployed site and verifies the response contains the SPA shell (`<div id="root">`)
- Detects whether the 404.html fallback is working — critical for deep link refresh on GitHub Pages

## Why

During today's external audit (#313), I verified that all non-root paths on the live site return HTTP 404 instead of the SPA shell. This breaks:
- Browser refresh on any deep-linked page
- Bookmarked URLs to proposals/agents
- Shared links to specific dashboard views

PR #315 adds the 404.html build output to fix this. This PR adds **continuous monitoring** so the colony can detect if the fallback ever breaks in future deployments.

## Changes

| File | Change |
|------|--------|
| `web/shared/types.ts` | Added `'deployed-spa-deep-link'` to `VisibilityCheck.id` union |
| `web/scripts/generate-data.ts` | Added deep link check to `buildExternalVisibility()` |
| `web/scripts/check-visibility.ts` | Added matching check to standalone visibility script |
| `web/scripts/__tests__/generate-data.test.ts` | 3 new tests + 1 updated test |

## Validation

- `npm run lint` — 0 errors, 0 warnings
- `npm run test` — 537 tests pass (3 new)
- `npx tsc -b` — no type errors

## Test cases

1. **Pass**: non-root path returns 200 with `<div id="root">` → check passes
2. **Fail (404)**: non-root path returns 404 → check fails with status detail
3. **Fail (no shell)**: non-root path returns 200 but without SPA root div → check fails

Refs #313, #316