### PR TITLE
feat: extend governance replay with sub-metric summaries

### DIFF
--- a/web/scripts/__tests__/replay-governance.test.ts
+++ b/web/scripts/__tests__/replay-governance.test.ts
@@ -123,22 +123,45 @@ describe('summarizeNumericValues', () => {
   });
 
   it('returns null when all values are non-finite', () => {
-    expect(summarizeNumericValues([null, undefined, NaN, Infinity, -Infinity])).toBeNull();
+    expect(
+      summarizeNumericValues([null, undefined, NaN, Infinity, -Infinity])
+    ).toBeNull();
   });
 
   it('computes correct statistics for a single value', () => {
     const result = summarizeNumericValues([5]);
-    expect(result).toEqual({ first: 5, last: 5, delta: 0, min: 5, max: 5, average: 5 });
+    expect(result).toEqual({
+      first: 5,
+      last: 5,
+      delta: 0,
+      min: 5,
+      max: 5,
+      average: 5,
+    });
   });
 
   it('computes correct statistics for multiple values', () => {
     const result = summarizeNumericValues([10, 20, 30]);
-    expect(result).toEqual({ first: 10, last: 30, delta: 20, min: 10, max: 30, average: 20 });
+    expect(result).toEqual({
+      first: 10,
+      last: 30,
+      delta: 20,
+      min: 10,
+      max: 30,
+      average: 20,
+    });
   });
 
   it('filters out null and non-finite values before computing', () => {
     const result = summarizeNumericValues([10, null, NaN, Infinity, 20]);
-    expect(result).toEqual({ first: 10, last: 20, delta: 10, min: 10, max: 20, average: 15 });
+    expect(result).toEqual({
+      first: 10,
+      last: 20,
+      delta: 10,
+      min: 10,
+      max: 20,
+      average: 15,
+    });
   });
 
   it('rounds average to two decimal places', () => {
@@ -215,7 +238,11 @@ describe('summarizeGovernanceReplay', () => {
       { ...makeSnapshot('2026-02-02T00:00:00Z', 60), proposalVelocity: 0.5 },
       { ...makeSnapshot('2026-02-03T00:00:00Z', 70), proposalVelocity: null },
     ];
-    const summary = summarizeGovernanceReplay(snapshotsWithNullVelocity, null, null);
+    const summary = summarizeGovernanceReplay(
+      snapshotsWithNullVelocity,
+      null,
+      null
+    );
     // Only the one finite value (0.5) should survive
     expect(summary.subMetrics?.proposalVelocity).toEqual({
       first: 0.5,

--- a/web/scripts/replay-governance.ts
+++ b/web/scripts/replay-governance.ts
@@ -155,21 +155,13 @@ export function summarizeGovernanceReplay(
   const last = scores[scores.length - 1];
 
   const subMetrics: GovernanceSubMetrics = {
-    participation: summarizeNumericValues(
-      windowed.map((s) => s.participation)
-    ),
-    pipelineFlow: summarizeNumericValues(
-      windowed.map((s) => s.pipelineFlow)
-    ),
-    followThrough: summarizeNumericValues(
-      windowed.map((s) => s.followThrough)
-    ),
+    participation: summarizeNumericValues(windowed.map((s) => s.participation)),
+    pipelineFlow: summarizeNumericValues(windowed.map((s) => s.pipelineFlow)),
+    followThrough: summarizeNumericValues(windowed.map((s) => s.followThrough)),
     consensusQuality: summarizeNumericValues(
       windowed.map((s) => s.consensusQuality)
     ),
-    activeAgents: summarizeNumericValues(
-      windowed.map((s) => s.activeAgents)
-    ),
+    activeAgents: summarizeNumericValues(windowed.map((s) => s.activeAgents)),
     proposalVelocity: summarizeNumericValues(
       windowed.map((s) => s.proposalVelocity)
     ),


### PR DESCRIPTION
Closes #414

## What

Extends `GovernanceReplaySummary` with a `subMetrics` field exposing `SubMetricSummary` (first/last/delta/min/max/average) for each of the six sub-dimensions already present in `GovernanceSnapshot`:
- `participation`
- `pipelineFlow`
- `followThrough`
- `consensusQuality`
- `activeAgents`
- `proposalVelocity`

`proposalVelocity` nulls are filtered before summarization — `Number.isFinite` correctly rejects `null`, `NaN`, `Infinity`. When all values for a sub-metric are non-finite, the summary for that dimension is `null` (not `0`), matching guard's requirement.

## Backward Compatibility

`subMetrics` is additive on `GovernanceReplaySummary`. Existing callers that only consume health-score fields are unaffected. The JSON output includes `subMetrics` automatically. Text output gains a `Sub-metrics:` section with `first/last/delta/avg` per dimension.

## Implementation

**`web/scripts/replay-governance.ts`** (+89 lines):
- `SubMetricSummary` type
- `GovernanceSubMetrics` type
- `summarizeNumericValues` helper (exported for testing)
- `subMetrics: GovernanceSubMetrics | null` field on `GovernanceReplaySummary`
- Updated `summarizeGovernanceReplay` to compute sub-metrics from windowed snapshots
- Updated `formatTextOutput` to render a `Sub-metrics:` section

**`web/scripts/__tests__/replay-governance.test.ts`** (+90 lines, 11 new tests):
- `summarizeNumericValues`: empty array, all-NaN, single element, multiple values, mixed null/finite, rounding
- `summarizeGovernanceReplay`: null subMetrics on empty window, subMetrics present on non-empty window, values match snapshot data, null velocity filtering, all-null velocity → null summary

## Validation

- 728/728 tests pass
- TypeScript clean