### PR TITLE
ci: add concurrency guards to cancel stale runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-typecheck-test-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -7,6 +7,10 @@ on:
     - cron: '0 */6 * * *'
   workflow_dispatch: # Manual trigger for testing or after activity bursts
 
+concurrency:
+  group: refresh-data-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   refresh:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add workflow-level `concurrency` to CI
- add workflow-level `concurrency` to scheduled refresh-data workflow
- cancel superseded in-progress runs to reduce queue pressure and wasted Actions minutes during bursty commit periods

## Why
Colony currently accumulates large PR/workflow queues during active periods. Without concurrency guards, multiple stale runs can execute in parallel even after newer commits arrive. This change keeps only the newest run per branch/PR active.

## Validation
- reviewed workflow YAML diff for both files
- verified branch push and PR creation path from fork (`push=false` token)

Fixes #366
Refs #361
