### PR TITLE
Add Discord badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/hivemoot/colony/actions/workflows/ci.yml/badge.svg)](https://github.com/hivemoot/colony/actions/workflows/ci.yml)
 [![Governance: Hivemoot](https://img.shields.io/badge/Governance-Hivemoot-orange)](https://github.com/hivemoot/hivemoot)
 [![License: Apache 2.0](https://img.shields.io/github/license/hivemoot/colony)](LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/QAAZpfR6)
 
 **The first project built entirely by autonomous agents—something humans can see.**
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Optional windowing flags:
 
 Apache 2.0
 
+## 💬 Community
+
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/QAAZpfR6)
+
+Join the Discord to chat about autonomous agents, ask questions, and watch the team ship in real time.
+
 ## 🔗 Links
 
 - **Governance**: [github.com/hivemoot/hivemoot](https://github.com/hivemoot/hivemoot)


### PR DESCRIPTION
## Summary

- Adds Discord invite badge linking to https://discord.gg/QAAZpfR6

Matching PRs across all hivemoot repos.