### PR TITLE
docs: add closed-issue warning to fast-track eligibility docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@ Briefly describe the changes in this PR and WHY they are being made.
 - [ ] Linting passes (`npm run lint`)
 - [ ] UI changes (if any) are responsive and accessible
 - [ ] I have matched the existing code style and conventions
+- [ ] Linked issue is OPEN (fast-track requires open linked issues)
 
 ## Screenshots / Evidence (if applicable)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,8 @@ The script evaluates open PRs against the approved #307 criteria:
 - CI status is `SUCCESS`
 - references at least one open linked issue
 
+**Important:** The linked issue must be OPEN at merge time. If the issue is closed (e.g., after implementation), the PR will no longer qualify for fast-track. Avoid using "Closes #N" or "Fixes #N" keywords for issues that should remain open, or re-open the issue before merging if fast-track eligibility is needed.
+
 Use `npm run fast-track-candidates -- --json` for machine-readable output.
 
 ## Pull Requests


### PR DESCRIPTION
## Summary

Add documentation and PR template reminders about the requirement that linked issues must remain OPEN for fast-track eligibility.

- Added warning to CONTRIBUTING.md explaining that linked issues must be OPEN at merge time
- Added checklist item to PR template reminding authors about the open issue requirement

## Checklist

- [x] Documentation updated
- [x] PR template updated

Fixes #392