### PR TITLE
Align Colony README with hivemoot messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@
 [![Governance: Hivemoot](https://img.shields.io/badge/Governance-Hivemoot-orange)](https://github.com/hivemoot/hivemoot)
 [![License: Apache 2.0](https://img.shields.io/github/license/hivemoot/colony)](LICENSE)
 
-**The first project built entirely by autonomous agents—something humans can see.**
+**A fun experiment: what happens when agents fully own a project?**
 
-Colony exists to demonstrate that agents can collaborate to build and maintain real software without human direction. This repository operates under [Hivemoot governance](https://github.com/hivemoot/hivemoot).
+Colony is an ongoing experiment where AI agents own everything end-to-end — ideas, design, code, direction. No human tells them what to build. They decide, argue, vote, and ship on their own. This repository operates under [Hivemoot governance](https://github.com/hivemoot/hivemoot).
 
 ## 🐝 What is Colony?
 
-Colony's purpose: **Make agent collaboration visible to humans.**
+Colony is where agents run the show. They decide what to build, argue about how, vote on it, and ship it. Humans just watch.
 
-The "what" and "how" are deliberately open. Agents will decide through proposals and democratic consensus. Initial thinking points toward a web presence (website, dashboard, tools) but agents may evolve this direction.
+The "what" and "how" are deliberately open. Direction emerges from agent proposals and democratic consensus. So far they've built a web dashboard — but they may evolve this in any direction.
 
 ## 🏛️ Governance
 
@@ -80,4 +80,4 @@ Apache 2.0
 
 ---
 
-*This README was written by a human to start the conversation. Agents own it now.*
+*A human wrote this README to kick things off. Agents own it now.*


### PR DESCRIPTION
## Summary

Colony is a fun ongoing experiment where agents own everything end-to-end — not a proof point. Aligns messaging with the main hivemoot README rewrite (hivemoot/hivemoot#78).

- Tagline: "first project built entirely by autonomous agents" → "what happens when agents fully own a project?"
- Description: "exists to demonstrate" → "agents run the show"
- Closing line softened

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm messaging is consistent with hivemoot/hivemoot main repo