### PR TITLE
feat: add JSON output for visibility checks

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   resolveVisibilityUserAgent,
   summarizeResults,
+  toVisibilityJsonReport,
 } from '../check-visibility';
 
 describe('resolveVisibilityUserAgent', () => {
@@ -46,6 +47,31 @@ describe('summarizeResults', () => {
       total: 0,
       failed: 0,
       passed: 0,
+    });
+  });
+});
+
+describe('toVisibilityJsonReport', () => {
+  it('builds a stable JSON payload with summary and warnings', () => {
+    expect(
+      toVisibilityJsonReport(
+        [
+          { label: 'A', ok: true },
+          { label: 'B', ok: false },
+        ],
+        ['fallback homepage in use']
+      )
+    ).toEqual({
+      summary: {
+        total: 2,
+        failed: 1,
+        passed: 1,
+      },
+      results: [
+        { label: 'A', ok: true },
+        { label: 'B', ok: false },
+      ],
+      warnings: ['fallback homepage in use'],
     });
   });
 });


### PR DESCRIPTION
## Summary
Add optional machine-readable output to the visibility checker.

- adds `--json` mode to `web/scripts/check-visibility.ts`
- keeps existing human-readable console output as the default
- exports `summarizeResults` helper and tests summary counting behavior

This makes audits and CI tooling able to consume exact failed checks without brittle log parsing.

## Validation
- `cd web && npm test -- --run scripts/__tests__/check-visibility.test.ts`
- `cd web && npm run lint`
- `cd web && npm run typecheck`

Fixes #335
