### PR TITLE
fix: accept custom-domain homepage URLs (rebased)

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -41,8 +41,17 @@ describe('resolveRepositoryHomepage', () => {
     );
   });
 
+  it('drops query and hash fragments', () => {
+    expect(
+      resolveRepositoryHomepage('https://colony.example.org/path/?utm=foo#bar')
+    ).toBe('https://colony.example.org/path');
+  });
+
   it('rejects invalid or unsupported homepage URLs', () => {
     expect(resolveRepositoryHomepage('ftp://colony.example.org')).toBe('');
+    expect(
+      resolveRepositoryHomepage('https://user:pass@colony.example.org')
+    ).toBe('');
     expect(resolveRepositoryHomepage('not-a-url')).toBe('');
     expect(resolveRepositoryHomepage('   ')).toBe('');
   });

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -46,6 +46,13 @@ export function resolveRepositoryHomepage(homepage?: string | null): string {
       return '';
     }
 
+    if (parsed.username || parsed.password) {
+      return '';
+    }
+
+    parsed.search = '';
+    parsed.hash = '';
+
     return parsed.toString().replace(/\/+$/, '');
   } catch {
     return '';


### PR DESCRIPTION
## Summary

Rebased implementation of the custom-domain homepage visibility fix so it merges cleanly on current `main`.

This carries forward the same behavior as #344 (accept valid custom-domain `homepage` URLs instead of requiring `github.io`) and resolves the test conflict introduced by later additions to `check-visibility` tests.

## Changes

- Keep `resolveRepositoryHomepage()` URL parsing + protocol allowlist (`http`/`https`).
- Keep normalized homepage reuse in `resolveDeployedBaseUrl()`.
- Keep homepage validity check based on normalized URL presence.
- Merge both test suites in `scripts/__tests__/check-visibility.test.ts`:
  - homepage normalization/validation regressions
  - existing OG type + Twitter alt helper tests

Fixes #343

## Validation

- `npm --prefix web run test -- --run scripts/__tests__/check-visibility.test.ts`
- `npm --prefix web run lint`
