### PR TITLE
chore: add high-approval waiver to fast-track criteria

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,14 +95,23 @@ cd web
 npm run fast-track-candidates
 ```
 
-The script evaluates open PRs against the approved #307 criteria:
+The script evaluates open PRs against the approved criteria (#307, amended by #445):
 
 - title prefix is one of `fix:`, `test:`, `docs:`, `chore:`, `a11y:`, `polish:`
 - at least 2 distinct approvals
 - CI status is `SUCCESS`
 - references at least one **open** linked issue (the issue must remain open at merge time)
+- no 👎 veto reaction on the PR
 
-**Important:** If you close the linked issue before the PR merges, the PR becomes ineligible for fast-track. Keep the issue open until the PR is merged.
+**High-approval waiver (#445):** A PR with **6 or more distinct approvals** and no
+active `CHANGES_REQUESTED` reviews is eligible for fast-track even if its linked issue
+was closed before the PR merged. This covers cases where a linked issue was closed
+prematurely — the governance process completed, and the approval count is strong evidence
+of peer consensus. The script marks waiver-eligible PRs with `[high-approval waiver]` in
+its output.
+
+**Important:** For PRs with fewer than 6 approvals, keep the linked issue open until the
+PR merges to maintain fast-track eligibility.
 
 Use `npm run fast-track-candidates -- --json` for machine-readable output.
 


### PR DESCRIPTION
Closes #445

PRs with **≥6 distinct approvals** and no active `CHANGES_REQUESTED` reviews are now
fast-track eligible even when their linked issue was closed before the PR merged.

This unblocks 8+ PRs that have been stuck because a governance process artifact
(premature issue closure) blocked an otherwise clean merge. The governance DID complete —
the issue was just closed slightly before the PR.

## Changes

**`web/scripts/fast-track-candidates.ts`**
- `FAST_TRACK_HIGH_APPROVAL_WAIVER_THRESHOLD = 6` — exported constant
- `hasChangesRequested()` — exported guard for CHANGES_REQUESTED reviews
- `evaluateEligibility()` — applies waiver when ≥6 approvals, no CHANGES_REQUESTED, no open linked issue
- `EligibilityResult` and `CandidateRecord` — gain `waiverApplied: boolean`
- `printHumanReport()` — marks waiver PRs with `[high-approval waiver]` in output

**`CONTRIBUTING.md`**
- Documents the high-approval waiver rule atomically with the script change (per nurse's requirement)

**`web/scripts/__tests__/fast-track-candidates.test.ts`**
- 9 new tests: waiver granted with 6 approvals, CHANGES_REQUESTED blocks waiver,
  5 approvals insufficient, waiverApplied=false when open issue present,
  hasChangesRequested() unit tests, threshold constant is 6

## Validation

```bash
cd web
npm run lint    # clean
npm run test    # 755/755 pass
```

Tests added: 17 total in fast-track-candidates.test.ts (was 8).