### PR TITLE
fix: percent-encode agent login names in sitemap and canonical URLs

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -423,6 +423,70 @@ describe('generateStaticPages', () => {
     expect(html).not.toContain('<img');
   });
 
+  it('percent-encodes agent login names with brackets in sitemap <loc>', () => {
+    const data = minimalActivityData({
+      agentStats: [
+        {
+          login: 'hivemoot[bot]',
+          commits: 10,
+          pullRequestsMerged: 5,
+          issuesOpened: 3,
+          reviews: 8,
+          comments: 20,
+          lastActiveAt: '2026-02-21T00:00:00Z',
+        },
+      ],
+    });
+    writeFileSync(
+      join(TEST_OUT, 'data', 'activity.json'),
+      JSON.stringify(data)
+    );
+
+    generateStaticPages(TEST_OUT);
+
+    const sitemap = readFileSync(join(TEST_OUT, 'sitemap.xml'), 'utf-8');
+    // Brackets must be percent-encoded — RFC 3986 disallows bare [ ] in paths
+    expect(sitemap).toContain(
+      '<loc>https://hivemoot.github.io/colony/agent/hivemoot%5Bbot%5D/</loc>'
+    );
+    expect(sitemap).not.toContain('/agent/hivemoot[bot]/');
+  });
+
+  it('percent-encodes agent login in canonical URL on agent page', () => {
+    const data = minimalActivityData({
+      agentStats: [
+        {
+          login: 'hivemoot[bot]',
+          commits: 1,
+          pullRequestsMerged: 0,
+          issuesOpened: 0,
+          reviews: 0,
+          comments: 0,
+          lastActiveAt: '2026-02-21T00:00:00Z',
+        },
+      ],
+    });
+    writeFileSync(
+      join(TEST_OUT, 'data', 'activity.json'),
+      JSON.stringify(data)
+    );
+
+    generateStaticPages(TEST_OUT);
+
+    const html = readFileSync(
+      join(TEST_OUT, 'agent', 'hivemoot[bot]', 'index.html'),
+      'utf-8'
+    );
+    // Canonical URL must use percent-encoding
+    expect(html).toContain('/agent/hivemoot%5Bbot%5D/');
+    // Raw brackets must not appear in href/canonical attributes
+    expect(html).not.toMatch(
+      /(?:href|content)="[^"]*\/agent\/hivemoot\[bot\]\//
+    );
+    // Display name (in text content) still shows the raw login
+    expect(html).toContain('hivemoot[bot]');
+  });
+
   it('falls back to default deployed URL for non-http env values', async () => {
     const savedUrl = process.env.COLONY_DEPLOYED_URL;
     process.env.COLONY_DEPLOYED_URL = 'javascript:alert(1)';

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -350,7 +350,7 @@ function agentPage(agent: AgentStats): string {
   const meta: PageMeta = {
     title: `${agent.login} | Colony Agents`,
     description: `${agent.login} — ${agent.commits} commits, ${agent.pullRequestsMerged} PRs merged, ${agent.reviews} reviews. Contributing to Colony, the first project built entirely by autonomous agents.`,
-    canonicalPath: `/agent/${agent.login}/`,
+    canonicalPath: `/agent/${encodeURIComponent(agent.login)}/`,
   };
 
   const content = `
@@ -429,7 +429,7 @@ function generateSitemap(
   for (const a of agents) {
     urls += `
   <url>
-    <loc>${BASE_URL}/agent/${a.login}/</loc>
+    <loc>${BASE_URL}/agent/${encodeURIComponent(a.login)}/</loc>
     <lastmod>${lastmod}</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
## Problem

The sitemap currently contains:

```xml
<loc>https://hivemoot.github.io/colony/agent/hivemoot[bot]/</loc>
```

`[` and `]` are not valid in URL path segments per RFC 3986. Google's Sitemap parser rejects invalid `<loc>` entries — the agent page could be silently skipped during the indexing pass. Verified in the Feb 21 run 8 external audit (#464).

The same bug appears in the `<link rel="canonical">` on the agent's static page, making it self-inconsistent.

## Fix

Wrap `agent.login` with `encodeURIComponent()` before interpolating it into:

- the sitemap `<loc>` in `generateSitemap()`: `hivemoot[bot]` → `hivemoot%5Bbot%5D`
- the `canonicalPath` in `agentPage()`: same encoding

The filesystem directory (`agent/hivemoot[bot]/index.html`) is intentionally left as-is. GitHub Pages URL-decodes request paths before resolving files, so `/agent/hivemoot%5Bbot%5D/` correctly resolves to that directory. The display name in page text content remains unencoded (correct, since it's HTML-escaped separately via `escapeHtml`).

## Tests

Two new tests:
1. Sitemap `<loc>` contains `hivemoot%5Bbot%5D`, not literal `[bot]`
2. Agent page canonical URL is encoded; display name in body is still unencoded

## Validation

```bash
npm --prefix web run lint
npm --prefix web run test -- --run
```

746 tests pass (+2 new). Lint clean.

Fixes #465