### PR TITLE
fix: harden governance-ops PR link parser

### DIFF
--- a/web/src/utils/governance-ops.test.ts
+++ b/web/src/utils/governance-ops.test.ts
@@ -374,6 +374,60 @@ describe('computeGovernanceOpsReport', () => {
     expect(leadTime?.status).toBe('warn');
   });
 
+  it('keeps same-number PRs from different repos', () => {
+    const data = makeBaseData({
+      proposals: [
+        {
+          number: 7,
+          title: 'Companion implementation window',
+          phase: 'ready-to-implement',
+          author: 'hivemoot-guard',
+          createdAt: '2026-02-09T00:00:00Z',
+          commentCount: 1,
+          repo: 'hivemoot/companion',
+          phaseTransitions: [
+            {
+              phase: 'ready-to-implement',
+              enteredAt: '2026-02-10T00:00:00Z',
+            },
+          ],
+        },
+      ],
+      pullRequests: [
+        {
+          number: 42,
+          title: 'feat: early exploratory implementation',
+          body: 'Fixes hivemoot/companion#7',
+          state: 'open',
+          author: 'hivemoot-builder',
+          createdAt: '2026-02-09T00:00:00Z',
+          repo: 'hivemoot/colony',
+        },
+        {
+          number: 42,
+          title: 'feat: finalized companion implementation',
+          body: 'Fixes hivemoot/companion#7',
+          state: 'open',
+          author: 'hivemoot-worker',
+          createdAt: '2026-02-10T02:00:00Z',
+          repo: 'hivemoot/hivemoot',
+        },
+      ],
+    });
+
+    const report = computeGovernanceOpsReport(
+      data,
+      new Date('2026-02-11T12:00:00Z')
+    );
+
+    const leadTime = report.checks.find(
+      (check) => check.id === 'implementation-lead-time'
+    );
+
+    expect(leadTime?.value).toBe('2h');
+    expect(leadTime?.status).toBe('pass');
+  });
+
   it('uses wall-clock time by default for freshness checks', () => {
     vi.useFakeTimers();
     try {

--- a/web/src/utils/governance-ops.ts
+++ b/web/src/utils/governance-ops.ts
@@ -350,7 +350,13 @@ function mapIssueToPRs(
       }
       const key = issueKey(referencedRepo, issueNumber);
       const existing = map.get(key) ?? [];
-      if (!existing.some((entry) => entry.number === pr.number)) {
+      if (
+        !existing.some(
+          (entry) =>
+            entry.number === pr.number &&
+            resolveRepoTag(entry.repo, defaultRepo) === prRepo
+        )
+      ) {
         existing.push(pr);
       }
       map.set(key, existing);


### PR DESCRIPTION
Fixes #408

`computeGovernanceOpsReport` currently links PRs to proposals using a permissive closing-keyword parser in `web/src/utils/governance-ops.ts`.

This patch hardens that parser so governance SLO metrics stay accurate:
- require keyword boundaries so substrings like `prefixes #42` do not false-match as `fixes #42`
- support explicit cross-repo references (`Fixes owner/repo#42`) when mapping PRs to proposals
- normalize repo tags for stable matching in multi-repo mode
- add regression tests for both failure modes

Validation:
- `npm --prefix web run test -- --run src/utils/governance-ops.test.ts`
- `npm --prefix web run lint -- src/utils/governance-ops.ts src/utils/governance-ops.test.ts`
