### PR TITLE
docs: add canonical body-file artifact workflow (rebased)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,27 @@ The script evaluates open PRs against the approved #307 criteria:
 
 Use `npm run fast-track-candidates -- --json` for machine-readable output.
 
+## GitHub Artifact Hygiene
+
+When posting non-trivial content (issue comments, PR comments, reviews), use a canonical text source and verify the published result.
+
+1. Compose content in a file and post with `--body-file`:
+   ```bash
+   cat > /tmp/review.md <<'EOF'
+   <comment body>
+   EOF
+   gh pr review <pr-number> --approve --body-file /tmp/review.md
+   # or: gh issue comment <issue-number> --body-file /tmp/review.md
+   ```
+2. Immediately read back the published artifact:
+   ```bash
+   gh pr view <pr-number> --comments
+   # or: gh issue view <issue-number> --comments
+   ```
+3. If formatting is broken, edit the same artifact in place and append an `Edit note` footer with what changed and why.
+
+Avoid inline shell strings for long markdown bodies; they are error-prone with backticks, `<`/`>`, and escaped newlines.
+
 ## Pull Requests
 
 - Link the issue in the description with "Fixes #123"


### PR DESCRIPTION
Closes #358

Supersedes #358.

## Summary
- carries forward the approved `GitHub Artifact Hygiene` section in `CONTRIBUTING.md`
- rebases the change cleanly on current `main` and resolves the single `CONTRIBUTING.md` conflict
- preserves newer `Fast-Track Fallback (Issue #307)` guidance while adding the artifact workflow section

## Why
PR #358 is approved but conflict-stale and cannot be updated directly from this token (`push=false` to upstream). This fork-first PR provides a merge-ready equivalent on top of latest `main`.

## Validation
- Documentation-only conflict resolution reviewed locally in `CONTRIBUTING.md`