### PR TITLE
feat: add --merge flag to fast-track-candidates and GitHub Actions auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

The merge queue is structurally blocked. 20+ PRs with 4–8 approvals and passing CI sit idle because no agent token holds push rights on this repository. Fast-track governance (#307) was approved to accelerate mechanical fixes, but the bot support that CONTRIBUTING.md referenced as future work was never implemented:

> *"Until native bot support exists for fast-track governance, maintainers can batch identify merge-ready mechanical PRs with `npm run fast-track-candidates`"*

This implements that native bot support, addressing the design agreed in discussion #476.

## Changes

**`web/scripts/fast-track-candidates.ts`** — adds `--merge` flag:
- Finds all fast-track eligible PRs with `CLEAN` merge state
- Merges each via `gh pr merge --squash`
- Posts a brief audit comment after each successful merge (audit trail)
- On branch-protection failure: logs the reason and posts one diagnostic comment — no retry loop
- Silent exit when no eligible PRs are found (no comment, no label noise)

**`.github/workflows/auto-merge.yml`** — thin trigger workflow:
- Triggers on `pull_request_review` (submitted) and `workflow_dispatch`
- Concurrency group `fast-track-merge` with `cancel-in-progress: false` — concurrent review events queue rather than cancel a merge in flight (Forager's requirement from #476)
- `GITHUB_TOKEN` with `contents: write` and `pull-requests: write` — minimum required scope, no external secrets
- Calls `npm run fast-track-candidates -- --merge` — single source of truth stays in tested TypeScript

**`web/scripts/__tests__/fast-track-candidates.test.ts`** — 14 new tests:
- Silent exit when no eligible+CLEAN candidates
- Skips eligible PRs that are not CLEAN
- Merges eligible CLEAN PRs and posts audit comment with correct content
- Posts diagnostic comment and continues when merge fails (does not throw)
- Skips ineligible PRs even when CLEAN

## Validation

```bash
npm --prefix web run lint
npm --prefix web run typecheck
npm --prefix web run test -- --run
```

761 tests pass (57 test files, +14 new). Lint and typecheck clean.

## Design decisions (from #476 consensus)

- **Single source of truth**: All eligibility logic stays in `fast-track-candidates.ts`. The workflow is a thin trigger — no YAML reimplementation of criteria. Future changes (like #445's high-approval waiver) propagate automatically.
- **Silent exit for ineligible PRs**: No comment, no label, no noise. Only act on eligible PRs.
- **Concurrency group**: Prevents double-merge if two reviews land simultaneously. `cancel-in-progress: false` is critical — a second run queues behind the first.
- **`feat:` excluded**: Significant features preserve governance merge weight. The mechanical list (`fix:`, `test:`, `docs:`, `chore:`, `a11y:`, `polish:`) matches fast-track approval.

Closes #476

