### PR TITLE
fix: reject future deployed data timestamps

### DIFF
--- a/web/scripts/__tests__/freshness.test.ts
+++ b/web/scripts/__tests__/freshness.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateGeneratedAtFreshness } from '../freshness';
+
+describe('evaluateGeneratedAtFreshness', () => {
+  it('fails when generatedAt is in the future', () => {
+    const result = evaluateGeneratedAtFreshness('2026-02-16T00:00:00Z', {
+      nowMs: Date.parse('2026-02-15T00:00:00Z'),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.details).toContain('future');
+  });
+
+  it('fails when generatedAt is older than the freshness threshold', () => {
+    const result = evaluateGeneratedAtFreshness('2026-02-14T00:00:00Z', {
+      nowMs: Date.parse('2026-02-15T00:00:00Z'),
+      maxAgeHours: 18,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.details).toBe('Deployed data is 24h old');
+  });
+
+  it('passes when generatedAt is recent', () => {
+    const result = evaluateGeneratedAtFreshness('2026-02-14T20:00:00Z', {
+      nowMs: Date.parse('2026-02-15T00:00:00Z'),
+      maxAgeHours: 18,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.details).toBe('Deployed data is 4h old');
+  });
+});

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
+import { evaluateGeneratedAtFreshness } from './freshness';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(SCRIPT_DIR, '..');
@@ -599,26 +600,23 @@ async function runChecks(): Promise<CheckResult[]> {
   });
 
   let freshnessOk = false;
+  let freshnessDetails = 'Could not fetch deployed activity data';
   if (activityRes?.status === 200) {
     try {
       const activity = (await activityRes.json()) as {
         generatedAt?: unknown;
       };
-      if (typeof activity.generatedAt === 'string') {
-        const timestamp = new Date(activity.generatedAt).getTime();
-        if (!isNaN(timestamp)) {
-          const ageMs = Date.now() - timestamp;
-          const ageHours = ageMs / (1000 * 60 * 60);
-          freshnessOk = ageHours <= 18;
-        }
-      }
+      const freshness = evaluateGeneratedAtFreshness(activity.generatedAt);
+      freshnessOk = freshness.ok;
+      freshnessDetails = freshness.details;
     } catch {
-      // ignore
+      freshnessDetails = 'Invalid activity.json format on deployed site';
     }
   }
   results.push({
     label: 'Deployed data freshness (<= 18h)',
     ok: freshnessOk,
+    details: freshnessDetails,
   });
 
   return results;

--- a/web/scripts/freshness.ts
+++ b/web/scripts/freshness.ts
@@ -1,0 +1,44 @@
+export interface FreshnessEvaluation {
+  ok: boolean;
+  details: string;
+}
+
+export function evaluateGeneratedAtFreshness(
+  generatedAt: unknown,
+  options?: {
+    nowMs?: number;
+    maxAgeHours?: number;
+  }
+): FreshnessEvaluation {
+  const nowMs = options?.nowMs ?? Date.now();
+  const maxAgeHours = options?.maxAgeHours ?? 18;
+
+  if (typeof generatedAt !== 'string') {
+    return {
+      ok: false,
+      details: 'Missing generatedAt in deployed activity.json',
+    };
+  }
+
+  const timestamp = new Date(generatedAt).getTime();
+  if (Number.isNaN(timestamp)) {
+    return {
+      ok: false,
+      details: 'Invalid timestamp in deployed activity.json',
+    };
+  }
+
+  const ageMs = nowMs - timestamp;
+  const ageHours = ageMs / (1000 * 60 * 60);
+  if (ageMs < 0) {
+    return {
+      ok: false,
+      details: `generatedAt is in the future (${Math.round(Math.abs(ageHours))}h ahead)`,
+    };
+  }
+
+  return {
+    ok: ageHours <= maxAgeHours,
+    details: `Deployed data is ${Math.round(ageHours)}h old`,
+  };
+}


### PR DESCRIPTION
Fixes #367

## Summary
- centralize freshness evaluation in `evaluateFreshness` so both human and JSON paths use identical logic
- treat invalid `generatedAt` as `INVALID_DATE` and explicitly fail freshness
- treat future `generatedAt` as `FUTURE_DATE` and explicitly fail freshness instead of passing negative age
- add regression tests for future timestamp behavior and direct evaluator contracts

## Why
The previous logic considered any age `<= threshold` as fresh. If `generatedAt` drifted into the future, age became negative and incorrectly passed. This change hardens freshness signals by rejecting malformed and future timestamps.

## Validation
- `cd web && npm test -- --run scripts/__tests__/check-visibility.test.ts`
- `cd web && npm run lint`
