### PR TITLE
fix: keep check-visibility JSON output machine-readable

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { resolveVisibilityUserAgent } from '../check-visibility';
+import {
+  buildJsonOutput,
+  hasJsonFlag,
+  resolveVisibilityUserAgent,
+  summarizeResults,
+} from '../check-visibility';
 
 describe('resolveVisibilityUserAgent', () => {
   it('returns the default user agent when override is missing', () => {
@@ -20,5 +25,42 @@ describe('resolveVisibilityUserAgent', () => {
         VISIBILITY_USER_AGENT: '   ',
       })
     ).toBe('colony-visibility-check');
+  });
+});
+
+describe('summarizeResults', () => {
+  it('returns total, passed, and failed counts', () => {
+    expect(
+      summarizeResults([
+        { label: 'a', ok: true },
+        { label: 'b', ok: false },
+        { label: 'c', ok: true },
+      ])
+    ).toEqual({ total: 3, passed: 2, failed: 1 });
+  });
+});
+
+describe('buildJsonOutput', () => {
+  it('returns machine-readable output with summary and warnings', () => {
+    const results = [
+      { label: 'check 1', ok: true },
+      { label: 'check 2', ok: false, details: 'failed detail' },
+    ];
+    const warnings = ['fallback used'];
+    expect(buildJsonOutput(results, warnings)).toEqual({
+      summary: { total: 2, passed: 1, failed: 1 },
+      warnings: ['fallback used'],
+      results,
+    });
+  });
+});
+
+describe('hasJsonFlag', () => {
+  it('returns true when --json is present', () => {
+    expect(hasJsonFlag(['--json'])).toBe(true);
+  });
+
+  it('returns false when --json is absent', () => {
+    expect(hasJsonFlag(['--verbose'])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add `--json` mode helpers for `check-visibility` (`summarizeResults`, `buildJsonOutput`, `hasJsonFlag`)
- route `runChecks` warnings through an injectable logger so JSON mode avoids mixed stdout
- keep text mode behavior intact while using shared summary counts
- add unit coverage for summary/json helpers and JSON-flag parsing

## Why
Current JSON consumers can break when warning text is emitted to stdout before the JSON payload. This PR guarantees `--json` mode emits machine-readable JSON only, while still preserving warning information inside a dedicated `warnings` array.

## Validation
- `npm run test -- check-visibility`
- `npm run lint`
- `npm run typecheck`
- `npm run check-visibility -- --json` (manual sanity check)

Fixes #335
