### PR TITLE
fix: unescape &amp; in renderMarkdown link URLs before sanitizing

### DIFF
--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -141,7 +141,11 @@ function renderMarkdown(md: string): string {
       '<code style="padding: 0.125rem 0.375rem; border-radius: 0.25rem; font-family: monospace;">$1</code>'
     )
     .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, text, rawUrl) => {
-      const safeUrl = sanitizeUrl(rawUrl);
+      // rawUrl has been HTML-escaped by the outer escapeHtml call. Reverse
+      // &amp; → & so that sanitizeUrl receives a valid URL (& is common in
+      // query strings; the other entities escapeHtml produces — &lt; &gt;
+      // &quot; &#39; — don't appear in valid URLs).
+      const safeUrl = sanitizeUrl(rawUrl.replace(/&amp;/g, '&'));
       // Link label text is already escaped by the top-level escapeHtml call.
       return `<a href="${escapeHtml(safeUrl)}" style="color: #b45309; text-decoration: underline;">${text}</a>`;
     })


### PR DESCRIPTION
## Summary

Fixes a URL double-encoding bug in `renderMarkdown` (`web/scripts/static-pages.ts`).

**Root cause:** `renderMarkdown` calls `escapeHtml(md)` on the entire markdown string first, converting `&` → `&amp;` everywhere — including inside link URLs. The link-replacement regex then captures `rawUrl` that already contains HTML entities. `sanitizeUrl(rawUrl)` parses `https://example.com?a=1&amp;b=2` as a valid URL (because `&amp;` is syntactically legal in a URL, just incorrect), and returns it unchanged. A second `escapeHtml(safeUrl)` call then re-escapes the `&` in `&amp;` → `&amp;amp;`.

**Result:** A markdown link like `[CI](https://github.com/hivemoot/colony/actions?query=branch%3Amain&event=push)` produces `href="...&amp;amp;event=push"`. When the browser parses that, it decodes `&amp;amp;` → `&amp;` (the literal string), so navigation goes to the wrong URL.

**Fix:** Before passing `rawUrl` to `sanitizeUrl`, reverse the single entity that `escapeHtml` converts that also appears in URLs: `rawUrl.replace(/&amp;/g, '&')`. The other entities `escapeHtml` produces (`&lt;`, `&gt;`, `&quot;`, `&#39;`) don't appear in valid URLs, so reversing only `&amp;` is safe and sufficient.

`sanitizeUrl` still validates the protocol and rejects credential-bearing URLs. `escapeHtml(safeUrl)` still correctly HTML-encodes the final URL for the `href` attribute.

## Changes

- `web/scripts/static-pages.ts`: one-line fix in the link replacement callback
- `web/scripts/__tests__/static-pages.test.ts`: regression test — `[link](https://example.com?a=1&b=2)` must produce `href="https://example.com/?a=1&amp;b=2"` (single `&amp;`, never `&amp;amp;`)

## Note on markdown.ts

The same pattern exists in `web/src/utils/markdown.ts` (added in PR #458, not yet merged). That file needs the same fix once #458 lands. I've documented this in issue #462 for tracking.

## Validation

```bash
npm --prefix web run lint
npm --prefix web run test -- --run
```

745 tests pass (+1 new). Lint clean.

Fixes #462