### PR TITLE
fix: fail dashboard freshness for future timestamps

### DIFF
--- a/web/src/utils/governance-ops.test.ts
+++ b/web/src/utils/governance-ops.test.ts
@@ -286,4 +286,37 @@ describe('computeGovernanceOpsReport', () => {
       vi.useRealTimers();
     }
   });
+
+  it('fails freshness when generatedAt is in the future', () => {
+    const report = computeGovernanceOpsReport(
+      makeBaseData({
+        generatedAt: '2026-02-11T13:00:00Z',
+      }),
+      new Date('2026-02-11T12:00:00Z')
+    );
+
+    const freshness = report.checks.find(
+      (check) => check.id === 'dashboard-freshness'
+    );
+
+    expect(freshness?.status).toBe('fail');
+    expect(freshness?.detail).toContain('in the future');
+  });
+
+  it('fails freshness when generatedAt is invalid', () => {
+    const report = computeGovernanceOpsReport(
+      makeBaseData({
+        generatedAt: 'not-a-date',
+      }),
+      new Date('2026-02-11T12:00:00Z')
+    );
+
+    const freshness = report.checks.find(
+      (check) => check.id === 'dashboard-freshness'
+    );
+
+    expect(freshness?.status).toBe('fail');
+    expect(freshness?.value).toBe('Invalid timestamp');
+    expect(freshness?.detail).toContain('invalid');
+  });
 });

--- a/web/src/utils/governance-ops.ts
+++ b/web/src/utils/governance-ops.ts
@@ -223,8 +223,30 @@ function computeDashboardFreshnessCheck(
   now: Date
 ): GovernanceSLOCheck {
   const generated = new Date(data.generatedAt);
+  const generatedTimestamp = generated.getTime();
+  if (Number.isNaN(generatedTimestamp)) {
+    return {
+      id: 'dashboard-freshness',
+      label: 'Dashboard Freshness',
+      target: '<=6h data staleness',
+      status: 'fail',
+      value: 'Invalid timestamp',
+      detail: `Latest snapshot timestamp is invalid (${data.generatedAt}).`,
+    };
+  }
+
   const freshnessHours =
-    (now.getTime() - generated.getTime()) / (1000 * 60 * 60);
+    (now.getTime() - generatedTimestamp) / (1000 * 60 * 60);
+  if (freshnessHours < 0) {
+    return {
+      id: 'dashboard-freshness',
+      label: 'Dashboard Freshness',
+      target: '<=6h data staleness',
+      status: 'fail',
+      value: formatHours(0),
+      detail: `Latest snapshot timestamp is in the future (${data.generatedAt}).`,
+    };
+  }
 
   const status =
     freshnessHours <= DASHBOARD_FRESH_HOURS


### PR DESCRIPTION
## Summary
- fail governance ops dashboard freshness when `generatedAt` is invalid
- fail dashboard freshness when `generatedAt` is in the future instead of treating negative age as fresh
- add regression tests for both invalid and future timestamps

## Why
The dashboard freshness SLO previously computed age directly from `now - generatedAt` and treated any value `<= 6h` as pass. If `generatedAt` drifted into the future, the age became negative and incorrectly reported healthy status. This hardens the health signal so malformed timestamps cannot mask data integrity problems.

## Validation
- `npm run lint`
- `npm test -- --run src/utils/governance-ops.test.ts`
- `npm test -- --run`

Fixes #367
