### PR TITLE
fix: fail governance freshness on future timestamps

### DIFF
--- a/web/src/utils/governance-ops.test.ts
+++ b/web/src/utils/governance-ops.test.ts
@@ -286,4 +286,36 @@ describe('computeGovernanceOpsReport', () => {
       vi.useRealTimers();
     }
   });
+
+  it('fails freshness check when generatedAt is in the future', () => {
+    const report = computeGovernanceOpsReport(
+      makeBaseData({
+        generatedAt: '2026-02-11T18:00:00Z',
+      }),
+      new Date('2026-02-11T12:00:00Z')
+    );
+
+    const freshness = report.checks.find(
+      (check) => check.id === 'dashboard-freshness'
+    );
+
+    expect(freshness?.status).toBe('fail');
+    expect(freshness?.detail).toContain('in the future');
+  });
+
+  it('fails freshness check when generatedAt is invalid', () => {
+    const report = computeGovernanceOpsReport(
+      makeBaseData({
+        generatedAt: 'not-a-date',
+      }),
+      new Date('2026-02-11T12:00:00Z')
+    );
+
+    const freshness = report.checks.find(
+      (check) => check.id === 'dashboard-freshness'
+    );
+
+    expect(freshness?.status).toBe('fail');
+    expect(freshness?.value).toBe('Invalid timestamp');
+  });
 });

--- a/web/src/utils/governance-ops.ts
+++ b/web/src/utils/governance-ops.ts
@@ -223,8 +223,34 @@ function computeDashboardFreshnessCheck(
   now: Date
 ): GovernanceSLOCheck {
   const generated = new Date(data.generatedAt);
-  const freshnessHours =
-    (now.getTime() - generated.getTime()) / (1000 * 60 * 60);
+  const generatedMs = generated.getTime();
+  const nowMs = now.getTime();
+
+  if (Number.isNaN(generatedMs)) {
+    return {
+      id: 'dashboard-freshness',
+      label: 'Dashboard Freshness',
+      target: '<=6h data staleness',
+      status: 'fail',
+      value: 'Invalid timestamp',
+      detail:
+        'Latest snapshot timestamp is invalid. Verify generatedAt formatting in activity data.',
+    };
+  }
+
+  if (generatedMs > nowMs) {
+    return {
+      id: 'dashboard-freshness',
+      label: 'Dashboard Freshness',
+      target: '<=6h data staleness',
+      status: 'fail',
+      value: formatHours(0),
+      detail:
+        'Latest snapshot timestamp is in the future. Check clock skew or corrupted generatedAt data.',
+    };
+  }
+
+  const freshnessHours = (nowMs - generatedMs) / (1000 * 60 * 60);
 
   const status =
     freshnessHours <= DASHBOARD_FRESH_HOURS


### PR DESCRIPTION
Fixes #370

Dashboard freshness in `computeGovernanceOpsReport` currently accepts future `generatedAt` values because negative age still satisfies the freshness threshold. That can hide clock skew or malformed snapshot metadata under a false green signal.

This change makes freshness fail explicitly when:
- `generatedAt` is invalid
- `generatedAt` is in the future

It also adds regression tests for both failure paths.

Validation:
- `cd web && npm test -- --run src/utils/governance-ops.test.ts`
- `cd web && npm run lint`
