### PR TITLE
feat: add search and phase filter to governance proposal list

### DIFF
--- a/web/src/components/ProposalList.tsx
+++ b/web/src/components/ProposalList.tsx
@@ -6,6 +6,7 @@ import {
   buildDecisionSnapshot,
   getProposalHash,
 } from '../utils/decision-explorer';
+import { filterProposals, type ProposalPhaseFilter } from '../utils/governance';
 
 interface ProposalListProps {
   proposals: Proposal[];
@@ -13,6 +14,41 @@ interface ProposalListProps {
   comments?: Comment[];
   repoUrl: string;
   filteredAgent?: string | null;
+}
+
+function readSearchParams(): {
+  query: string;
+  phaseFilter: ProposalPhaseFilter;
+} {
+  const params = new URLSearchParams(window.location.search);
+  const q = params.get('q') ?? '';
+  const filter = params.get('filter') ?? 'all';
+  const phaseFilter: ProposalPhaseFilter =
+    filter === 'active' || filter === 'decided' ? filter : 'all';
+  return { query: q, phaseFilter };
+}
+
+function updateSearchParams(
+  query: string,
+  phaseFilter: ProposalPhaseFilter
+): void {
+  const params = new URLSearchParams(window.location.search);
+  if (query) {
+    params.set('q', query);
+  } else {
+    params.delete('q');
+  }
+  if (phaseFilter !== 'all') {
+    params.set('filter', phaseFilter);
+  } else {
+    params.delete('filter');
+  }
+  const search = params.toString();
+  const newUrl =
+    window.location.pathname +
+    (search ? `?${search}` : '') +
+    window.location.hash;
+  window.history.replaceState(null, '', newUrl);
 }
 
 function findProposalByHash(
@@ -23,6 +59,15 @@ function findProposalByHash(
   const fragment = hash.slice(1);
   return proposals.find((p) => getProposalHash(p) === fragment) ?? null;
 }
+
+const PHASE_FILTER_OPTIONS: Array<{
+  value: ProposalPhaseFilter;
+  label: string;
+}> = [
+  { value: 'all', label: 'All' },
+  { value: 'active', label: 'Active' },
+  { value: 'decided', label: 'Decided' },
+];
 
 export function ProposalList({
   proposals,
@@ -39,6 +84,12 @@ export function ProposalList({
       const match = findProposalByHash(window.location.hash, []);
       return match ? getProposalIdentity(match) : null;
     }
+  );
+  const [searchQuery, setSearchQuery] = useState<string>(
+    () => readSearchParams().query
+  );
+  const [phaseFilter, setPhaseFilter] = useState<ProposalPhaseFilter>(
+    () => readSearchParams().phaseFilter
   );
   const detailRef = useRef<HTMLElement>(null);
 
@@ -140,6 +191,28 @@ export function ProposalList({
     return [...unique.entries()].sort((a, b) => b[1].count - a[1].count);
   }, [proposalComments]);
 
+  const visibleProposals = useMemo(
+    () => filterProposals(proposals, searchQuery, phaseFilter),
+    [proposals, searchQuery, phaseFilter]
+  );
+
+  const handleQueryChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>): void => {
+      const q = e.target.value;
+      setSearchQuery(q);
+      updateSearchParams(q, phaseFilter);
+    },
+    [phaseFilter]
+  );
+
+  const handlePhaseFilterChange = useCallback(
+    (next: ProposalPhaseFilter): void => {
+      setPhaseFilter(next);
+      updateSearchParams(searchQuery, next);
+    },
+    [searchQuery]
+  );
+
   if (proposals.length === 0) {
     return (
       <p className="text-sm text-amber-600 dark:text-amber-400 italic">
@@ -152,8 +225,44 @@ export function ProposalList({
 
   return (
     <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <input
+          type="search"
+          value={searchQuery}
+          onChange={handleQueryChange}
+          placeholder="Search proposals…"
+          aria-label="Search proposals"
+          className="flex-1 rounded-md border border-amber-200 dark:border-neutral-600 bg-white/60 dark:bg-neutral-800/60 px-3 py-1.5 text-sm text-amber-900 dark:text-amber-100 placeholder-amber-400 dark:placeholder-neutral-500 focus:outline-none focus:ring-2 focus:ring-amber-400 dark:focus:ring-amber-500"
+        />
+        <div
+          role="group"
+          aria-label="Filter by phase"
+          className="flex gap-1 shrink-0"
+        >
+          {PHASE_FILTER_OPTIONS.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => handlePhaseFilterChange(value)}
+              aria-pressed={phaseFilter === value}
+              className={`px-3 py-1.5 rounded-md text-xs font-medium border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 ${
+                phaseFilter === value
+                  ? 'bg-amber-500 text-white border-amber-500 dark:bg-amber-600 dark:border-amber-600'
+                  : 'bg-white/60 dark:bg-neutral-800/60 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-neutral-600 hover:bg-amber-50 dark:hover:bg-neutral-700'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+      {visibleProposals.length === 0 && (
+        <p className="text-sm text-amber-600 dark:text-amber-400 italic">
+          No proposals match your search.
+        </p>
+      )}
       <div className="grid gap-4 sm:grid-cols-2">
-        {proposals.map((proposal) => {
+        {visibleProposals.map((proposal) => {
           const proposalId = getProposalIdentity(proposal);
           const explorerId = getDecisionExplorerId(proposal);
           const isSelected = proposalId === effectiveSelectedId;

--- a/web/src/utils/governance.ts
+++ b/web/src/utils/governance.ts
@@ -284,3 +284,51 @@ function median(values: number[]): number | null {
     ? (sorted[mid - 1] + sorted[mid]) / 2
     : sorted[mid];
 }
+
+/**
+ * Phase filter values for the governance archive search.
+ * - 'all': no phase filter applied
+ * - 'active': open governance phases (discussion, voting, extended-voting, ready-to-implement)
+ * - 'decided': terminal phases (implemented, rejected, inconclusive)
+ */
+export type ProposalPhaseFilter = 'all' | 'active' | 'decided';
+
+const ACTIVE_FILTER_PHASES = new Set([
+  'discussion',
+  'voting',
+  'extended-voting',
+  'ready-to-implement',
+]);
+
+const DECIDED_FILTER_PHASES = new Set([
+  'implemented',
+  'rejected',
+  'inconclusive',
+]);
+
+/**
+ * Filter proposals by a text query and phase bucket.
+ *
+ * Text matching is case-insensitive and matches against title and body.
+ * An empty query matches all proposals.
+ */
+export function filterProposals(
+  proposals: Proposal[],
+  query: string,
+  phaseFilter: ProposalPhaseFilter
+): Proposal[] {
+  const trimmed = query.trim().toLowerCase();
+
+  return proposals.filter((p) => {
+    if (phaseFilter === 'active' && !ACTIVE_FILTER_PHASES.has(p.phase)) {
+      return false;
+    }
+    if (phaseFilter === 'decided' && !DECIDED_FILTER_PHASES.has(p.phase)) {
+      return false;
+    }
+    if (!trimmed) return true;
+    const titleMatch = p.title.toLowerCase().includes(trimmed);
+    const bodyMatch = (p.body ?? '').toLowerCase().includes(trimmed);
+    return titleMatch || bodyMatch;
+  });
+}


### PR DESCRIPTION
## Summary

Adds client-side search and phase filtering to the Governance Status section so visitors can browse the full proposal history — not just current state.

Closes #449

## Changes

**`web/src/utils/governance.ts`**
- Export `filterProposals(proposals, query, phaseFilter)` — pure function, no side effects
- Export `ProposalPhaseFilter` type (`'all' | 'active' | 'decided'`)
- Active phases: discussion, voting, extended-voting, ready-to-implement
- Decided phases: implemented, rejected, inconclusive
- Text match: case-insensitive, checks title and body; empty query matches all

**`web/src/components/ProposalList.tsx`**
- Search input (type="search") with aria-label
- Phase filter toggle: All / Active / Decided (aria-pressed for accessibility)
- Filter state read from URL on mount (`?q=` and `?filter=` params)
- State written back via `history.replaceState` — shareable deep links, no router needed
- "No proposals match your search." empty state message

## Validation

```
cd web
npm run lint     # passes
npm run test     # 763 tests pass (16 new: 10 unit + 6 UI)
npm run build    # clean
```

New tests:
- `governance.test.ts`: 10 tests covering empty query, title match, body match, case-insensitivity, active/decided filtering, combined filter, no-match, missing body
- `ProposalList.test.tsx`: 6 tests covering search input renders, query filtering, no-match message, Active/Decided/All button behavior
