### PR TITLE
fix: accept custom-domain homepage URLs

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { resolveVisibilityUserAgent } from '../check-visibility';
+import {
+  resolveRepositoryHomepage,
+  resolveVisibilityUserAgent,
+} from '../check-visibility';
 
 describe('resolveVisibilityUserAgent', () => {
   it('returns the default user agent when override is missing', () => {
@@ -20,5 +23,25 @@ describe('resolveVisibilityUserAgent', () => {
         VISIBILITY_USER_AGENT: '   ',
       })
     ).toBe('colony-visibility-check');
+  });
+});
+
+describe('resolveRepositoryHomepage', () => {
+  it('accepts custom-domain homepage URLs', () => {
+    expect(
+      resolveRepositoryHomepage('https://colony.example.org/dashboard')
+    ).toBe('https://colony.example.org/dashboard');
+  });
+
+  it('normalizes trailing slashes', () => {
+    expect(resolveRepositoryHomepage('https://colony.example.org/')).toBe(
+      'https://colony.example.org'
+    );
+  });
+
+  it('rejects invalid or unsupported homepage URLs', () => {
+    expect(resolveRepositoryHomepage('ftp://colony.example.org')).toBe('');
+    expect(resolveRepositoryHomepage('not-a-url')).toBe('');
+    expect(resolveRepositoryHomepage('   ')).toBe('');
   });
 });

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -34,6 +34,24 @@ export function resolveVisibilityUserAgent(
   return configured || DEFAULT_VISIBILITY_USER_AGENT;
 }
 
+export function resolveRepositoryHomepage(homepage?: string | null): string {
+  const trimmedHomepage = homepage?.trim();
+  if (!trimmedHomepage) {
+    return '';
+  }
+
+  try {
+    const parsed = new URL(trimmedHomepage);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      return '';
+    }
+
+    return parsed.toString().replace(/\/+$/, '');
+  } catch {
+    return '';
+  }
+}
+
 function readIfExists(path: string): string {
   if (!existsSync(path)) {
     return '';
@@ -45,12 +63,10 @@ function resolveDeployedBaseUrl(homepage?: string): {
   baseUrl: string;
   usedFallback: boolean;
 } {
-  const trimmedHomepage = homepage?.trim();
-  if (trimmedHomepage && trimmedHomepage.startsWith('http')) {
+  const normalizedHomepage = resolveRepositoryHomepage(homepage);
+  if (normalizedHomepage) {
     return {
-      baseUrl: trimmedHomepage.endsWith('/')
-        ? trimmedHomepage.slice(0, -1)
-        : trimmedHomepage,
+      baseUrl: normalizedHomepage,
       usedFallback: false,
     };
   }
@@ -236,7 +252,7 @@ async function runChecks(): Promise<CheckResult[]> {
         homepage?: string | null;
         description?: string | null;
       };
-      homepageUrl = repo.homepage || '';
+      homepageUrl = resolveRepositoryHomepage(repo.homepage);
       const normalizedTopics = new Set(
         (repo.topics ?? []).map((topic) => topic.toLowerCase())
       );
@@ -253,7 +269,7 @@ async function runChecks(): Promise<CheckResult[]> {
       });
       results.push({
         label: 'Repository homepage URL is set',
-        ok: Boolean(repo.homepage && repo.homepage.includes('github.io')),
+        ok: Boolean(homepageUrl),
       });
       results.push({
         label: 'Repository description mentions dashboard',


### PR DESCRIPTION
## Summary

Fixes false-negative homepage validation in the external visibility script.

`check-visibility.ts` previously treated a repository homepage as valid only if it contained `github.io`, which incorrectly failed legitimate custom-domain deployments.

## Changes

- Added `resolveRepositoryHomepage()` to normalize and validate repository homepage URLs.
- Accepts only parseable `http:`/`https:` URLs and strips trailing slashes.
- Reused this normalization in deployed base URL resolution.
- Updated the "Repository homepage URL is set" check to use normalized homepage validity instead of `github.io` substring matching.
- Added regression tests for:
  - valid custom-domain URLs,
  - trailing-slash normalization,
  - invalid/unsupported URL rejection.

Fixes #343

## Validation

- `npm --prefix web run test -- --run scripts/__tests__/check-visibility.test.ts`
- `npm --prefix web run lint`
