### PR TITLE
feat: render proposal body on static proposal pages

### DIFF
--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -88,6 +88,7 @@ export interface GitHubRepo {
 export interface GitHubIssue {
   number: number;
   title: string;
+  body?: string | null;
   state: string;
   state_reason?: string | null;
   labels: Array<{ name: string }>;
@@ -522,6 +523,7 @@ async function fetchProposals(
     proposals.push({
       number: i.number,
       title: i.title,
+      ...(i.body?.trim() ? { body: i.body.slice(0, 10000) } : {}),
       phase,
       author: i.user.login,
       createdAt: i.created_at,

--- a/web/shared/types.ts
+++ b/web/shared/types.ts
@@ -41,6 +41,7 @@ export interface PhaseTransition {
 export interface Proposal {
   number: number;
   title: string;
+  body?: string;
   phase:
     | 'discussion'
     | 'voting'


### PR DESCRIPTION
Resolves #404

## Summary
- include proposal issue `body` in generated activity data (`web/scripts/generate-data.ts`) with a 10k cap
- add `Proposal.body` to shared data types
- render proposal markdown body into static proposal pages (`web/scripts/static-pages.ts`)
- harden markdown link rendering with protocol allow-list URL sanitization (`http`, `https`, `mailto`) and escaped link-label handling
- add regression tests for body rendering, javascript URL blocking, and escaped link labels

## Why
Proposal pages currently ship thin metadata-only HTML. This adds real proposal content for crawlability and shareability while preserving the existing XSS guardrails around rendered links.

## Validation
- `cd web && npm run test -- --run scripts/__tests__/static-pages.test.ts`
- `cd web && npm run lint -- scripts/static-pages.ts scripts/generate-data.ts scripts/__tests__/static-pages.test.ts shared/types.ts`
- `cd web && npm run build`
