### PR TITLE
check: enforce minimum OG image dimensions

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -43,6 +43,14 @@ describe('validateOpenGraphDimensions', () => {
     });
   });
 
+  it('fails when dimensions include non-numeric suffixes', () => {
+    expect(validateOpenGraphDimensions('1200px', '630;')).toEqual({
+      ok: false,
+      details:
+        'Invalid og:image dimension values: width=1200px, height=630;. Add og:image:width and og:image:height meta tags (at least 1200x630) to the deployed homepage.',
+    });
+  });
+
   it('fails when dimensions are below the minimum size', () => {
     expect(validateOpenGraphDimensions('800', '418')).toEqual({
       ok: false,

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -42,28 +42,32 @@ export function validateOpenGraphDimensions(
   widthRaw: string,
   heightRaw: string
 ): { ok: boolean; details: string } {
-  const width = Number.parseInt(widthRaw, 10);
-  const height = Number.parseInt(heightRaw, 10);
+  const widthValue = widthRaw.trim();
+  const heightValue = heightRaw.trim();
+  const width = Number.parseInt(widthValue, 10);
+  const height = Number.parseInt(heightValue, 10);
+  const isStrictPositiveInteger = (value: string): boolean =>
+    /^\d+$/.test(value) && Number.parseInt(value, 10) > 0;
   const hasDeclaredDimensions =
+    isStrictPositiveInteger(widthValue) &&
+    isStrictPositiveInteger(heightValue) &&
     Number.isInteger(width) &&
-    Number.isInteger(height) &&
-    width > 0 &&
-    height > 0;
+    Number.isInteger(height);
 
   if (!hasDeclaredDimensions) {
-    if (!widthRaw && !heightRaw) {
+    if (!widthValue && !heightValue) {
       return {
         ok: false,
         details: `Missing og:image:width and og:image:height metadata on deployed homepage. ${OPEN_GRAPH_DIMENSION_FIX_HINT}`,
       };
     }
-    if (!widthRaw) {
+    if (!widthValue) {
       return {
         ok: false,
         details: `Missing og:image:width metadata on deployed homepage. ${OPEN_GRAPH_DIMENSION_FIX_HINT}`,
       };
     }
-    if (!heightRaw) {
+    if (!heightValue) {
       return {
         ok: false,
         details: `Missing og:image:height metadata on deployed homepage. ${OPEN_GRAPH_DIMENSION_FIX_HINT}`,


### PR DESCRIPTION
## Summary
- enforce minimum Open Graph image dimensions (`1200x630`) in the external visibility check
- extract OG dimension validation into a reusable helper with clear failure reasons
- add unit tests for missing, invalid, undersized, and valid dimension metadata

## Why
Current checks only verify that `og:image:width` and `og:image:height` exist and are positive numbers. That can still pass with undersized social cards, which weakens link-preview quality and can regress discoverability.

## Validation
- `npm run test -- --run scripts/__tests__/check-visibility.test.ts`
- `npm run lint`

Fixes #335
