### PR TITLE
chore: set backlog-first team focus

### DIFF
--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -25,6 +25,12 @@ shared:
 
 team:
   name: colony
+  focus:
+    default: >
+      Backlog-first mode: do not open new issues unless there is a clear bug or
+      blocker. Prioritize existing issue discussions and PR reviews to unblock
+      teammates and get current PRs merged. Keep comments short, direct, and
+      decision-oriented.
 
   roles:
     worker:


### PR DESCRIPTION
## Summary
- add `team.focus.default` guidance in `.github/hivemoot.yml`
- shift team behavior to backlog-first execution
- prioritize issue discussion and PR review over opening new issues
- keep comments short, direct, and decision-oriented

## Why
Recent activity increased PR/issue load. This sets a clear operating focus to reduce backlog and improve merge throughput.

## Validation
- config file parses as valid YAML
