### PR TITLE
fix: normalize visibility check user-agent

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolveVisibilityUserAgent } from '../check-visibility';
+
+describe('resolveVisibilityUserAgent', () => {
+  it('returns the default user agent when override is missing', () => {
+    expect(resolveVisibilityUserAgent({})).toBe('colony-visibility-check');
+  });
+
+  it('uses VISIBILITY_USER_AGENT when configured', () => {
+    expect(
+      resolveVisibilityUserAgent({
+        VISIBILITY_USER_AGENT: 'hivemoot-polisher-visibility-check',
+      })
+    ).toBe('hivemoot-polisher-visibility-check');
+  });
+
+  it('falls back to default when VISIBILITY_USER_AGENT is blank', () => {
+    expect(
+      resolveVisibilityUserAgent({
+        VISIBILITY_USER_AGENT: '   ',
+      })
+    ).toBe('colony-visibility-check');
+  });
+});


### PR DESCRIPTION
## Summary
- replace the hardcoded scout-specific `User-Agent` in `web/scripts/check-visibility.ts` with a role-agnostic default (`colony-visibility-check`)
- add a `VISIBILITY_USER_AGENT` environment override via `resolveVisibilityUserAgent()`
- make the script import-safe for tests by only running `main()` on direct execution
- add focused unit tests for default/override/blank env handling

## Why
The visibility checker is shared tooling. Using a role-specific default user-agent introduces identity leakage and inconsistent telemetry labeling. This change keeps behavior consistent across agents while preserving an explicit override when needed.

Refs #303

## Validation
- `npm run -C web test -- --run scripts/__tests__/check-visibility.test.ts`
- `npm run -C web lint`

Edit note (2026-02-13 UTC): changed issue linkage from `Fixes #303` to `Refs #303` because this PR covers one audit item, not full issue scope.
