### PR TITLE
feat(web): add automated governance health assessment engine

### DIFF
--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -18,6 +18,7 @@ import { GovernanceOps } from './GovernanceOps';
 import { GovernanceBalance } from './GovernanceBalance';
 import { VelocityMetrics } from './VelocityMetrics';
 import { BenchmarkPanel } from './BenchmarkPanel';
+import { GovernanceAssessment } from './GovernanceAssessment';
 import { CollaborationNetwork } from './CollaborationNetwork';
 import { ProposalList } from './ProposalList';
 import { CommentList } from './CommentList';
@@ -281,6 +282,25 @@ export function ActivityFeed({
                 Governance Analytics
               </h2>
               <GovernanceAnalytics data={data} />
+            </section>
+          )}
+
+          {data && data.proposals.length > 0 && (
+            <section
+              id="assessment"
+              aria-labelledby="section-assessment"
+              className="bg-white/50 dark:bg-neutral-700/50 rounded-xl p-6 backdrop-blur-sm border border-amber-200 dark:border-neutral-600"
+            >
+              <h2
+                id="section-assessment"
+                className="text-xl font-bold text-amber-900 dark:text-amber-100 mb-4 flex items-center justify-center gap-2"
+              >
+                <span role="img" aria-label="assessment">
+                  🔍
+                </span>
+                Governance Assessment
+              </h2>
+              <GovernanceAssessment data={data} history={governanceHistory} />
             </section>
           )}
 

--- a/web/src/components/GovernanceAssessment.test.tsx
+++ b/web/src/components/GovernanceAssessment.test.tsx
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { GovernanceAssessment } from './GovernanceAssessment';
+import type { ActivityData, AgentStats, Proposal } from '../types/activity';
+import type { GovernanceSnapshot } from '../../shared/governance-snapshot';
+
+function makeAgentStats(overrides: Partial<AgentStats> = {}): AgentStats {
+  return {
+    login: 'agent-a',
+    commits: 5,
+    pullRequestsMerged: 3,
+    issuesOpened: 2,
+    reviews: 5,
+    comments: 10,
+    lastActiveAt: '2026-02-10T12:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
+  return {
+    number: 1,
+    title: 'Test proposal',
+    phase: 'discussion',
+    author: 'agent-a',
+    createdAt: '2026-02-05T09:00:00Z',
+    commentCount: 3,
+    ...overrides,
+  };
+}
+
+function makeActivityData(overrides: Partial<ActivityData> = {}): ActivityData {
+  return {
+    generatedAt: '2026-02-10T12:00:00Z',
+    repository: {
+      owner: 'hivemoot',
+      name: 'colony',
+      url: 'https://github.com/hivemoot/colony',
+      stars: 10,
+      forks: 2,
+      openIssues: 5,
+    },
+    agents: [],
+    agentStats: [
+      makeAgentStats({ login: 'agent-a', reviews: 5, comments: 10 }),
+      makeAgentStats({ login: 'agent-b', reviews: 5, comments: 8 }),
+      makeAgentStats({ login: 'agent-c', reviews: 4, comments: 6 }),
+      makeAgentStats({ login: 'agent-d', reviews: 3, comments: 5 }),
+    ],
+    commits: [],
+    issues: [],
+    pullRequests: [],
+    comments: [],
+    proposals: [
+      makeProposal({ number: 1, phase: 'implemented', commentCount: 5 }),
+      makeProposal({ number: 2, phase: 'implemented', commentCount: 4 }),
+      makeProposal({ number: 3, phase: 'voting', commentCount: 3 }),
+    ],
+    ...overrides,
+  };
+}
+
+function makeSnapshot(
+  overrides: Partial<GovernanceSnapshot> = {}
+): GovernanceSnapshot {
+  return {
+    timestamp: '2026-02-10T12:00:00Z',
+    healthScore: 65,
+    participation: 18,
+    pipelineFlow: 15,
+    followThrough: 17,
+    consensusQuality: 15,
+    activeProposals: 5,
+    totalProposals: 20,
+    activeAgents: 4,
+    proposalVelocity: 1.5,
+    ...overrides,
+  };
+}
+
+describe('GovernanceAssessment', () => {
+  it('renders healthy status when no alerts or patterns', () => {
+    const data = makeActivityData();
+    render(<GovernanceAssessment data={data} history={[]} />);
+    expect(
+      screen.getByText(/no governance alerts or patterns detected/i)
+    ).toBeDefined();
+  });
+
+  it('renders alerts when health is declining', () => {
+    const data = makeActivityData();
+    const history = [
+      makeSnapshot({ timestamp: '2026-02-07T00:00:00Z', healthScore: 70 }),
+      makeSnapshot({ timestamp: '2026-02-08T00:00:00Z', healthScore: 65 }),
+      makeSnapshot({ timestamp: '2026-02-09T00:00:00Z', healthScore: 60 }),
+      makeSnapshot({ timestamp: '2026-02-10T00:00:00Z', healthScore: 55 }),
+    ];
+    render(<GovernanceAssessment data={data} history={history} />);
+    expect(screen.getByText('Health score declining')).toBeDefined();
+  });
+
+  it('renders merge queue alert with many open PRs', () => {
+    const openPRs = Array.from({ length: 15 }, (_, i) => ({
+      number: i + 1,
+      title: `PR ${i + 1}`,
+      state: 'open' as const,
+      author: 'agent-a',
+      createdAt: '2026-02-09T00:00:00Z',
+    }));
+    const data = makeActivityData({ pullRequests: openPRs });
+    render(<GovernanceAssessment data={data} history={[]} />);
+    expect(screen.getByText('Merge queue bottleneck')).toBeDefined();
+  });
+
+  it('renders 7-day trend when history is available', () => {
+    const history = [
+      makeSnapshot({
+        timestamp: '2026-02-03T00:00:00Z',
+        healthScore: 60,
+        participation: 15,
+      }),
+      makeSnapshot({
+        timestamp: '2026-02-10T00:00:00Z',
+        healthScore: 70,
+        participation: 20,
+      }),
+    ];
+    // Need to trigger at least one alert or pattern for the section to render
+    const openPRs = Array.from({ length: 15 }, (_, i) => ({
+      number: i + 1,
+      title: `PR ${i + 1}`,
+      state: 'open' as const,
+      author: 'agent-a',
+      createdAt: '2026-02-09T00:00:00Z',
+    }));
+    const data = makeActivityData({ pullRequests: openPRs });
+    render(<GovernanceAssessment data={data} history={history} />);
+    expect(screen.getByText('7-Day Trend')).toBeDefined();
+    expect(screen.getByText('+10')).toBeDefined(); // health delta
+  });
+
+  it('renders insufficient history message', () => {
+    const openPRs = Array.from({ length: 15 }, (_, i) => ({
+      number: i + 1,
+      title: `PR ${i + 1}`,
+      state: 'open' as const,
+      author: 'agent-a',
+      createdAt: '2026-02-09T00:00:00Z',
+    }));
+    const data = makeActivityData({ pullRequests: openPRs });
+    render(<GovernanceAssessment data={data} history={[]} />);
+    expect(
+      screen.getByText(/insufficient history for trend analysis/i)
+    ).toBeDefined();
+  });
+
+  it('renders pattern detection results', () => {
+    const proposals = [
+      makeProposal({ phase: 'implemented', commentCount: 1 }),
+      makeProposal({ phase: 'implemented', commentCount: 1 }),
+      makeProposal({ phase: 'implemented', commentCount: 1 }),
+      makeProposal({ phase: 'implemented', commentCount: 0 }),
+    ];
+    const data = makeActivityData({ proposals });
+    render(<GovernanceAssessment data={data} history={[]} />);
+    expect(screen.getByText('Rubber-stamping risk')).toBeDefined();
+  });
+
+  it('renders recommendations section', () => {
+    const openPRs = Array.from({ length: 15 }, (_, i) => ({
+      number: i + 1,
+      title: `PR ${i + 1}`,
+      state: 'open' as const,
+      author: 'agent-a',
+      createdAt: '2026-02-09T00:00:00Z',
+    }));
+    const data = makeActivityData({ pullRequests: openPRs });
+    render(<GovernanceAssessment data={data} history={[]} />);
+    expect(screen.getByText('Recommendations')).toBeDefined();
+  });
+
+  it('has proper ARIA attributes', () => {
+    const openPRs = Array.from({ length: 15 }, (_, i) => ({
+      number: i + 1,
+      title: `PR ${i + 1}`,
+      state: 'open' as const,
+      author: 'agent-a',
+      createdAt: '2026-02-09T00:00:00Z',
+    }));
+    const data = makeActivityData({ pullRequests: openPRs });
+    render(<GovernanceAssessment data={data} history={[]} />);
+    expect(
+      screen.getByRole('region', { name: /governance assessment/i })
+    ).toBeDefined();
+    expect(
+      screen.getByRole('list', { name: /governance alerts/i })
+    ).toBeDefined();
+  });
+});

--- a/web/src/components/GovernanceAssessment.tsx
+++ b/web/src/components/GovernanceAssessment.tsx
@@ -1,0 +1,279 @@
+import { useMemo } from 'react';
+import type { ActivityData } from '../types/activity';
+import type { GovernanceSnapshot } from '../../shared/governance-snapshot';
+import {
+  assessGovernanceHealth,
+  type Alert,
+  type AlertSeverity,
+  type GovernanceAssessment as Assessment,
+  type Pattern,
+  type Recommendation,
+} from '../utils/governance-assessment';
+
+interface GovernanceAssessmentProps {
+  data: ActivityData;
+  history: GovernanceSnapshot[];
+}
+
+export function GovernanceAssessment({
+  data,
+  history,
+}: GovernanceAssessmentProps): React.ReactElement {
+  const assessment = useMemo(
+    () => assessGovernanceHealth(data, history),
+    [data, history]
+  );
+
+  const hasContent =
+    assessment.alerts.length > 0 ||
+    assessment.patterns.length > 0 ||
+    assessment.recommendations.length > 0;
+
+  if (!hasContent) {
+    return (
+      <div
+        role="status"
+        aria-label="Governance assessment"
+        className="text-center text-amber-600 dark:text-amber-400 text-sm py-4"
+      >
+        No governance alerts or patterns detected. Governance appears healthy.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6" role="region" aria-label="Governance assessment">
+      {assessment.alerts.length > 0 && (
+        <AlertsSection alerts={assessment.alerts} />
+      )}
+      {assessment.patterns.length > 0 && (
+        <PatternsSection patterns={assessment.patterns} />
+      )}
+      {assessment.recommendations.length > 0 && (
+        <RecommendationsSection recommendations={assessment.recommendations} />
+      )}
+      <TrendSummarySection assessment={assessment} />
+    </div>
+  );
+}
+
+// ── Alerts ─────────────────────────────────────
+
+function AlertsSection({ alerts }: { alerts: Alert[] }): React.ReactElement {
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-2">
+        Active Alerts
+      </h3>
+      <ul className="space-y-2" role="list" aria-label="Governance alerts">
+        {alerts.map((alert, i) => (
+          <li
+            key={`${alert.type}-${i}`}
+            className={`flex items-start gap-2 text-sm rounded-lg px-3 py-2 ${severityStyles(alert.severity)}`}
+          >
+            <span aria-hidden="true" className="mt-0.5 shrink-0">
+              {severityIcon(alert.severity)}
+            </span>
+            <div>
+              <span className="font-medium">{alert.title}</span>
+              <span className="text-amber-700 dark:text-amber-300">
+                {' '}
+                — {alert.detail}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ── Patterns ───────────────────────────────────
+
+function PatternsSection({
+  patterns,
+}: {
+  patterns: Pattern[];
+}): React.ReactElement {
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-2">
+        Detected Patterns
+      </h3>
+      <ul className="space-y-2" role="list" aria-label="Governance patterns">
+        {patterns.map((pattern, i) => (
+          <li
+            key={`${pattern.type}-${i}`}
+            className={`flex items-start gap-2 text-sm rounded-lg px-3 py-2 ${
+              pattern.positive
+                ? 'bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800'
+                : 'bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800'
+            }`}
+          >
+            <span aria-hidden="true" className="mt-0.5 shrink-0">
+              {pattern.positive ? '\u2705' : '\u26A0\uFE0F'}
+            </span>
+            <div>
+              <span className="font-medium">{pattern.label}</span>
+              <span className="text-amber-700 dark:text-amber-300">
+                {' '}
+                — {pattern.detail}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// ── Recommendations ────────────────────────────
+
+function RecommendationsSection({
+  recommendations,
+}: {
+  recommendations: Recommendation[];
+}): React.ReactElement {
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-2">
+        Recommendations
+      </h3>
+      <ol
+        className="space-y-2"
+        role="list"
+        aria-label="Governance recommendations"
+      >
+        {recommendations.map((rec, i) => (
+          <li
+            key={i}
+            className="flex items-start gap-2 text-sm text-amber-800 dark:text-amber-200"
+          >
+            <span
+              className={`shrink-0 inline-flex items-center justify-center w-5 h-5 rounded text-xs font-bold ${priorityBadge(rec.priority)}`}
+              aria-label={`${rec.priority} priority`}
+            >
+              {priorityLabel(rec.priority)}
+            </span>
+            <span>{rec.description}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+// ── Trend Summary ──────────────────────────────
+
+function TrendSummarySection({
+  assessment,
+}: {
+  assessment: Assessment;
+}): React.ReactElement {
+  const { trendSummary } = assessment;
+
+  if (trendSummary.healthDelta7d === null) {
+    return (
+      <div className="text-xs text-amber-500 dark:text-amber-400">
+        Insufficient history for trend analysis.
+      </div>
+    );
+  }
+
+  const deltas = [
+    { label: 'Health', value: trendSummary.healthDelta7d },
+    { label: 'Participation', value: trendSummary.participationDelta7d },
+    { label: 'Pipeline', value: trendSummary.pipelineFlowDelta7d },
+    { label: 'Follow-through', value: trendSummary.followThroughDelta7d },
+    { label: 'Consensus', value: trendSummary.consensusDelta7d },
+  ];
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-2">
+        7-Day Trend
+      </h3>
+      <div
+        className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2"
+        role="group"
+        aria-label="7-day governance trends"
+      >
+        {deltas.map(({ label, value }) => (
+          <div
+            key={label}
+            className="text-center bg-amber-50/50 dark:bg-neutral-600/50 rounded-lg px-2 py-1.5"
+          >
+            <div className="text-xs text-amber-600 dark:text-amber-400">
+              {label}
+            </div>
+            <div
+              className={`text-sm font-semibold ${deltaColor(value)}`}
+              aria-label={`${label} ${formatDelta(value)}`}
+            >
+              {formatDelta(value)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Helpers ────────────────────────────────────
+
+function severityIcon(severity: AlertSeverity): string {
+  switch (severity) {
+    case 'critical':
+      return '\uD83D\uDED1';
+    case 'warning':
+      return '\u26A0\uFE0F';
+    case 'info':
+      return '\u2139\uFE0F';
+  }
+}
+
+function severityStyles(severity: AlertSeverity): string {
+  switch (severity) {
+    case 'critical':
+      return 'bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-900 dark:text-red-200';
+    case 'warning':
+      return 'bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 text-amber-900 dark:text-amber-200';
+    case 'info':
+      return 'bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 text-blue-900 dark:text-blue-200';
+  }
+}
+
+function priorityBadge(priority: string): string {
+  switch (priority) {
+    case 'high':
+      return 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200';
+    case 'medium':
+      return 'bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200';
+    default:
+      return 'bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-200';
+  }
+}
+
+function priorityLabel(priority: string): string {
+  switch (priority) {
+    case 'high':
+      return 'H';
+    case 'medium':
+      return 'M';
+    default:
+      return 'L';
+  }
+}
+
+function deltaColor(value: number | null): string {
+  if (value === null) return 'text-amber-500 dark:text-amber-400';
+  if (value > 0) return 'text-green-600 dark:text-green-400';
+  if (value < 0) return 'text-red-600 dark:text-red-400';
+  return 'text-amber-600 dark:text-amber-400';
+}
+
+function formatDelta(value: number | null): string {
+  if (value === null) return '--';
+  if (value > 0) return `+${value}`;
+  return String(value);
+}

--- a/web/src/utils/governance-assessment.test.ts
+++ b/web/src/utils/governance-assessment.test.ts
@@ -1,0 +1,597 @@
+import { describe, it, expect } from 'vitest';
+import type { ActivityData, AgentStats, Proposal } from '../types/activity';
+import type { GovernanceSnapshot } from '../../shared/governance-snapshot';
+import {
+  assessGovernanceHealth,
+  computeTrendSummary,
+  detectAlerts,
+  detectPatterns,
+  generateRecommendations,
+  type Alert,
+  type AlertType,
+} from './governance-assessment';
+
+function makeSnapshot(
+  overrides: Partial<GovernanceSnapshot> = {}
+): GovernanceSnapshot {
+  return {
+    timestamp: '2026-02-10T12:00:00Z',
+    healthScore: 65,
+    participation: 18,
+    pipelineFlow: 15,
+    followThrough: 17,
+    consensusQuality: 15,
+    activeProposals: 5,
+    totalProposals: 20,
+    activeAgents: 4,
+    proposalVelocity: 1.5,
+    ...overrides,
+  };
+}
+
+function makeAgentStats(overrides: Partial<AgentStats> = {}): AgentStats {
+  return {
+    login: 'agent-a',
+    commits: 5,
+    pullRequestsMerged: 3,
+    issuesOpened: 2,
+    reviews: 5,
+    comments: 10,
+    lastActiveAt: '2026-02-10T12:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
+  return {
+    number: 1,
+    title: 'Test proposal',
+    phase: 'discussion',
+    author: 'agent-a',
+    createdAt: '2026-02-05T09:00:00Z',
+    commentCount: 3,
+    ...overrides,
+  };
+}
+
+function makeActivityData(overrides: Partial<ActivityData> = {}): ActivityData {
+  return {
+    generatedAt: '2026-02-10T12:00:00Z',
+    repository: {
+      owner: 'hivemoot',
+      name: 'colony',
+      url: 'https://github.com/hivemoot/colony',
+      stars: 10,
+      forks: 2,
+      openIssues: 5,
+    },
+    agents: [],
+    agentStats: [
+      makeAgentStats({ login: 'agent-a', reviews: 5, comments: 10 }),
+      makeAgentStats({ login: 'agent-b', reviews: 5, comments: 8 }),
+      makeAgentStats({ login: 'agent-c', reviews: 4, comments: 6 }),
+      makeAgentStats({ login: 'agent-d', reviews: 3, comments: 5 }),
+    ],
+    commits: [],
+    issues: [],
+    pullRequests: [],
+    comments: [],
+    proposals: [
+      makeProposal({ number: 1, phase: 'implemented', commentCount: 5 }),
+      makeProposal({ number: 2, phase: 'implemented', commentCount: 4 }),
+      makeProposal({ number: 3, phase: 'voting', commentCount: 3 }),
+      makeProposal({ number: 4, phase: 'discussion', commentCount: 2 }),
+    ],
+    ...overrides,
+  };
+}
+
+function makeAlert(overrides: Partial<Alert> = {}): Alert {
+  return {
+    type: 'merge-queue-growth',
+    severity: 'warning',
+    title: 'test',
+    detail: 'test',
+    ...overrides,
+  };
+}
+
+// ──────────────────────────────────────────────
+// Trend Summary
+// ──────────────────────────────────────────────
+
+describe('computeTrendSummary', () => {
+  it('returns null deltas with fewer than 2 snapshots', () => {
+    const summary = computeTrendSummary([makeSnapshot()]);
+    expect(summary.healthDelta7d).toBeNull();
+    expect(summary.healthDelta30d).toBeNull();
+    expect(summary.consecutiveDeclines).toBe(0);
+  });
+
+  it('computes 7-day delta between snapshots', () => {
+    const old = makeSnapshot({
+      timestamp: '2026-02-03T12:00:00Z',
+      healthScore: 60,
+      participation: 15,
+    });
+    const recent = makeSnapshot({
+      timestamp: '2026-02-10T12:00:00Z',
+      healthScore: 70,
+      participation: 20,
+    });
+    const summary = computeTrendSummary([old, recent]);
+    expect(summary.healthDelta7d).toBe(10);
+    expect(summary.participationDelta7d).toBe(5);
+  });
+
+  it('counts consecutive declines', () => {
+    const snapshots = [
+      makeSnapshot({ timestamp: '2026-02-07T00:00:00Z', healthScore: 70 }),
+      makeSnapshot({ timestamp: '2026-02-08T00:00:00Z', healthScore: 65 }),
+      makeSnapshot({ timestamp: '2026-02-09T00:00:00Z', healthScore: 60 }),
+      makeSnapshot({ timestamp: '2026-02-10T00:00:00Z', healthScore: 55 }),
+    ];
+    const summary = computeTrendSummary(snapshots);
+    expect(summary.consecutiveDeclines).toBe(3);
+  });
+
+  it('stops counting declines at first non-decline', () => {
+    const snapshots = [
+      makeSnapshot({ timestamp: '2026-02-07T00:00:00Z', healthScore: 70 }),
+      makeSnapshot({ timestamp: '2026-02-08T00:00:00Z', healthScore: 65 }),
+      makeSnapshot({ timestamp: '2026-02-09T00:00:00Z', healthScore: 68 }),
+      makeSnapshot({ timestamp: '2026-02-10T00:00:00Z', healthScore: 63 }),
+    ];
+    const summary = computeTrendSummary(snapshots);
+    expect(summary.consecutiveDeclines).toBe(1);
+  });
+});
+
+// ──────────────────────────────────────────────
+// Alerts
+// ──────────────────────────────────────────────
+
+describe('detectAlerts', () => {
+  it('detects health-declining with 3+ consecutive drops', () => {
+    const data = makeActivityData();
+    const history = [
+      makeSnapshot({ timestamp: '2026-02-07T00:00:00Z', healthScore: 70 }),
+      makeSnapshot({ timestamp: '2026-02-08T00:00:00Z', healthScore: 65 }),
+      makeSnapshot({ timestamp: '2026-02-09T00:00:00Z', healthScore: 60 }),
+      makeSnapshot({ timestamp: '2026-02-10T00:00:00Z', healthScore: 55 }),
+    ];
+    const trend = computeTrendSummary(history);
+    const alerts = detectAlerts(data, history, trend);
+    const declining = alerts.find((a) => a.type === 'health-declining');
+    expect(declining).toBeDefined();
+    expect(declining?.severity).toBe('warning');
+  });
+
+  it('does not fire health-declining with only 2 drops', () => {
+    const data = makeActivityData();
+    const history = [
+      makeSnapshot({ timestamp: '2026-02-08T00:00:00Z', healthScore: 70 }),
+      makeSnapshot({ timestamp: '2026-02-09T00:00:00Z', healthScore: 65 }),
+      makeSnapshot({ timestamp: '2026-02-10T00:00:00Z', healthScore: 60 }),
+    ];
+    const trend = computeTrendSummary(history);
+    const alerts = detectAlerts(data, history, trend);
+    expect(alerts.find((a) => a.type === 'health-declining')).toBeUndefined();
+  });
+
+  it('detects health-critical when score stays below 25', () => {
+    const data = makeActivityData();
+    const history = [
+      makeSnapshot({ timestamp: '2026-02-09T00:00:00Z', healthScore: 20 }),
+      makeSnapshot({ timestamp: '2026-02-10T00:00:00Z', healthScore: 15 }),
+    ];
+    const trend = computeTrendSummary(history);
+    const alerts = detectAlerts(data, history, trend);
+    const critical = alerts.find((a) => a.type === 'health-critical');
+    expect(critical).toBeDefined();
+    expect(critical?.severity).toBe('critical');
+  });
+
+  it('does not fire health-critical when only one snapshot is low', () => {
+    const data = makeActivityData();
+    const history = [
+      makeSnapshot({ timestamp: '2026-02-09T00:00:00Z', healthScore: 50 }),
+      makeSnapshot({ timestamp: '2026-02-10T00:00:00Z', healthScore: 20 }),
+    ];
+    const trend = computeTrendSummary(history);
+    const alerts = detectAlerts(data, history, trend);
+    expect(alerts.find((a) => a.type === 'health-critical')).toBeUndefined();
+  });
+
+  it('detects participation collapse', () => {
+    const data = makeActivityData();
+    const history = [
+      makeSnapshot({
+        timestamp: '2026-02-03T00:00:00Z',
+        participation: 22,
+      }),
+      makeSnapshot({
+        timestamp: '2026-02-10T00:00:00Z',
+        participation: 10,
+      }),
+    ];
+    const trend = computeTrendSummary(history);
+    const alerts = detectAlerts(data, history, trend);
+    const collapse = alerts.find((a) => a.type === 'participation-collapse');
+    expect(collapse).toBeDefined();
+    expect(collapse?.severity).toBe('warning');
+  });
+
+  it('detects pipeline stall', () => {
+    const data = makeActivityData();
+    const history = [
+      makeSnapshot({
+        timestamp: '2026-02-10T00:00:00Z',
+        pipelineFlow: 0,
+        totalProposals: 10,
+      }),
+    ];
+    const trend = computeTrendSummary(history);
+    const alerts = detectAlerts(data, history, trend);
+    expect(alerts.find((a) => a.type === 'pipeline-stall')).toBeDefined();
+  });
+
+  it('does not fire pipeline stall with zero proposals', () => {
+    const data = makeActivityData();
+    const history = [
+      makeSnapshot({
+        timestamp: '2026-02-10T00:00:00Z',
+        pipelineFlow: 0,
+        totalProposals: 0,
+      }),
+    ];
+    const trend = computeTrendSummary(history);
+    const alerts = detectAlerts(data, history, trend);
+    expect(alerts.find((a) => a.type === 'pipeline-stall')).toBeUndefined();
+  });
+
+  it('detects merge queue growth', () => {
+    const openPRs = Array.from({ length: 15 }, (_, i) => ({
+      number: i + 1,
+      title: `PR ${i + 1}`,
+      state: 'open' as const,
+      author: 'agent-a',
+      createdAt: '2026-02-09T00:00:00Z',
+    }));
+    const data = makeActivityData({ pullRequests: openPRs });
+    const alerts = detectAlerts(data, [], computeTrendSummary([]));
+    const queue = alerts.find((a) => a.type === 'merge-queue-growth');
+    expect(queue).toBeDefined();
+    expect(queue?.severity).toBe('warning');
+  });
+
+  it('anchors merge recency to generatedAt, not wall-clock time', () => {
+    // generatedAt is Feb 1. Merged PRs are within 48h of that timestamp.
+    // Without the fix (Date.now()), these merges would appear stale and trigger
+    // a false merge-queue-growth alert.
+    const openPRs = Array.from({ length: 11 }, (_, i) => ({
+      number: i + 1,
+      title: `PR ${i + 1}`,
+      state: 'open' as const,
+      author: 'agent-a',
+      createdAt: '2026-01-30T00:00:00Z',
+    }));
+    const mergedPRs = Array.from({ length: 4 }, (_, i) => ({
+      number: 100 + i,
+      title: `Merged PR ${i}`,
+      state: 'merged' as const,
+      author: 'agent-b',
+      createdAt: '2026-01-30T00:00:00Z',
+      mergedAt: '2026-01-31T12:00:00Z',
+    }));
+    const data = makeActivityData({
+      generatedAt: '2026-02-01T00:00:00Z',
+      pullRequests: [...openPRs, ...mergedPRs],
+    });
+    const alerts = detectAlerts(data, [], computeTrendSummary([]));
+    const queue = alerts.find((a) => a.type === 'merge-queue-growth');
+    // 4 merged within 48h of generatedAt → 11 > 4*3=12 is false → no alert
+    expect(queue).toBeUndefined();
+  });
+
+  it('excludes future mergedAt timestamps from merge recency calculation', () => {
+    // generatedAt is Feb 1. One merged PR has a future timestamp (Feb 5).
+    // The future-dated PR should be excluded from mergedRecently count.
+    const openPRs = Array.from({ length: 11 }, (_, i) => ({
+      number: i + 1,
+      title: `PR ${i + 1}`,
+      state: 'open' as const,
+      author: 'agent-a',
+      createdAt: '2026-01-30T00:00:00Z',
+    }));
+    const validMergedPR = {
+      number: 100,
+      title: 'Valid merged PR',
+      state: 'merged' as const,
+      author: 'agent-b',
+      createdAt: '2026-01-30T00:00:00Z',
+      mergedAt: '2026-01-31T12:00:00Z',
+    };
+    const futureMergedPR = {
+      number: 101,
+      title: 'Future merged PR',
+      state: 'merged' as const,
+      author: 'agent-c',
+      createdAt: '2026-01-30T00:00:00Z',
+      mergedAt: '2026-02-05T00:00:00Z', // 4 days after generatedAt
+    };
+    const data = makeActivityData({
+      generatedAt: '2026-02-01T00:00:00Z',
+      pullRequests: [...openPRs, validMergedPR, futureMergedPR],
+    });
+    const alerts = detectAlerts(data, [], computeTrendSummary([]));
+    const queue = alerts.find((a) => a.type === 'merge-queue-growth');
+    // Only 1 valid merged PR (future timestamp excluded) → 11 > 1*3 → alert triggers
+    expect(queue).toBeDefined();
+    expect(queue?.detail).toContain('1 merged in last 48h');
+  });
+
+  it('counts Refs #n as linked for follow-through-gap detection', () => {
+    // 6 ready-to-implement proposals (>5 threshold for alert)
+    const proposals = Array.from({ length: 6 }, (_, i) =>
+      makeProposal({
+        number: i + 200,
+        phase: 'ready-to-implement',
+        commentCount: 5,
+      })
+    );
+    // One PR uses "Refs #200" (not a closing keyword) — should still count as linked
+    const pullRequests = [
+      {
+        number: 50,
+        title: 'feat: implement widget',
+        body: 'Refs #200',
+        state: 'open' as const,
+        author: 'agent-a',
+        createdAt: '2026-02-09T00:00:00Z',
+      },
+    ];
+    const data = makeActivityData({ proposals, pullRequests });
+    const alerts = detectAlerts(data, [], computeTrendSummary([]));
+    const gap = alerts.find((a) => a.type === 'follow-through-gap');
+    // 6 proposals, 1 linked via Refs → 5 unclaimed, which is not >5, so no alert
+    expect(gap).toBeUndefined();
+  });
+
+  it('fires follow-through-gap when no PRs reference ready proposals', () => {
+    const proposals = Array.from({ length: 6 }, (_, i) =>
+      makeProposal({
+        number: i + 300,
+        phase: 'ready-to-implement',
+        commentCount: 5,
+      })
+    );
+    const data = makeActivityData({ proposals, pullRequests: [] });
+    const alerts = detectAlerts(data, [], computeTrendSummary([]));
+    const gap = alerts.find((a) => a.type === 'follow-through-gap');
+    expect(gap).toBeDefined();
+    expect(gap?.detail).toContain('6');
+  });
+
+  it('detects review concentration', () => {
+    const data = makeActivityData({
+      agentStats: [
+        makeAgentStats({ login: 'agent-a', reviews: 20 }),
+        makeAgentStats({ login: 'agent-b', reviews: 3 }),
+        makeAgentStats({ login: 'agent-c', reviews: 2 }),
+        makeAgentStats({ login: 'agent-d', reviews: 1 }),
+      ],
+    });
+    const alerts = detectAlerts(data, [], computeTrendSummary([]));
+    const concentration = alerts.find((a) => a.type === 'review-concentration');
+    expect(concentration).toBeDefined();
+    expect(concentration?.severity).toBe('info');
+    expect(concentration?.detail).toContain('agent-a');
+  });
+});
+
+// ──────────────────────────────────────────────
+// Patterns
+// ──────────────────────────────────────────────
+
+describe('detectPatterns', () => {
+  it('detects rubber-stamping with high approval and low comments', () => {
+    const proposals = [
+      makeProposal({ phase: 'implemented', commentCount: 1 }),
+      makeProposal({ phase: 'implemented', commentCount: 1 }),
+      makeProposal({ phase: 'implemented', commentCount: 1 }),
+      makeProposal({ phase: 'implemented', commentCount: 1 }),
+    ];
+    const data = makeActivityData({ proposals });
+    const patterns = detectPatterns(data, [], computeTrendSummary([]));
+    const rubber = patterns.find((p) => p.type === 'rubber-stamping');
+    expect(rubber).toBeDefined();
+    expect(rubber?.positive).toBe(false);
+  });
+
+  it('detects rubber-stamping using terminal proposals only', () => {
+    const proposals = [
+      makeProposal({ phase: 'implemented', commentCount: 0 }),
+      makeProposal({ phase: 'implemented', commentCount: 1 }),
+      makeProposal({ phase: 'implemented', commentCount: 0 }),
+      makeProposal({ phase: 'implemented', commentCount: 1 }),
+      makeProposal({ phase: 'discussion', commentCount: 25 }),
+      makeProposal({ phase: 'voting', commentCount: 20 }),
+      makeProposal({ phase: 'ready-to-implement', commentCount: 18 }),
+    ];
+    const data = makeActivityData({ proposals });
+    const patterns = detectPatterns(data, [], computeTrendSummary([]));
+    const rubber = patterns.find((p) => p.type === 'rubber-stamping');
+    expect(rubber).toBeDefined();
+    expect(rubber?.detail).toContain('0.5 avg comments');
+  });
+
+  it('does not detect rubber-stamping with healthy discussion', () => {
+    const proposals = [
+      makeProposal({ phase: 'implemented', commentCount: 5 }),
+      makeProposal({ phase: 'implemented', commentCount: 6 }),
+      makeProposal({ phase: 'rejected', commentCount: 4 }),
+    ];
+    const data = makeActivityData({ proposals });
+    const patterns = detectPatterns(data, [], computeTrendSummary([]));
+    expect(patterns.find((p) => p.type === 'rubber-stamping')).toBeUndefined();
+  });
+
+  it('detects governance debt with growing backlog', () => {
+    const history = [
+      makeSnapshot({
+        timestamp: '2026-02-08T00:00:00Z',
+        activeProposals: 3,
+      }),
+      makeSnapshot({
+        timestamp: '2026-02-09T00:00:00Z',
+        activeProposals: 5,
+      }),
+      makeSnapshot({
+        timestamp: '2026-02-10T00:00:00Z',
+        activeProposals: 8,
+      }),
+    ];
+    const data = makeActivityData();
+    const patterns = detectPatterns(
+      data,
+      history,
+      computeTrendSummary(history)
+    );
+    expect(patterns.find((p) => p.type === 'governance-debt')).toBeDefined();
+  });
+
+  it('detects velocity cliff', () => {
+    const history = [
+      makeSnapshot({
+        timestamp: '2026-02-09T00:00:00Z',
+        proposalVelocity: 2.0,
+      }),
+      makeSnapshot({
+        timestamp: '2026-02-10T00:00:00Z',
+        proposalVelocity: 0.5,
+      }),
+    ];
+    const data = makeActivityData();
+    const patterns = detectPatterns(
+      data,
+      history,
+      computeTrendSummary(history)
+    );
+    const cliff = patterns.find((p) => p.type === 'velocity-cliff');
+    expect(cliff).toBeDefined();
+    expect(cliff?.positive).toBe(false);
+  });
+
+  it('detects healthy growth', () => {
+    const history = [
+      makeSnapshot({
+        timestamp: '2026-02-03T00:00:00Z',
+        healthScore: 55,
+        activeAgents: 3,
+      }),
+      makeSnapshot({
+        timestamp: '2026-02-10T00:00:00Z',
+        healthScore: 70,
+        activeAgents: 4,
+      }),
+    ];
+    const data = makeActivityData();
+    const patterns = detectPatterns(
+      data,
+      history,
+      computeTrendSummary(history)
+    );
+    const growth = patterns.find((p) => p.type === 'healthy-growth');
+    expect(growth).toBeDefined();
+    expect(growth?.positive).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────
+// Recommendations
+// ──────────────────────────────────────────────
+
+describe('generateRecommendations', () => {
+  it('generates recommendations from alerts sorted by priority', () => {
+    const alerts = [
+      makeAlert({ type: 'review-concentration', severity: 'info' }),
+      makeAlert({ type: 'merge-queue-growth', severity: 'warning' }),
+    ];
+    const data = makeActivityData({
+      pullRequests: Array.from({ length: 12 }, (_, i) => ({
+        number: i + 1,
+        title: `PR ${i + 1}`,
+        state: 'open' as const,
+        author: 'agent-a',
+        createdAt: '2026-02-09T00:00:00Z',
+      })),
+    });
+    const recs = generateRecommendations(alerts, [], data);
+    expect(recs.length).toBeGreaterThanOrEqual(2);
+    expect(recs[0].priority).toBe('high');
+  });
+
+  it('limits to 5 recommendations', () => {
+    const alertTypes: AlertType[] = [
+      'merge-queue-growth',
+      'health-critical',
+      'pipeline-stall',
+      'follow-through-gap',
+      'participation-collapse',
+      'review-concentration',
+    ];
+    const manyAlerts = alertTypes.map((type) => makeAlert({ type }));
+    const data = makeActivityData({
+      pullRequests: Array.from({ length: 12 }, (_, i) => ({
+        number: i + 1,
+        title: `PR ${i + 1}`,
+        state: 'open' as const,
+        author: 'agent-a',
+        createdAt: '2026-02-09T00:00:00Z',
+      })),
+    });
+    const recs = generateRecommendations(manyAlerts, [], data);
+    expect(recs.length).toBeLessThanOrEqual(5);
+  });
+});
+
+// ──────────────────────────────────────────────
+// Integration
+// ──────────────────────────────────────────────
+
+describe('assessGovernanceHealth', () => {
+  it('returns a complete assessment', () => {
+    const data = makeActivityData();
+    const history = [
+      makeSnapshot({ timestamp: '2026-02-03T00:00:00Z', healthScore: 60 }),
+      makeSnapshot({ timestamp: '2026-02-10T00:00:00Z', healthScore: 65 }),
+    ];
+    const assessment = assessGovernanceHealth(data, history);
+    expect(assessment.alerts).toBeDefined();
+    expect(assessment.patterns).toBeDefined();
+    expect(assessment.recommendations).toBeDefined();
+    expect(assessment.trendSummary).toBeDefined();
+    expect(assessment.trendSummary.healthDelta7d).toBe(5);
+  });
+
+  it('handles empty history gracefully', () => {
+    const data = makeActivityData();
+    const assessment = assessGovernanceHealth(data, []);
+    expect(assessment.alerts).toBeDefined();
+    expect(assessment.patterns).toBeDefined();
+    expect(assessment.trendSummary.healthDelta7d).toBeNull();
+  });
+
+  it('handles empty data gracefully', () => {
+    const data = makeActivityData({
+      agentStats: [],
+      proposals: [],
+      pullRequests: [],
+      comments: [],
+    });
+    const assessment = assessGovernanceHealth(data, []);
+    expect(assessment.alerts).toEqual([]);
+    expect(assessment.patterns).toEqual([]);
+  });
+});

--- a/web/src/utils/governance-assessment.ts
+++ b/web/src/utils/governance-assessment.ts
@@ -1,0 +1,512 @@
+import type { ActivityData } from '../types/activity';
+import type { GovernanceSnapshot } from '../../shared/governance-snapshot';
+import { computeGovernanceBalance } from './governance-balance';
+
+// ──────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────
+
+export type AlertSeverity = 'info' | 'warning' | 'critical';
+
+export type AlertType =
+  | 'health-declining'
+  | 'health-critical'
+  | 'participation-collapse'
+  | 'pipeline-stall'
+  | 'follow-through-gap'
+  | 'merge-queue-growth'
+  | 'review-concentration';
+
+export interface Alert {
+  type: AlertType;
+  severity: AlertSeverity;
+  title: string;
+  detail: string;
+}
+
+export type PatternType =
+  | 'rubber-stamping'
+  | 'single-point-of-failure'
+  | 'governance-debt'
+  | 'velocity-cliff'
+  | 'healthy-growth';
+
+export interface Pattern {
+  type: PatternType;
+  label: string;
+  detail: string;
+  positive: boolean;
+}
+
+export interface Recommendation {
+  priority: 'high' | 'medium' | 'low';
+  description: string;
+}
+
+export interface TrendSummary {
+  healthDelta7d: number | null;
+  healthDelta30d: number | null;
+  participationDelta7d: number | null;
+  pipelineFlowDelta7d: number | null;
+  followThroughDelta7d: number | null;
+  consensusDelta7d: number | null;
+  consecutiveDeclines: number;
+}
+
+export interface GovernanceAssessment {
+  alerts: Alert[];
+  patterns: Pattern[];
+  recommendations: Recommendation[];
+  trendSummary: TrendSummary;
+}
+
+// ──────────────────────────────────────────────
+// Constants
+// ──────────────────────────────────────────────
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const CONSECUTIVE_DECLINE_THRESHOLD = 3;
+const CRITICAL_SCORE_THRESHOLD = 25;
+const PARTICIPATION_DROP_THRESHOLD = 10;
+const REVIEW_CONCENTRATION_THRESHOLD = 0.6;
+
+// ──────────────────────────────────────────────
+// Main entry
+// ──────────────────────────────────────────────
+
+/**
+ * Assess governance health using trend analysis and pattern detection.
+ *
+ * Combines governance history snapshots (temporal) with current ActivityData
+ * (structural) to produce alerts, detected patterns, and recommendations.
+ *
+ * Pure function — no side effects, no API calls.
+ */
+export function assessGovernanceHealth(
+  data: ActivityData,
+  history: GovernanceSnapshot[]
+): GovernanceAssessment {
+  const trendSummary = computeTrendSummary(history);
+  const alerts = detectAlerts(data, history, trendSummary);
+  const patterns = detectPatterns(data, history, trendSummary);
+  const recommendations = generateRecommendations(alerts, patterns, data);
+
+  return { alerts, patterns, recommendations, trendSummary };
+}
+
+// ──────────────────────────────────────────────
+// Trend Summary
+// ──────────────────────────────────────────────
+
+export function computeTrendSummary(
+  history: GovernanceSnapshot[]
+): TrendSummary {
+  if (history.length < 2) {
+    return {
+      healthDelta7d: null,
+      healthDelta30d: null,
+      participationDelta7d: null,
+      pipelineFlowDelta7d: null,
+      followThroughDelta7d: null,
+      consensusDelta7d: null,
+      consecutiveDeclines: 0,
+    };
+  }
+
+  const sorted = [...history].sort(
+    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+  );
+
+  const latest = sorted[sorted.length - 1];
+  const latestTime = new Date(latest.timestamp).getTime();
+
+  const snap7d = findClosestBefore(sorted, latestTime - 7 * MS_PER_DAY);
+  const snap30d = findClosestBefore(sorted, latestTime - 30 * MS_PER_DAY);
+
+  return {
+    healthDelta7d: snap7d ? latest.healthScore - snap7d.healthScore : null,
+    healthDelta30d: snap30d ? latest.healthScore - snap30d.healthScore : null,
+    participationDelta7d: snap7d
+      ? latest.participation - snap7d.participation
+      : null,
+    pipelineFlowDelta7d: snap7d
+      ? latest.pipelineFlow - snap7d.pipelineFlow
+      : null,
+    followThroughDelta7d: snap7d
+      ? latest.followThrough - snap7d.followThrough
+      : null,
+    consensusDelta7d: snap7d
+      ? latest.consensusQuality - snap7d.consensusQuality
+      : null,
+    consecutiveDeclines: countConsecutiveDeclines(sorted),
+  };
+}
+
+function findClosestBefore(
+  sorted: GovernanceSnapshot[],
+  targetTime: number
+): GovernanceSnapshot | null {
+  let best: GovernanceSnapshot | null = null;
+  for (const s of sorted) {
+    const t = new Date(s.timestamp).getTime();
+    if (t <= targetTime) {
+      best = s;
+    } else {
+      break;
+    }
+  }
+  return best;
+}
+
+function countConsecutiveDeclines(sorted: GovernanceSnapshot[]): number {
+  let count = 0;
+  for (let i = sorted.length - 1; i > 0; i--) {
+    if (sorted[i].healthScore < sorted[i - 1].healthScore) {
+      count++;
+    } else {
+      break;
+    }
+  }
+  return count;
+}
+
+// ──────────────────────────────────────────────
+// Alert Detection
+// ──────────────────────────────────────────────
+
+export function detectAlerts(
+  data: ActivityData,
+  history: GovernanceSnapshot[],
+  trend: TrendSummary
+): Alert[] {
+  const alerts: Alert[] = [];
+
+  // Health declining: 3+ consecutive drops
+  if (trend.consecutiveDeclines >= CONSECUTIVE_DECLINE_THRESHOLD) {
+    alerts.push({
+      type: 'health-declining',
+      severity: 'warning',
+      title: 'Health score declining',
+      detail: `Health score has dropped for ${trend.consecutiveDeclines} consecutive snapshots`,
+    });
+  }
+
+  // Health critical: score below 25 for recent snapshots
+  if (history.length >= 2) {
+    const sorted = [...history].sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+    const recent = sorted.slice(-2);
+    if (recent.every((s) => s.healthScore < CRITICAL_SCORE_THRESHOLD)) {
+      alerts.push({
+        type: 'health-critical',
+        severity: 'critical',
+        title: 'Governance health critical',
+        detail: `Health score has been below ${CRITICAL_SCORE_THRESHOLD} for the last ${recent.length} snapshots`,
+      });
+    }
+  }
+
+  // Participation collapse: drop >10pts in 7d
+  if (
+    trend.participationDelta7d !== null &&
+    trend.participationDelta7d < -PARTICIPATION_DROP_THRESHOLD
+  ) {
+    alerts.push({
+      type: 'participation-collapse',
+      severity: 'warning',
+      title: 'Participation dropping',
+      detail: `Participation sub-metric dropped ${Math.abs(trend.participationDelta7d)} points in 7 days`,
+    });
+  }
+
+  // Pipeline stall: pipeline flow at 0 in the latest snapshot
+  if (history.length > 0) {
+    const latest = [...history].sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    )[history.length - 1];
+    if (latest.pipelineFlow === 0 && latest.totalProposals > 0) {
+      alerts.push({
+        type: 'pipeline-stall',
+        severity: 'critical',
+        title: 'Pipeline stalled',
+        detail: 'No proposals are advancing through the governance pipeline',
+      });
+    }
+  }
+
+  // Follow-through gap: many ready-to-implement with no PRs
+  const readyToImplement = data.proposals.filter(
+    (p) => p.phase === 'ready-to-implement'
+  );
+  const openPRs = data.pullRequests.filter((pr) => pr.state === 'open');
+  // Count ready proposals that have no linked open PR
+  const pattern = /(?:fix(?:es)?|close[sd]?|resolve[sd]?|refs?)\s+#(\d+)/gi;
+  const linkedIssues = new Set<number>();
+  for (const pr of openPRs) {
+    const text = `${pr.title} ${pr.body ?? ''}`;
+    let match;
+    pattern.lastIndex = 0;
+    while ((match = pattern.exec(text)) !== null) {
+      linkedIssues.add(parseInt(match[1], 10));
+    }
+  }
+  const unclaimedReady = readyToImplement.filter(
+    (p) => !linkedIssues.has(p.number)
+  );
+  if (unclaimedReady.length > 5) {
+    alerts.push({
+      type: 'follow-through-gap',
+      severity: 'warning',
+      title: 'Implementation backlog growing',
+      detail: `${unclaimedReady.length} approved proposals have no implementation PR`,
+    });
+  }
+
+  // Merge queue growth: many open PRs relative to recent merges
+  // Anchor recency window to data generation time, not wall-clock time,
+  // so the assessment is deterministic for a given snapshot.
+  const anchorTime = ((): number => {
+    const parsed = new Date(data.generatedAt).getTime();
+    return Number.isNaN(parsed) ? Date.now() : parsed;
+  })();
+  const mergedRecently = data.pullRequests.filter((pr) => {
+    if (pr.state !== 'merged' || !pr.mergedAt) return false;
+    const mergedAtTime = new Date(pr.mergedAt).getTime();
+    // Reject invalid, future, or non-recent timestamps
+    if (!Number.isFinite(mergedAtTime)) return false;
+    if (mergedAtTime > anchorTime) return false;
+    return anchorTime - mergedAtTime < 2 * MS_PER_DAY;
+  });
+  if (openPRs.length > 10 && openPRs.length > mergedRecently.length * 3) {
+    alerts.push({
+      type: 'merge-queue-growth',
+      severity: 'warning',
+      title: 'Merge queue bottleneck',
+      detail: `${openPRs.length} open PRs with only ${mergedRecently.length} merged in last 48h`,
+    });
+  }
+
+  // Review concentration: one agent doing >60% of reviews
+  const totalReviews = data.agentStats.reduce((s, a) => s + a.reviews, 0);
+  if (totalReviews > 0) {
+    for (const agent of data.agentStats) {
+      if (agent.reviews / totalReviews > REVIEW_CONCENTRATION_THRESHOLD) {
+        alerts.push({
+          type: 'review-concentration',
+          severity: 'info',
+          title: 'Review concentration',
+          detail: `${agent.login} performed ${Math.round((agent.reviews / totalReviews) * 100)}% of all reviews`,
+        });
+        break; // Only report the top concentrator
+      }
+    }
+  }
+
+  return alerts;
+}
+
+// ──────────────────────────────────────────────
+// Pattern Detection
+// ──────────────────────────────────────────────
+
+export function detectPatterns(
+  data: ActivityData,
+  history: GovernanceSnapshot[],
+  trend: TrendSummary
+): Pattern[] {
+  const patterns: Pattern[] = [];
+
+  // Rubber-stamping: high approval + low discussion
+  const terminal = data.proposals.filter((p) =>
+    ['implemented', 'rejected', 'inconclusive'].includes(p.phase)
+  );
+  if (terminal.length >= 3) {
+    const approvalRate =
+      terminal.filter((p) => p.phase === 'implemented').length /
+      terminal.length;
+    const avgComments =
+      terminal.reduce((s, p) => s + p.commentCount, 0) / terminal.length;
+    if (approvalRate > 0.95 && avgComments < 2) {
+      patterns.push({
+        type: 'rubber-stamping',
+        label: 'Rubber-stamping risk',
+        detail: `${Math.round(approvalRate * 100)}% approval rate with only ${avgComments.toFixed(1)} avg comments per proposal`,
+        positive: false,
+      });
+    }
+  }
+
+  // Single point of failure
+  const balance = computeGovernanceBalance(data);
+  if (balance.powerConcentration.topAgentShare > 0.5) {
+    const top = balance.powerConcentration.agents[0];
+    patterns.push({
+      type: 'single-point-of-failure',
+      label: 'Single point of failure',
+      detail: `${top.login} holds ${Math.round(top.share * 100)}% of governance influence`,
+      positive: false,
+    });
+  }
+
+  // Governance debt: ready-to-implement growing across snapshots
+  if (history.length >= 3) {
+    const sorted = [...history].sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+    const recent = sorted.slice(-3);
+    const readyGrowing =
+      recent.length === 3 &&
+      recent[2].activeProposals > recent[1].activeProposals &&
+      recent[1].activeProposals > recent[0].activeProposals;
+    if (readyGrowing) {
+      patterns.push({
+        type: 'governance-debt',
+        label: 'Governance debt accumulating',
+        detail: 'Active proposal backlog has grown for 3 consecutive snapshots',
+        positive: false,
+      });
+    }
+  }
+
+  // Velocity cliff: velocity drops >50% based on history
+  if (history.length >= 2) {
+    const sorted = [...history].sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+    const latest = sorted[sorted.length - 1];
+    const previous = sorted[sorted.length - 2];
+    if (
+      previous.proposalVelocity !== null &&
+      previous.proposalVelocity > 0 &&
+      latest.proposalVelocity !== null &&
+      latest.proposalVelocity < previous.proposalVelocity * 0.5
+    ) {
+      patterns.push({
+        type: 'velocity-cliff',
+        label: 'Velocity cliff',
+        detail: `Proposal velocity dropped from ${previous.proposalVelocity}/day to ${latest.proposalVelocity}/day`,
+        positive: false,
+      });
+    }
+  }
+
+  // Healthy growth: health improving + stable/growing agent count
+  if (
+    trend.healthDelta7d !== null &&
+    trend.healthDelta7d > 0 &&
+    history.length >= 2
+  ) {
+    const sorted = [...history].sort(
+      (a, b) =>
+        new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+    const latest = sorted[sorted.length - 1];
+    const earliest = sorted[0];
+    if (latest.activeAgents >= earliest.activeAgents) {
+      patterns.push({
+        type: 'healthy-growth',
+        label: 'Healthy growth',
+        detail: `Health score up ${trend.healthDelta7d} points over 7 days with stable agent participation`,
+        positive: true,
+      });
+    }
+  }
+
+  return patterns;
+}
+
+// ──────────────────────────────────────────────
+// Recommendations
+// ──────────────────────────────────────────────
+
+export function generateRecommendations(
+  alerts: Alert[],
+  patterns: Pattern[],
+  data: ActivityData
+): Recommendation[] {
+  const recs: Recommendation[] = [];
+
+  for (const alert of alerts) {
+    switch (alert.type) {
+      case 'merge-queue-growth':
+        recs.push({
+          priority: 'high',
+          description: `Merge queue bottleneck: ${data.pullRequests.filter((pr) => pr.state === 'open').length} open PRs. This may be a permissions issue rather than a governance issue.`,
+        });
+        break;
+      case 'health-critical':
+        recs.push({
+          priority: 'high',
+          description:
+            'Governance health is critically low. Review sub-metrics to identify which dimension needs immediate attention.',
+        });
+        break;
+      case 'pipeline-stall':
+        recs.push({
+          priority: 'high',
+          description:
+            'No proposals are progressing. Check if discussion or voting phases are blocked.',
+        });
+        break;
+      case 'follow-through-gap':
+        recs.push({
+          priority: 'medium',
+          description:
+            'Approved proposals are piling up without implementation. Consider a focused implementation sprint.',
+        });
+        break;
+      case 'participation-collapse':
+        recs.push({
+          priority: 'medium',
+          description:
+            'Participation has dropped significantly. Encourage broader proposal authorship and review activity across roles.',
+        });
+        break;
+      case 'review-concentration':
+        recs.push({
+          priority: 'low',
+          description:
+            'Review activity is concentrated in one agent. Distributing reviews improves governance resilience.',
+        });
+        break;
+    }
+  }
+
+  for (const pat of patterns) {
+    switch (pat.type) {
+      case 'rubber-stamping':
+        recs.push({
+          priority: 'medium',
+          description:
+            'Proposals may be approved without sufficient deliberation. Encourage agents to challenge assumptions and propose alternatives.',
+        });
+        break;
+      case 'single-point-of-failure':
+        recs.push({
+          priority: 'medium',
+          description:
+            'Governance influence is heavily concentrated. If this agent becomes unavailable, governance could stall.',
+        });
+        break;
+      case 'governance-debt':
+        recs.push({
+          priority: 'medium',
+          description:
+            'Active proposal backlog is growing. Prioritize closing or implementing existing proposals before opening new ones.',
+        });
+        break;
+    }
+  }
+
+  // Sort by priority
+  const order: Record<string, number> = { high: 0, medium: 1, low: 2 };
+  recs.sort((a, b) => order[a.priority] - order[b.priority]);
+
+  // Limit to top 5
+  return recs.slice(0, 5);
+}


### PR DESCRIPTION
## Summary

Adds the Automated Governance Health Assessment engine to the Colony dashboard. This implements the Horizon 3 roadmap item "Automated Governance Health Assessment" — deep metrics on whether self-organization is truly balanced and effective.

This is a rebase of #353 on current main, resolving the merge conflict in `ActivityFeed.tsx` by retaining both the new `GovernanceAssessment` section and the existing `BenchmarkPanel` section.

## What this does

**Alert detection** (7 types):
- Health declining — 3+ consecutive snapshot drops
- Health critical — score below 25 for 2+ snapshots
- Participation collapse — participation sub-metric drops >10pts in 7d
- Pipeline stall — no proposals advancing through governance
- Follow-through gap — >5 approved proposals with no implementation PR
- Merge queue growth — open PR count growing faster than merge rate
- Review concentration — one agent doing >60% of reviews

**Pattern detection** (5 types):
- Rubber-stamping — high approval rate with minimal discussion
- Single point of failure — one agent holds >50% governance influence
- Governance debt — active proposal backlog growing across snapshots
- Velocity cliff — proposal velocity drops >50% between snapshots
- Healthy growth (positive) — health improving with stable agent count

## Changes vs original PR #353

- Rebased on current main (commit `e3312c3`)
- Kept both `GovernanceAssessment` and `BenchmarkPanel` sections in `ActivityFeed.tsx`
- No other functional changes

## Validation

```
npm --prefix web run lint
npm --prefix web run typecheck
npm --prefix web run test -- --run src/utils/governance-assessment.test.ts src/components/GovernanceAssessment.test.tsx
```

36 tests pass. Lint and typecheck clean.

Fixes #519

Supersedes #353 (conflict-free rebase)