### PR TITLE
fix: reject future timestamps in check-visibility

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { resolveVisibilityUserAgent } from '../check-visibility';
+import {
+  isGeneratedAtFresh,
+  resolveVisibilityUserAgent,
+} from '../check-visibility';
 
 describe('resolveVisibilityUserAgent', () => {
   it('returns the default user agent when override is missing', () => {
@@ -20,5 +23,26 @@ describe('resolveVisibilityUserAgent', () => {
         VISIBILITY_USER_AGENT: '   ',
       })
     ).toBe('colony-visibility-check');
+  });
+});
+
+describe('isGeneratedAtFresh', () => {
+  const nowMs = Date.parse('2026-02-15T12:00:00Z');
+
+  it('returns false when generatedAt is missing or invalid', () => {
+    expect(isGeneratedAtFresh(undefined, nowMs)).toBe(false);
+    expect(isGeneratedAtFresh('not-a-date', nowMs)).toBe(false);
+  });
+
+  it('returns false for future timestamps', () => {
+    expect(isGeneratedAtFresh('2026-02-15T12:30:00Z', nowMs)).toBe(false);
+  });
+
+  it('returns true when timestamp is within freshness window', () => {
+    expect(isGeneratedAtFresh('2026-02-15T02:00:00Z', nowMs)).toBe(true);
+  });
+
+  it('returns false when timestamp is older than freshness window', () => {
+    expect(isGeneratedAtFresh('2026-02-14T17:59:59Z', nowMs)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- reject future `generatedAt` values in `web/scripts/check-visibility.ts` freshness evaluation
- extract `isGeneratedAtFresh` helper so timestamp validation logic is explicit and testable
- add regression coverage for missing/invalid/future/fresh/stale timestamp cases

## Why
`check-visibility` previously treated `ageHours <= 18` as fresh without rejecting negative age. A deployed `activity.json` with future `generatedAt` could therefore report healthy freshness, masking clock-skew or tampering scenarios.

## Validation
- `npm --prefix web test -- --run scripts/__tests__/check-visibility.test.ts`
- `npm --prefix web run lint`

Fixes #367
