### PR TITLE
fix: require https homepage for visibility checks

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { resolveVisibilityUserAgent } from '../check-visibility';
+import {
+  resolveDeployedBaseUrl,
+  resolveVisibilityUserAgent,
+} from '../check-visibility';
 
 describe('resolveVisibilityUserAgent', () => {
   it('returns the default user agent when override is missing', () => {
@@ -20,5 +23,28 @@ describe('resolveVisibilityUserAgent', () => {
         VISIBILITY_USER_AGENT: '   ',
       })
     ).toBe('colony-visibility-check');
+  });
+});
+
+describe('resolveDeployedBaseUrl', () => {
+  it('uses normalized https homepage when valid', () => {
+    expect(resolveDeployedBaseUrl(' https://example.com/path/ ')).toEqual({
+      baseUrl: 'https://example.com/path',
+      usedFallback: false,
+    });
+  });
+
+  it('falls back when homepage is non-https', () => {
+    expect(resolveDeployedBaseUrl('http://example.com/path')).toEqual({
+      baseUrl: 'https://hivemoot.github.io/colony',
+      usedFallback: true,
+    });
+  });
+
+  it('falls back when homepage URL is malformed', () => {
+    expect(resolveDeployedBaseUrl('not-a-url')).toEqual({
+      baseUrl: 'https://hivemoot.github.io/colony',
+      usedFallback: true,
+    });
   });
 });

--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -876,6 +876,39 @@ describe('buildExternalVisibility', () => {
     );
   });
 
+  it('treats non-https homepage as invalid and uses fallback URL', async () => {
+    const fallbackBaseUrl = 'https://hivemoot.github.io/colony';
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (): Promise<Response> => {
+        throw new Error('network unavailable');
+      });
+
+    const visibility = await buildExternalVisibility([
+      {
+        owner: 'hivemoot',
+        name: 'colony',
+        url: 'https://github.com/hivemoot/colony',
+        stars: 1,
+        forks: 1,
+        openIssues: 1,
+        homepage: 'http://hivemoot.github.io/colony',
+        topics: REQUIRED_DISCOVERABILITY_TOPICS,
+        description: 'Open-source dashboard for autonomous agent governance',
+      },
+    ]);
+
+    const homepageCheck = visibility.checks.find(
+      (c) => c.id === 'has-homepage'
+    );
+    expect(homepageCheck?.ok).toBe(false);
+    expect(homepageCheck?.details).toContain('invalid https homepage');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      fallbackBaseUrl,
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
   it('flags canonical mismatch on deployed homepage', async () => {
     const baseUrl = 'https://hivemoot.github.io/colony';
     vi.spyOn(globalThis, 'fetch').mockImplementation(

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -890,12 +890,10 @@ function resolveDeployedBaseUrl(homepage?: string | null): {
   baseUrl: string;
   usedFallback: boolean;
 } {
-  const trimmedHomepage = homepage?.trim();
-  if (trimmedHomepage && trimmedHomepage.startsWith('http')) {
+  const normalizedHomepage = normalizeHttpsHomepageUrl(homepage);
+  if (normalizedHomepage) {
     return {
-      baseUrl: trimmedHomepage.endsWith('/')
-        ? trimmedHomepage.slice(0, -1)
-        : trimmedHomepage,
+      baseUrl: normalizedHomepage,
       usedFallback: false,
     };
   }
@@ -904,6 +902,30 @@ function resolveDeployedBaseUrl(homepage?: string | null): {
     baseUrl: DEFAULT_DEPLOYED_BASE_URL,
     usedFallback: true,
   };
+}
+
+function normalizeHttpsHomepageUrl(homepage?: string | null): string {
+  const trimmedHomepage = homepage?.trim();
+  if (!trimmedHomepage) {
+    return '';
+  }
+
+  try {
+    const parsed = new URL(trimmedHomepage);
+    if (
+      parsed.protocol !== 'https:' ||
+      !parsed.hostname ||
+      parsed.username ||
+      parsed.password
+    ) {
+      return '';
+    }
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString().replace(/\/+$/, '');
+  } catch {
+    return '';
+  }
 }
 
 function normalizeUrlForMatch(value: string): string {
@@ -1045,7 +1067,8 @@ export async function buildExternalVisibility(
     (topic) => !normalizedTopics.has(topic)
   );
 
-  const hasHomepage = Boolean(primary?.homepage?.trim());
+  const normalizedHomepage = normalizeHttpsHomepageUrl(primary?.homepage);
+  const hasHomepage = Boolean(normalizedHomepage);
   const hasTopics = missingRequiredTopics.length === 0;
   const hasDescription = Boolean(
     primary?.description && /dashboard/i.test(primary.description)
@@ -1071,8 +1094,8 @@ export async function buildExternalVisibility(
       label: 'Repository homepage URL configured',
       ok: hasHomepage,
       details: hasHomepage
-        ? (primary.homepage ?? undefined)
-        : 'Missing homepage repository setting.',
+        ? normalizedHomepage
+        : 'Missing or invalid https homepage repository setting.',
       blockedByAdmin: !hasHomepage,
     },
     {


### PR DESCRIPTION
## Summary
- require repository homepage values to be absolute `https` URLs before treating homepage checks as passing
- normalize homepage URLs (strip trailing slash, query, and hash) before deployed visibility checks use them
- add regression tests for `check-visibility` base URL resolution and `generate-data` fallback behavior on invalid homepage values

## Why
The previous logic treated any non-empty homepage (or any string prefixed with `http`) as valid. That allowed false-positive admin checks and could route deployed checks to malformed/insecure URLs. Tightening this validation improves reliability and reduces trust on potentially unsafe metadata.

## Validation
- `npm --prefix web run lint`
- `npm --prefix web test -- --run scripts/__tests__/check-visibility.test.ts scripts/__tests__/generate-data.test.ts`
