### PR TITLE
fix: require https homepage for visibility checks (rebased)

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -3,6 +3,7 @@ import {
   buildRepositoryApiUrl,
   hasTwitterImageAltText,
   isValidOpenGraphImageType,
+  resolveDeployedBaseUrl,
   resolveRepositoryHomepage,
   resolveVisibilityRepository,
   resolveVisibilityUserAgent,
@@ -49,13 +50,37 @@ describe('resolveRepositoryHomepage', () => {
     ).toBe('https://colony.example.org/path');
   });
 
-  it('rejects invalid or unsupported homepage URLs', () => {
+  it('rejects non-https, invalid, or unsupported homepage URLs', () => {
+    expect(resolveRepositoryHomepage('http://colony.example.org')).toBe('');
     expect(resolveRepositoryHomepage('ftp://colony.example.org')).toBe('');
     expect(
       resolveRepositoryHomepage('https://user:pass@colony.example.org')
     ).toBe('');
     expect(resolveRepositoryHomepage('not-a-url')).toBe('');
     expect(resolveRepositoryHomepage('   ')).toBe('');
+  });
+});
+
+describe('resolveDeployedBaseUrl', () => {
+  it('uses normalized https homepage when valid', () => {
+    expect(resolveDeployedBaseUrl(' https://example.com/path/ ')).toEqual({
+      baseUrl: 'https://example.com/path',
+      usedFallback: false,
+    });
+  });
+
+  it('falls back when homepage is non-https', () => {
+    expect(resolveDeployedBaseUrl('http://example.com/path')).toEqual({
+      baseUrl: 'https://hivemoot.github.io/colony',
+      usedFallback: true,
+    });
+  });
+
+  it('falls back when homepage URL is malformed', () => {
+    expect(resolveDeployedBaseUrl('not-a-url')).toEqual({
+      baseUrl: 'https://hivemoot.github.io/colony',
+      usedFallback: true,
+    });
   });
 });
 

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -52,11 +52,12 @@ export function resolveRepositoryHomepage(homepage?: string | null): string {
 
   try {
     const parsed = new URL(trimmedHomepage);
-    if (!['http:', 'https:'].includes(parsed.protocol)) {
-      return '';
-    }
-
-    if (parsed.username || parsed.password) {
+    if (
+      parsed.protocol !== 'https:' ||
+      !parsed.hostname ||
+      parsed.username ||
+      parsed.password
+    ) {
       return '';
     }
 
@@ -76,7 +77,7 @@ function readIfExists(path: string): string {
   return readFileSync(path, 'utf-8');
 }
 
-function resolveDeployedBaseUrl(homepage?: string): {
+export function resolveDeployedBaseUrl(homepage?: string): {
   baseUrl: string;
   usedFallback: boolean;
 } {


### PR DESCRIPTION
## Summary
- require repository homepage metadata to be absolute `https://` before visibility checks treat it as valid
- continue normalizing homepage URLs (drop query/hash and trailing slash) for stable deployed checks
- keep explicit fallback to `https://hivemoot.github.io/colony` when homepage metadata is missing/invalid
- add/update regression coverage in `check-visibility` and `generate-data` tests

## Why
`check-visibility` and `generate-data` currently accept non-HTTPS homepage values. That can create false-green metadata checks and route deployed checks to insecure endpoints.

This hardening ensures only trusted HTTPS homepage metadata is used.

Supersedes stale/conflicted work in #375.

## Validation
- `npm --prefix web run lint -- scripts/check-visibility.ts scripts/generate-data.ts scripts/__tests__/check-visibility.test.ts scripts/__tests__/generate-data.test.ts`
- `npm --prefix web run test -- --run scripts/__tests__/check-visibility.test.ts scripts/__tests__/generate-data.test.ts`

---
Edit note (2026-02-17): Replaced shell-expanded PR body with canonical markdown.