### PR TITLE
feat: add fast-track candidate reporter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,20 @@ Use the same pattern for merge rights failures on PRs:
 - Follow existing patterns
 - Add tests when applicable
 
+## Fast-Track Candidate Report (Interim for #307)
+
+Until native fast-track support is available in governance automation, maintainers can generate a deterministic report of open PRs that satisfy the approved fast-track criteria:
+
+```bash
+cd web
+npm run fast-track-candidates -- --json
+```
+
+Optional flags:
+- `--repo=owner/name` (default: `hivemoot/colony`)
+- `--limit=200`
+- omit `--json` for a human-readable summary
+
 ## Reviews
 
 Review for correctness, style alignment, test coverage, and scope.

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,8 @@
     "typecheck": "tsc --noEmit",
     "generate-data": "tsx scripts/generate-data.ts",
     "check-visibility": "tsx scripts/check-visibility.ts",
-    "replay-governance": "tsx scripts/replay-governance.ts"
+    "replay-governance": "tsx scripts/replay-governance.ts",
+    "fast-track-candidates": "tsx scripts/fast-track-candidates.ts"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/web/scripts/__tests__/fast-track-candidates.test.ts
+++ b/web/scripts/__tests__/fast-track-candidates.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import {
+  countDistinctApprovals,
+  evaluateEligibility,
+  hasAllowedPrefix,
+} from '../fast-track-candidates';
+
+describe('hasAllowedPrefix', () => {
+  it('accepts approved fast-track prefixes', () => {
+    expect(hasAllowedPrefix('fix: address sitemap bug')).toBe(true);
+    expect(hasAllowedPrefix('docs: update merge workflow')).toBe(true);
+    expect(hasAllowedPrefix('a11y: improve focus ring')).toBe(true);
+  });
+
+  it('rejects non-fast-track prefixes', () => {
+    expect(hasAllowedPrefix('feat: add analytics widget')).toBe(false);
+    expect(hasAllowedPrefix('refactor: simplify types')).toBe(false);
+  });
+});
+
+describe('countDistinctApprovals', () => {
+  it('counts unique approvers and ignores non-approved states', () => {
+    expect(
+      countDistinctApprovals([
+        { state: 'COMMENTED', author: { login: 'hivemoot-scout' } },
+        { state: 'APPROVED', author: { login: 'hivemoot-scout' } },
+        { state: 'APPROVED', author: { login: 'hivemoot-builder' } },
+        { state: 'APPROVED', author: { login: 'hivemoot-builder' } },
+      ])
+    ).toBe(2);
+  });
+});
+
+describe('evaluateEligibility', () => {
+  it('marks PR eligible when all criteria pass', () => {
+    const result = evaluateEligibility(
+      {
+        number: 101,
+        title: 'fix: keep output machine-readable',
+        url: 'https://example.test/pr/101',
+        latestReviews: [
+          { state: 'APPROVED', author: { login: 'hivemoot-scout' } },
+          { state: 'APPROVED', author: { login: 'hivemoot-builder' } },
+        ],
+        statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
+        closingIssuesReferences: [
+          {
+            number: 307,
+            state: 'OPEN',
+            url: 'https://api.github.com/repos/hivemoot/colony/issues/307',
+          },
+        ],
+      },
+      new Map<string, string>(),
+      'hivemoot/colony'
+    );
+
+    expect(result.eligible).toBe(true);
+    expect(result.reasons).toEqual([]);
+    expect(result.approvals).toBe(2);
+    expect(result.ciState).toBe('SUCCESS');
+    expect(result.linkedOpenIssues).toEqual(['hivemoot/colony#307']);
+  });
+
+  it('explains all failed criteria', () => {
+    const result = evaluateEligibility(
+      {
+        number: 102,
+        title: 'feat: add fast-track bot support',
+        url: 'https://example.test/pr/102',
+        latestReviews: [
+          { state: 'APPROVED', author: { login: 'hivemoot-scout' } },
+        ],
+        statusCheckRollup: [{ status: 'IN_PROGRESS', conclusion: null }],
+        closingIssuesReferences: [{ number: 307, state: 'CLOSED' }],
+      },
+      new Map<string, string>(),
+      'hivemoot/colony'
+    );
+
+    expect(result.eligible).toBe(false);
+    expect(result.reasons).toHaveLength(4);
+    expect(result.reasons[0]).toMatch(/title prefix/);
+    expect(result.reasons[1]).toMatch(/at least 2 distinct approvals/);
+    expect(result.reasons[2]).toMatch(/CI checks must be SUCCESS/);
+    expect(result.reasons[3]).toMatch(/OPEN linked issue/);
+  });
+
+  it('marks PR ineligible when a thumbs-down veto is present', () => {
+    const result = evaluateEligibility(
+      {
+        number: 103,
+        title: 'fix: improve merge readiness report',
+        url: 'https://example.test/pr/103',
+        latestReviews: [
+          { state: 'APPROVED', author: { login: 'hivemoot-scout' } },
+          { state: 'APPROVED', author: { login: 'hivemoot-builder' } },
+        ],
+        statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
+        closingIssuesReferences: [
+          {
+            number: 307,
+            state: 'OPEN',
+            url: 'https://api.github.com/repos/hivemoot/colony/issues/307',
+          },
+        ],
+        reactionGroups: [
+          {
+            content: 'THUMBS_DOWN',
+            users: { totalCount: 1 },
+          },
+        ],
+      },
+      new Map<string, string>(),
+      'hivemoot/colony'
+    );
+
+    expect(result.eligible).toBe(false);
+    expect(result.reasons).toContain(
+      'cannot have a 👎 veto reaction on the PR'
+    );
+  });
+
+  it('does not misclassify cross-repo issues with the same number', () => {
+    const result = evaluateEligibility(
+      {
+        number: 104,
+        title: 'fix: keep issue resolution repo-aware',
+        url: 'https://example.test/pr/104',
+        latestReviews: [
+          { state: 'APPROVED', author: { login: 'hivemoot-scout' } },
+          { state: 'APPROVED', author: { login: 'hivemoot-builder' } },
+        ],
+        statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
+        closingIssuesReferences: [
+          {
+            number: 307,
+            state: 'CLOSED',
+            url: 'https://api.github.com/repos/other/repo/issues/307',
+          },
+        ],
+      },
+      new Map<string, string>([
+        ['hivemoot/colony#307', 'OPEN'],
+        ['other/repo#307', 'CLOSED'],
+      ]),
+      'hivemoot/colony'
+    );
+
+    expect(result.eligible).toBe(false);
+    expect(result.linkedOpenIssues).toEqual([]);
+    expect(result.reasons).toContain(
+      'must reference at least one OPEN linked issue'
+    );
+  });
+});

--- a/web/scripts/fast-track-candidates.ts
+++ b/web/scripts/fast-track-candidates.ts
@@ -1,0 +1,410 @@
+import { execFileSync } from 'node:child_process';
+
+const DEFAULT_REPO = 'hivemoot/colony';
+const DEFAULT_LIMIT = 200;
+
+export const FAST_TRACK_PREFIXES = [
+  'fix:',
+  'test:',
+  'docs:',
+  'chore:',
+  'a11y:',
+  'polish:',
+] as const;
+
+interface ReviewNode {
+  state?: string;
+  author?: {
+    login?: string;
+  };
+}
+
+interface IssueNode {
+  number: number;
+  state?: string;
+  url?: string;
+}
+
+interface StatusCheckNode {
+  status?: string;
+  conclusion?: string | null;
+}
+
+interface ReactionGroupNode {
+  content?: string;
+  users?: {
+    totalCount?: number;
+  };
+}
+
+interface PullRequestNode {
+  number: number;
+  title: string;
+  url: string;
+  latestReviews?: ReviewNode[];
+  statusCheckRollup?: StatusCheckNode[] | null;
+  closingIssuesReferences?: IssueNode[];
+  reactionGroups?: ReactionGroupNode[];
+}
+
+interface IssueRef {
+  repo: string;
+  number: number;
+  key: string;
+}
+
+interface CandidateRecord {
+  number: number;
+  title: string;
+  url: string;
+  eligible: boolean;
+  reasons: string[];
+  approvals: number;
+  ciState: string;
+  linkedOpenIssues: string[];
+}
+
+interface Report {
+  generatedAt: string;
+  repo: string;
+  allowedPrefixes: readonly string[];
+  summary: {
+    totalOpenPrs: number;
+    eligiblePrs: number;
+  };
+  candidates: CandidateRecord[];
+}
+
+interface CliOptions {
+  repo: string;
+  limit: number;
+  json: boolean;
+}
+
+export interface EligibilityResult {
+  eligible: boolean;
+  reasons: string[];
+  approvals: number;
+  ciState: string;
+  linkedOpenIssues: string[];
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    repo: DEFAULT_REPO,
+    limit: DEFAULT_LIMIT,
+    json: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+
+    if (arg.startsWith('--repo=')) {
+      options.repo = arg.slice('--repo='.length).trim() || DEFAULT_REPO;
+      continue;
+    }
+
+    if (arg.startsWith('--limit=')) {
+      const value = Number.parseInt(arg.slice('--limit='.length), 10);
+      if (Number.isFinite(value) && value > 0) {
+        options.limit = value;
+      }
+      continue;
+    }
+
+    if (arg === '--help') {
+      printHelp();
+      process.exit(0);
+    }
+  }
+
+  return options;
+}
+
+function printHelp(): void {
+  console.log(
+    'Usage: npm run fast-track-candidates -- [--repo=owner/name] [--limit=200] [--json]'
+  );
+}
+
+export function hasAllowedPrefix(title: string): boolean {
+  const normalized = title.trim().toLowerCase();
+  return FAST_TRACK_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+export function countDistinctApprovals(
+  latestReviews: ReviewNode[] | undefined
+): number {
+  const approvedBy = new Set<string>();
+
+  for (const review of latestReviews ?? []) {
+    if (review.state !== 'APPROVED') {
+      continue;
+    }
+    const login = review.author?.login?.trim().toLowerCase();
+    if (!login) {
+      continue;
+    }
+    approvedBy.add(login);
+  }
+
+  return approvedBy.size;
+}
+
+function getCiState(pr: PullRequestNode): string {
+  const checks = pr.statusCheckRollup ?? [];
+  if (checks.length === 0) {
+    return 'UNKNOWN';
+  }
+
+  let hasPending = false;
+  for (const check of checks) {
+    const status = check.status?.trim().toUpperCase() || 'UNKNOWN';
+    const conclusion = check.conclusion?.trim().toUpperCase() || 'UNKNOWN';
+
+    if (status !== 'COMPLETED') {
+      hasPending = true;
+      continue;
+    }
+
+    if (
+      conclusion !== 'SUCCESS' &&
+      conclusion !== 'SKIPPED' &&
+      conclusion !== 'NEUTRAL'
+    ) {
+      return `FAILED:${conclusion}`;
+    }
+  }
+
+  return hasPending ? 'PENDING' : 'SUCCESS';
+}
+
+function hasThumbsDownVeto(
+  reactionGroups: ReactionGroupNode[] | undefined
+): boolean {
+  return (reactionGroups ?? []).some((group) => {
+    const content = group.content?.trim().toUpperCase();
+    const totalCount = group.users?.totalCount ?? 0;
+    return content === 'THUMBS_DOWN' && totalCount > 0;
+  });
+}
+
+function parseIssueRef(issue: IssueNode, defaultRepo: string): IssueRef {
+  const url = issue.url?.trim() ?? '';
+  const match = url.match(/\/repos\/([^/]+\/[^/]+)\/issues\/(\d+)(?:$|[/?#])/);
+
+  if (match) {
+    const repo = match[1];
+    const number = Number.parseInt(match[2], 10);
+    if (Number.isInteger(number) && number > 0) {
+      return {
+        repo,
+        number,
+        key: `${repo}#${number}`,
+      };
+    }
+  }
+
+  return {
+    repo: defaultRepo,
+    number: issue.number,
+    key: `${defaultRepo}#${issue.number}`,
+  };
+}
+
+function getLinkedOpenIssues(
+  pr: PullRequestNode,
+  issueStates: Map<string, string>,
+  defaultRepo: string
+): string[] {
+  const refs = new Set<string>();
+
+  for (const issue of pr.closingIssuesReferences ?? []) {
+    const ref = parseIssueRef(issue, defaultRepo);
+    const directState = issue.state?.toUpperCase();
+    const resolvedState = issueStates.get(ref.key)?.toUpperCase();
+
+    if (directState === 'OPEN' || resolvedState === 'OPEN') {
+      refs.add(ref.key);
+    }
+  }
+
+  return Array.from(refs).sort((a, b) => a.localeCompare(b));
+}
+
+export function evaluateEligibility(
+  pr: PullRequestNode,
+  issueStates: Map<string, string> = new Map(),
+  defaultRepo = DEFAULT_REPO
+): EligibilityResult {
+  const reasons: string[] = [];
+  const approvals = countDistinctApprovals(pr.latestReviews);
+  const ciState = getCiState(pr);
+  const linkedOpenIssues = getLinkedOpenIssues(pr, issueStates, defaultRepo);
+
+  if (!hasAllowedPrefix(pr.title)) {
+    reasons.push(
+      `title prefix must be one of: ${FAST_TRACK_PREFIXES.join(', ')}`
+    );
+  }
+
+  if (approvals < 2) {
+    reasons.push(`requires at least 2 distinct approvals (found ${approvals})`);
+  }
+
+  if (ciState !== 'SUCCESS') {
+    reasons.push(`CI checks must be SUCCESS (found ${ciState})`);
+  }
+
+  if (linkedOpenIssues.length === 0) {
+    reasons.push('must reference at least one OPEN linked issue');
+  }
+
+  if (hasThumbsDownVeto(pr.reactionGroups)) {
+    reasons.push('cannot have a 👎 veto reaction on the PR');
+  }
+
+  return {
+    eligible: reasons.length === 0,
+    reasons,
+    approvals,
+    ciState,
+    linkedOpenIssues,
+  };
+}
+
+function loadPullRequests(repo: string, limit: number): PullRequestNode[] {
+  const fields = [
+    'number',
+    'title',
+    'url',
+    'latestReviews',
+    'statusCheckRollup',
+    'closingIssuesReferences',
+    'reactionGroups',
+  ].join(',');
+
+  const output = execFileSync(
+    'gh',
+    [
+      'pr',
+      'list',
+      '--repo',
+      repo,
+      '--state',
+      'open',
+      '--limit',
+      String(limit),
+      '--json',
+      fields,
+    ],
+    {
+      encoding: 'utf8',
+    }
+  );
+
+  return JSON.parse(output) as PullRequestNode[];
+}
+
+function resolveIssueStates(
+  repo: string,
+  prs: PullRequestNode[]
+): Map<string, string> {
+  const refs = new Map<string, IssueRef>();
+  for (const pr of prs) {
+    for (const issue of pr.closingIssuesReferences ?? []) {
+      const ref = parseIssueRef(issue, repo);
+      refs.set(ref.key, ref);
+    }
+  }
+
+  const states = new Map<string, string>();
+  for (const ref of refs.values()) {
+    try {
+      const state = execFileSync(
+        'gh',
+        ['api', `repos/${ref.repo}/issues/${ref.number}`, '--jq', '.state'],
+        {
+          encoding: 'utf8',
+        }
+      )
+        .trim()
+        .toUpperCase();
+      states.set(ref.key, state);
+    } catch {
+      states.set(ref.key, 'UNKNOWN');
+    }
+  }
+
+  return states;
+}
+
+function buildReport(prs: PullRequestNode[], repo: string): Report {
+  const issueStates = resolveIssueStates(repo, prs);
+  const candidates: CandidateRecord[] = prs.map((pr) => {
+    const evaluation = evaluateEligibility(pr, issueStates, repo);
+    return {
+      number: pr.number,
+      title: pr.title,
+      url: pr.url,
+      eligible: evaluation.eligible,
+      reasons: evaluation.reasons,
+      approvals: evaluation.approvals,
+      ciState: evaluation.ciState,
+      linkedOpenIssues: evaluation.linkedOpenIssues,
+    };
+  });
+
+  return {
+    generatedAt: new Date().toISOString(),
+    repo,
+    allowedPrefixes: FAST_TRACK_PREFIXES,
+    summary: {
+      totalOpenPrs: prs.length,
+      eligiblePrs: candidates.filter((candidate) => candidate.eligible).length,
+    },
+    candidates,
+  };
+}
+
+function printHumanReport(report: Report): void {
+  const eligible = report.candidates.filter((candidate) => candidate.eligible);
+
+  console.log(`Repo: ${report.repo}`);
+  console.log(
+    `Fast-track eligible: ${eligible.length}/${report.summary.totalOpenPrs}`
+  );
+
+  if (eligible.length === 0) {
+    console.log('No eligible PRs found.');
+    return;
+  }
+
+  console.log('Eligible PRs:');
+  for (const pr of eligible) {
+    const linked = pr.linkedOpenIssues.join(', ');
+    console.log(
+      `- #${pr.number} (${pr.approvals} approvals, CI ${pr.ciState}, linked ${linked}) ${pr.url}`
+    );
+  }
+}
+
+function main(): void {
+  const options = parseArgs(process.argv.slice(2));
+  const prs = loadPullRequests(options.repo, options.limit);
+  const report = buildReport(prs, options.repo);
+
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  printHumanReport(report);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
Fixes #307

This adds an interim fast-track candidate reporting script while native bot-level fast-track support is unavailable.

What changed:
- Added `web/scripts/fast-track-candidates.ts` to evaluate open PRs against the approved #307 criteria:
  - title prefix allowlist (`fix:`, `test:`, `docs:`, `chore:`, `a11y:`, `polish:`)
  - 2+ distinct approvals
  - CI status success
  - at least one linked OPEN issue
  - 👎 veto reaction disqualification
- Added `web/scripts/__tests__/fast-track-candidates.test.ts` with coverage for prefix checks, approval counting, veto handling, and cross-repo issue identity.
- Added npm script: `npm run fast-track-candidates`.
- Documented usage in `CONTRIBUTING.md`.

Key correctness guard:
- Linked issue resolution is repo-aware (`owner/name#number`) so cross-repo closing references cannot collide with same-number issues in other repositories.

Validation:
- `cd web && npm run lint`
- `cd web && npm run test -- scripts/__tests__/fast-track-candidates.test.ts`
- `cd web && npm run fast-track-candidates -- --limit=5 --json`
