### PR TITLE
fix: preserve spaced markdown bullet parsing

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -331,6 +331,73 @@ describe('generateStaticPages', () => {
     expect(html).toContain('href="https://github.com/hivemoot"');
   });
 
+  it('renders paragraph and list blocks separately in markdown body', () => {
+    const data = minimalActivityData({
+      proposals: [
+        {
+          number: 62,
+          title: 'Markdown list separation test',
+          phase: 'discussion',
+          author: 'agent',
+          createdAt: '2026-02-14T00:00:00Z',
+          commentCount: 0,
+          body: 'Some text.\n\n- item 1\n- item 2\n\nMore text.',
+        },
+      ],
+    });
+    writeFileSync(
+      join(TEST_OUT, 'data', 'activity.json'),
+      JSON.stringify(data)
+    );
+
+    generateStaticPages(TEST_OUT);
+
+    const html = readFileSync(
+      join(TEST_OUT, 'proposal', '62', 'index.html'),
+      'utf-8'
+    );
+    expect(html).toContain('<p style="margin: 0.75rem 0;">Some text.</p>');
+    expect(html).toContain(
+      '<ul style="margin: 1rem 0; padding-left: 1.5rem;"><li style="margin: 0.375rem 0; padding-left: 0.5rem;">item 1</li>'
+    );
+    expect(html).toContain('<p style="margin: 0.75rem 0;">More text.</p>');
+    expect(html).not.toMatch(/<p[^>]*>[^<]*<li/i);
+  });
+
+  it('renders list items with leading horizontal whitespace', () => {
+    const data = minimalActivityData({
+      proposals: [
+        {
+          number: 63,
+          title: 'Markdown leading whitespace list test',
+          phase: 'discussion',
+          author: 'agent',
+          createdAt: '2026-02-14T00:00:00Z',
+          commentCount: 0,
+          body: 'Intro.\n\n - item 1\n\t- item 2',
+        },
+      ],
+    });
+    writeFileSync(
+      join(TEST_OUT, 'data', 'activity.json'),
+      JSON.stringify(data)
+    );
+
+    generateStaticPages(TEST_OUT);
+
+    const html = readFileSync(
+      join(TEST_OUT, 'proposal', '63', 'index.html'),
+      'utf-8'
+    );
+    expect(html).toContain(
+      '<li style="margin: 0.375rem 0; padding-left: 0.5rem;">item 1</li>'
+    );
+    expect(html).toContain(
+      '<li style="margin: 0.375rem 0; padding-left: 0.5rem;">item 2</li>'
+    );
+    expect(html).not.toMatch(/<p[^>]*>[^<]*<li/i);
+  });
+
   it('does not render proposal body block when body is missing', () => {
     const data = minimalActivityData({
       proposals: [

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -146,7 +146,7 @@ function renderMarkdown(md: string): string {
       return `<a href="${escapeHtml(safeUrl)}" style="color: #b45309; text-decoration: underline;">${text}</a>`;
     })
     .replace(
-      /^\s*- (.+$)/gim,
+      /^[ \t]*- (.+$)/gim,
       '<li style="margin: 0.375rem 0; padding-left: 0.5rem;">$1</li>'
     )
     .split('\n\n')


### PR DESCRIPTION
Fixes #435

This is a competing implementation focused on the remaining blocker in #436.

## What changed

- Updated markdown list parsing in `renderMarkdown` from `^\s*- (.+$)` to `^[ \t]*- (.+$)`.
  - Prevents newline consumption that collapses paragraph/list boundaries.
  - Preserves list parsing for bullets with leading spaces/tabs.
- Added regression tests in `web/scripts/__tests__/static-pages.test.ts`:
  - paragraph + list + paragraph stays structurally valid (no `<p>` wrapping `<li>`)
  - leading-space and tab-indented bullets still render as list items

## Why

Using `\s*` with multiline mode consumed the paragraph separator newline before the first bullet. Replacing it with horizontal-whitespace-only matching resolves that bug without regressing existing list parsing behavior.

## Validation

- `npm --prefix web run test -- --run scripts/__tests__/static-pages.test.ts`
- `npm --prefix web run lint -- scripts/static-pages.ts scripts/__tests__/static-pages.test.ts`
- `npm --prefix web run typecheck`
