### PR TITLE
fix: reject future deployed data timestamps

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { resolveVisibilityUserAgent } from '../check-visibility';
+import {
+  evaluateGeneratedAtFreshness,
+  resolveVisibilityUserAgent,
+} from '../check-visibility';
 
 describe('resolveVisibilityUserAgent', () => {
   it('returns the default user agent when override is missing', () => {
@@ -20,5 +23,36 @@ describe('resolveVisibilityUserAgent', () => {
         VISIBILITY_USER_AGENT: '   ',
       })
     ).toBe('colony-visibility-check');
+  });
+});
+
+describe('evaluateGeneratedAtFreshness', () => {
+  it('fails when generatedAt is in the future', () => {
+    const result = evaluateGeneratedAtFreshness('2026-02-16T00:00:00Z', {
+      nowMs: Date.parse('2026-02-15T00:00:00Z'),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.details).toContain('future');
+  });
+
+  it('fails when generatedAt is older than the freshness threshold', () => {
+    const result = evaluateGeneratedAtFreshness('2026-02-14T00:00:00Z', {
+      nowMs: Date.parse('2026-02-15T00:00:00Z'),
+      maxAgeHours: 18,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.details).toBe('Deployed data is 24h old');
+  });
+
+  it('passes when generatedAt is recent', () => {
+    const result = evaluateGeneratedAtFreshness('2026-02-14T20:00:00Z', {
+      nowMs: Date.parse('2026-02-15T00:00:00Z'),
+      maxAgeHours: 18,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.details).toBe('Deployed data is 4h old');
   });
 });

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -27,11 +27,56 @@ interface CheckResult {
   details?: string;
 }
 
+interface FreshnessEvaluation {
+  ok: boolean;
+  details: string;
+}
+
 export function resolveVisibilityUserAgent(
   env: NodeJS.ProcessEnv = process.env
 ): string {
   const configured = env.VISIBILITY_USER_AGENT?.trim();
   return configured || DEFAULT_VISIBILITY_USER_AGENT;
+}
+
+export function evaluateGeneratedAtFreshness(
+  generatedAt: unknown,
+  options?: {
+    nowMs?: number;
+    maxAgeHours?: number;
+  }
+): FreshnessEvaluation {
+  const nowMs = options?.nowMs ?? Date.now();
+  const maxAgeHours = options?.maxAgeHours ?? 18;
+
+  if (typeof generatedAt !== 'string') {
+    return {
+      ok: false,
+      details: 'Missing generatedAt in deployed activity.json',
+    };
+  }
+
+  const timestamp = new Date(generatedAt).getTime();
+  if (Number.isNaN(timestamp)) {
+    return {
+      ok: false,
+      details: 'Invalid timestamp in deployed activity.json',
+    };
+  }
+
+  const ageMs = nowMs - timestamp;
+  const ageHours = ageMs / (1000 * 60 * 60);
+  if (ageMs < 0) {
+    return {
+      ok: false,
+      details: `generatedAt is in the future (${Math.round(Math.abs(ageHours))}h ahead)`,
+    };
+  }
+
+  return {
+    ok: ageHours <= maxAgeHours,
+    details: `Deployed data is ${Math.round(ageHours)}h old`,
+  };
 }
 
 function readIfExists(path: string): string {
@@ -599,26 +644,23 @@ async function runChecks(): Promise<CheckResult[]> {
   });
 
   let freshnessOk = false;
+  let freshnessDetails = 'Could not fetch deployed activity data';
   if (activityRes?.status === 200) {
     try {
       const activity = (await activityRes.json()) as {
         generatedAt?: unknown;
       };
-      if (typeof activity.generatedAt === 'string') {
-        const timestamp = new Date(activity.generatedAt).getTime();
-        if (!isNaN(timestamp)) {
-          const ageMs = Date.now() - timestamp;
-          const ageHours = ageMs / (1000 * 60 * 60);
-          freshnessOk = ageHours <= 18;
-        }
-      }
+      const freshness = evaluateGeneratedAtFreshness(activity.generatedAt);
+      freshnessOk = freshness.ok;
+      freshnessDetails = freshness.details;
     } catch {
-      // ignore
+      freshnessDetails = 'Invalid activity.json format on deployed site';
     }
   }
   results.push({
     label: 'Deployed data freshness (<= 18h)',
     ok: freshnessOk,
+    details: freshnessDetails,
   });
 
   return results;

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -1509,8 +1509,12 @@ export async function buildExternalVisibility(
         if (!isNaN(timestamp)) {
           const ageMs = Date.now() - timestamp;
           const ageHours = ageMs / (1000 * 60 * 60);
-          freshnessOk = ageHours <= 18; // Critical threshold from proposal
-          freshnessDetails = `Deployed data is ${Math.round(ageHours)}h old`;
+          if (ageMs < 0) {
+            freshnessDetails = `generatedAt is in the future (${Math.round(Math.abs(ageHours))}h ahead). ${deployedSourceDetails}`;
+          } else {
+            freshnessOk = ageHours <= 18; // Critical threshold from proposal
+            freshnessDetails = `Deployed data is ${Math.round(ageHours)}h old`;
+          }
         } else {
           freshnessDetails = `Invalid timestamp in deployed activity.json. ${deployedSourceDetails}`;
         }


### PR DESCRIPTION
## Summary
- treat future `generatedAt` values as invalid in deployed data freshness checks
- add explicit freshness failure details in `check-visibility.ts` so failures surface clear diagnostics
- add regression tests for both script paths to prevent future timestamps from passing

## Why
Freshness currently checks only `ageHours <= 18`. If `generatedAt` is in the future (clock skew or malformed payload), age is negative and incorrectly passes. That creates a false-green reliability signal for deployment visibility.

## Validation
- `npm run lint -- scripts/check-visibility.ts scripts/generate-data.ts scripts/__tests__/check-visibility.test.ts scripts/__tests__/generate-data.test.ts`
- `npm run test -- scripts/__tests__/check-visibility.test.ts scripts/__tests__/generate-data.test.ts`

Fixes #367