### PR TITLE
feat(web): add sub-metric governance trend breakdown

### DIFF
--- a/web/src/components/GovernanceTrend.test.tsx
+++ b/web/src/components/GovernanceTrend.test.tsx
@@ -6,7 +6,8 @@ import type { GovernanceSnapshot } from '../../shared/governance-snapshot';
 function makeSnapshot(
   day: number,
   score: number,
-  hour = 0
+  hour = 0,
+  overrides?: Partial<GovernanceSnapshot>
 ): GovernanceSnapshot {
   const dd = String(day).padStart(2, '0');
   const hh = String(hour).padStart(2, '0');
@@ -21,6 +22,7 @@ function makeSnapshot(
     totalProposals: 20,
     activeAgents: 4,
     proposalVelocity: 0.5,
+    ...overrides,
   };
 }
 
@@ -121,5 +123,115 @@ describe('GovernanceTrend', () => {
     const svg = screen.getByRole('img', { name: /health score trend/i });
     expect(svg.getAttribute('aria-label')).toContain('55');
     expect(svg.getAttribute('aria-label')).toContain('65');
+  });
+});
+
+describe('GovernanceTrend sub-metrics', () => {
+  it('renders sub-metric grid with multiple days of data', () => {
+    const history = [
+      makeSnapshot(1, 60),
+      makeSnapshot(2, 65),
+      makeSnapshot(3, 70),
+    ];
+
+    render(<GovernanceTrend history={history} />);
+
+    const grid = screen.getByRole('group', {
+      name: /governance sub-metric trends/i,
+    });
+    expect(grid).toBeInTheDocument();
+    expect(grid.className).toContain('grid-cols-1');
+    expect(grid.className).toContain('sm:grid-cols-2');
+  });
+
+  it('renders all four sub-metric labels', () => {
+    const history = [
+      makeSnapshot(1, 60),
+      makeSnapshot(2, 65),
+      makeSnapshot(3, 70),
+    ];
+
+    render(<GovernanceTrend history={history} />);
+
+    expect(screen.getByText('Participation')).toBeInTheDocument();
+    expect(screen.getByText('Pipeline Flow')).toBeInTheDocument();
+    expect(screen.getByText('Follow-Through')).toBeInTheDocument();
+    expect(screen.getByText('Consensus')).toBeInTheDocument();
+  });
+
+  it('displays current sub-metric scores with max', () => {
+    const history = [
+      makeSnapshot(1, 60, 0, { participation: 20 }),
+      makeSnapshot(2, 65, 0, { participation: 22 }),
+    ];
+
+    render(<GovernanceTrend history={history} />);
+
+    // participation current value should be 22/25
+    expect(screen.getByText('22/25')).toBeInTheDocument();
+  });
+
+  it('renders sub-metric sparklines with proper aria labels', () => {
+    const history = [
+      makeSnapshot(1, 60, 0, { participation: 10, pipelineFlow: 12 }),
+      makeSnapshot(2, 65, 0, { participation: 15, pipelineFlow: 18 }),
+      makeSnapshot(3, 70, 0, { participation: 20, pipelineFlow: 22 }),
+    ];
+
+    render(<GovernanceTrend history={history} />);
+
+    const participationSparkline = screen.getByRole('img', {
+      name: /participation trend/i,
+    });
+    expect(participationSparkline).toBeInTheDocument();
+
+    const pipelineSparkline = screen.getByRole('img', {
+      name: /pipeline flow trend/i,
+    });
+    expect(pipelineSparkline).toBeInTheDocument();
+  });
+
+  it('shows trend arrows for sub-metrics with sufficient data', () => {
+    // Create data where participation is clearly improving but overall is stable
+    const history = [
+      makeSnapshot(1, 60, 0, { participation: 5 }),
+      makeSnapshot(2, 61, 0, { participation: 12 }),
+      makeSnapshot(3, 62, 0, { participation: 20 }),
+    ];
+
+    render(<GovernanceTrend history={history} />);
+
+    // The sub-metric grid should have trend arrows
+    const grid = screen.getByRole('group', {
+      name: /governance sub-metric trends/i,
+    });
+    expect(grid).toBeInTheDocument();
+
+    expect(
+      screen.getByLabelText(/participation trend: improving/i)
+    ).toBeInTheDocument();
+  });
+
+  it('does not render sub-metric grid with insufficient data', () => {
+    // Only one day — not enough for sub-metric trends
+    const { container } = render(
+      <GovernanceTrend history={[makeSnapshot(1, 60)]} />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('downsamples sub-metric values to daily averages', () => {
+    const history = [
+      makeSnapshot(1, 60, 0, { followThrough: 8 }),
+      makeSnapshot(1, 60, 6, { followThrough: 12 }),
+      makeSnapshot(2, 65, 0, { followThrough: 14 }),
+      makeSnapshot(2, 65, 6, { followThrough: 18 }),
+    ];
+
+    render(<GovernanceTrend history={history} />);
+
+    // Should render Follow-Through with averaged values
+    // Day 1 avg: 10, Day 2 avg: 16, current = 16
+    expect(screen.getByText('16/25')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add a governance sub-metric trend breakdown to `GovernanceTrend` with per-metric sparklines for participation, pipeline flow, follow-through, and consensus
- keep existing daily downsampling/trend logic and generalize it for all sub-metrics
- make the breakdown responsive (`grid-cols-1` on narrow screens, `sm:grid-cols-2` on larger screens)
- improve accessibility by giving each sub-metric arrow a metric-specific `aria-label` (for example, `Participation trend: improving`)
- add tests for sub-metric rendering, responsive classes, metric score display, metric-specific aria labels, and daily averaging behavior

## Validation
- `npm -C web run test -- --run src/components/GovernanceTrend.test.tsx`
- `npm -C web run lint`
- `npm -C web run build`

Fixes #318
