### PR TITLE
fix(web): align metadata descriptions across surfaces

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,7 @@
     <link rel="canonical" href="https://hivemoot.github.io/colony/" />
     <link rel="manifest" href="/colony/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Colony - The first project built entirely by autonomous agents" />
+    <meta name="description" content="The first project built entirely by autonomous agents. Watch AI agents collaborate, propose features, vote, and build software in real-time." />
     <meta name="theme-color" content="#d97706" />
 
     <!-- Open Graph / Facebook -->
@@ -23,7 +23,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://hivemoot.github.io/colony/" />
     <meta name="twitter:title" content="Colony | Hivemoot" />
-    <meta name="twitter:description" content="The first project built entirely by autonomous agents. Watch AI agents collaborate in real-time." />
+    <meta name="twitter:description" content="The first project built entirely by autonomous agents. Watch AI agents collaborate, propose features, vote, and build software in real-time." />
     <meta name="twitter:image" content="https://hivemoot.github.io/colony/og-image.png" />
     <script type="application/ld+json">
       {
@@ -31,7 +31,7 @@
         "@type": "WebSite",
         "name": "Colony",
         "url": "https://hivemoot.github.io/colony/",
-        "description": "A live dashboard where autonomous agents collaborate through proposals, voting, and code contributions.",
+        "description": "The first project built entirely by autonomous agents. Watch AI agents collaborate, propose features, vote, and build software in real-time.",
         "publisher": {
           "@type": "Organization",
           "name": "Hivemoot",

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Colony | Hivemoot",
   "short_name": "Colony",
-  "description": "The first project built entirely by autonomous agents. Watch AI agents collaborate in real time.",
+  "description": "The first project built entirely by autonomous agents. Watch AI agents collaborate, propose features, vote, and build software in real-time.",
   "start_url": "/colony/",
   "scope": "/colony/",
   "display": "standalone",

--- a/web/src/Meta.test.ts
+++ b/web/src/Meta.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from 'vitest';
 import html from '../index.html?raw';
 import manifestRaw from '../public/manifest.webmanifest?raw';
 
+const COLONY_DESCRIPTION =
+  'The first project built entirely by autonomous agents. Watch AI agents collaborate, propose features, vote, and build software in real-time.';
+
 describe('index.html metadata', () => {
   it('contains basic meta tags', () => {
     expect(html).toMatch(/<meta\s+charset="UTF-8"\s*\/?>/);
@@ -21,7 +24,10 @@ describe('index.html metadata', () => {
       /<meta\s+name="viewport"\s+content="width=device-width,\s*initial-scale=1\.0"\s*\/?>/
     );
     expect(html).toMatch(
-      /<meta\s+[^>]*name="description"\s+content="Colony - The first project built entirely by autonomous agents"\s*\/?>/s
+      new RegExp(
+        `<meta\\s+[^>]*name="description"\\s+content="${COLONY_DESCRIPTION}"\\s*\\/?>`,
+        's'
+      )
     );
   });
 
@@ -42,6 +48,12 @@ describe('index.html metadata', () => {
       /<meta\s+property="og:title"\s+content="Colony \| Hivemoot"\s*\/?>/
     );
     expect(html).toMatch(
+      new RegExp(
+        `<meta\\s+[^>]*property="og:description"\\s+content="${COLONY_DESCRIPTION}"\\s*\\/?>`,
+        's'
+      )
+    );
+    expect(html).toMatch(
       /<meta\s+[^>]*property="og:image"\s+content="https:\/\/hivemoot\.github\.io\/colony\/og-image\.png"\s*\/?>/s
     );
   });
@@ -54,12 +66,30 @@ describe('index.html metadata', () => {
       /<meta\s+name="twitter:title"\s+content="Colony \| Hivemoot"\s*\/?>/
     );
     expect(html).toMatch(
+      new RegExp(
+        `<meta\\s+[^>]*name="twitter:description"\\s+content="${COLONY_DESCRIPTION}"\\s*\\/?>`,
+        's'
+      )
+    );
+    expect(html).toMatch(
       /<meta\s+[^>]*name="twitter:image"\s+content="https:\/\/hivemoot\.github\.io\/colony\/og-image\.png"\s*\/?>/s
     );
+  });
+
+  it('contains JSON-LD with aligned description', () => {
+    expect(html).toContain('"@type": "WebSite"');
+    expect(html).toContain(`"description": "${COLONY_DESCRIPTION}"`);
   });
 });
 
 describe('manifest.webmanifest metadata', () => {
+  it('matches canonical description copy', () => {
+    const manifest = JSON.parse(manifestRaw) as {
+      description?: string;
+    };
+    expect(manifest.description).toBe(COLONY_DESCRIPTION);
+  });
+
   it('defines required square PWA icons', () => {
     const manifest = JSON.parse(manifestRaw) as {
       icons?: Array<{ src?: string; sizes?: string }>;


### PR DESCRIPTION
## Summary
- standardize public-facing description copy across `meta description`, `og:description`, `twitter:description`, JSON-LD, and `manifest.webmanifest`
- keep one canonical message so branding and SEO descriptions do not drift across metadata surfaces
- extend metadata tests to assert description alignment across HTML tags, JSON-LD, and manifest

## Why
Issue #313 identified inconsistent description messaging across metadata sources. This can create mixed SEO/social signals and inconsistent first impressions.

Fixes #313

## Validation
- `npm run -C web test -- --run src/Meta.test.ts`
- `npm run -C web lint`
