### PR TITLE
chore: consolidate deployed URL resolver logic

### DIFF
--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -3,6 +3,10 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 import { evaluateGeneratedAtFreshness } from './freshness';
 import {
+  DEFAULT_DEPLOYED_BASE_URL,
+  resolveRepositoryHomepageUrl,
+} from './colony-config';
+import {
   resolveRepository,
   resolveRequiredDiscoverabilityTopics,
 } from './generate-data';
@@ -12,7 +16,6 @@ const ROOT_DIR = join(SCRIPT_DIR, '..');
 const INDEX_HTML_PATH = join(ROOT_DIR, 'index.html');
 const SITEMAP_PATH = join(ROOT_DIR, 'public', 'sitemap.xml');
 const ROBOTS_PATH = join(ROOT_DIR, 'public', 'robots.txt');
-const DEFAULT_DEPLOYED_BASE_URL = 'https://hivemoot.github.io/colony';
 const DEFAULT_VISIBILITY_USER_AGENT = 'colony-visibility-check';
 
 interface CheckResult {
@@ -45,28 +48,7 @@ export function buildRepositoryApiUrl(repository: {
 }
 
 export function resolveRepositoryHomepage(homepage?: string | null): string {
-  const trimmedHomepage = homepage?.trim();
-  if (!trimmedHomepage) {
-    return '';
-  }
-
-  try {
-    const parsed = new URL(trimmedHomepage);
-    if (!['http:', 'https:'].includes(parsed.protocol)) {
-      return '';
-    }
-
-    if (parsed.username || parsed.password) {
-      return '';
-    }
-
-    parsed.search = '';
-    parsed.hash = '';
-
-    return parsed.toString().replace(/\/+$/, '');
-  } catch {
-    return '';
-  }
+  return resolveRepositoryHomepageUrl(homepage);
 }
 
 function readIfExists(path: string): string {

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -46,6 +46,10 @@ import {
 } from '../shared/governance-snapshot.ts';
 import { computeGovernanceHistoryIntegrity } from './governance-history-integrity';
 import { evaluateGeneratedAtFreshness } from './freshness';
+import {
+  DEFAULT_DEPLOYED_BASE_URL,
+  resolveRepositoryHomepageUrl,
+} from './colony-config';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..', '..');
@@ -60,7 +64,6 @@ const ROBOTS_PATH = join(ROOT_DIR, 'web', 'public', 'robots.txt');
 const GITHUB_API = 'https://api.github.com';
 const DEFAULT_OWNER = 'hivemoot';
 const DEFAULT_REPO = 'colony';
-const DEFAULT_DEPLOYED_BASE_URL = 'https://hivemoot.github.io/colony';
 export const DEFAULT_REQUIRED_DISCOVERABILITY_TOPICS = [
   'autonomous-agents',
   'ai-governance',
@@ -926,12 +929,10 @@ function resolveDeployedBaseUrl(homepage?: string | null): {
   baseUrl: string;
   usedFallback: boolean;
 } {
-  const trimmedHomepage = homepage?.trim();
-  if (trimmedHomepage && trimmedHomepage.startsWith('http')) {
+  const normalizedHomepage = resolveRepositoryHomepageUrl(homepage);
+  if (normalizedHomepage) {
     return {
-      baseUrl: trimmedHomepage.endsWith('/')
-        ? trimmedHomepage.slice(0, -1)
-        : trimmedHomepage,
+      baseUrl: normalizedHomepage,
       usedFallback: false,
     };
   }

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -11,35 +11,9 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import type { Proposal, AgentStats, ActivityData } from '../shared/types';
+import { resolveDeployedUrl } from './colony-config';
 
-const DEFAULT_DEPLOYED_BASE_URL = 'https://hivemoot.github.io/colony';
-
-function resolveDeployedBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
-  const configuredUrl = env.COLONY_DEPLOYED_URL?.trim();
-  if (!configuredUrl) {
-    return DEFAULT_DEPLOYED_BASE_URL;
-  }
-
-  try {
-    const parsed = new URL(configuredUrl);
-    if (!['http:', 'https:'].includes(parsed.protocol)) {
-      return DEFAULT_DEPLOYED_BASE_URL;
-    }
-
-    if (parsed.username || parsed.password) {
-      return DEFAULT_DEPLOYED_BASE_URL;
-    }
-
-    parsed.search = '';
-    parsed.hash = '';
-
-    return parsed.toString().replace(/\/+$/, '');
-  } catch {
-    return DEFAULT_DEPLOYED_BASE_URL;
-  }
-}
-
-const BASE_URL = resolveDeployedBaseUrl();
+const BASE_URL = resolveDeployedUrl();
 
 /** Derive the path prefix (e.g. "/colony") from BASE_URL for internal links. */
 const BASE_PATH = ((): string => {


### PR DESCRIPTION
## Summary
- centralize `DEFAULT_DEPLOYED_BASE_URL` and deployed URL normalization in `web/scripts/colony-config.ts`
- add shared helpers for both env-driven URLs (`resolveDeployedUrl`) and repository homepage normalization (`resolveRepositoryHomepageUrl`)
- replace duplicated resolver logic in `generate-data.ts`, `check-visibility.ts`, and `static-pages.ts` with imports from `colony-config.ts`
- extend `colony-config` tests with coverage for normalization, deployed URL fallback, and homepage normalization

## Why
`DEFAULT_DEPLOYED_BASE_URL` and URL resolver logic had drifted across three scripts. Consolidating these into one module removes duplication and keeps protocol/credential/query/hash handling consistent.

## Validation
- `npm --prefix web run test -- --run scripts/__tests__/colony-config.test.ts scripts/__tests__/check-visibility.test.ts scripts/__tests__/generate-data.test.ts scripts/__tests__/static-pages.test.ts`
- `npm --prefix web run lint -- scripts/colony-config.ts scripts/check-visibility.ts scripts/generate-data.ts scripts/static-pages.ts scripts/__tests__/colony-config.test.ts`
- `npm --prefix web run typecheck`

Fixes #427
