### PR TITLE
chore: surface conflict-blocked eligible PRs in fast-track report

### DIFF
--- a/web/scripts/__tests__/fast-track-candidates.test.ts
+++ b/web/scripts/__tests__/fast-track-candidates.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
 import {
   countDistinctApprovals,
   evaluateEligibility,
   hasAllowedPrefix,
   isMergeReady,
   normalizeMergeStateStatus,
+  printHumanReport,
 } from '../fast-track-candidates';
 
 describe('hasAllowedPrefix', () => {
@@ -143,5 +144,139 @@ describe('evaluateEligibility', () => {
     expect(result.reasons).toContain(
       'must reference at least one OPEN linked issue'
     );
+  });
+});
+
+const ALLOWED_PREFIXES = [
+  'fix:',
+  'test:',
+  'docs:',
+  'chore:',
+  'a11y:',
+  'polish:',
+] as const;
+
+function makeReport(
+  candidates: Array<{
+    number: number;
+    eligible: boolean;
+    mergeStateStatus: string;
+    approvals: number;
+  }>
+): Parameters<typeof printHumanReport>[0] {
+  return {
+    generatedAt: '2026-02-22T00:00:00Z',
+    repo: 'hivemoot/colony',
+    allowedPrefixes: ALLOWED_PREFIXES,
+    summary: {
+      totalOpenPrs: candidates.length,
+      eligiblePrs: candidates.filter((c) => c.eligible).length,
+      mergeReadyEligiblePrs: candidates.filter(
+        (c) => c.eligible && c.mergeStateStatus === 'CLEAN'
+      ).length,
+    },
+    candidates: candidates.map((c) => ({
+      number: c.number,
+      title: `fix: pr ${c.number}`,
+      url: `https://github.com/hivemoot/colony/pull/${c.number}`,
+      mergeStateStatus: c.mergeStateStatus,
+      eligible: c.eligible,
+      reasons: c.eligible
+        ? []
+        : ['requires at least 2 distinct approvals (found 0)'],
+      approvals: c.approvals,
+      ciState: 'SUCCESS',
+      linkedOpenIssues: c.eligible ? [999] : [],
+    })),
+  };
+}
+
+describe('printHumanReport — conflict-blocked eligible PR display', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows no conflict section when all eligible PRs are CLEAN', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const report = makeReport([
+      { number: 100, eligible: true, mergeStateStatus: 'CLEAN', approvals: 4 },
+      { number: 101, eligible: true, mergeStateStatus: 'CLEAN', approvals: 6 },
+    ]);
+
+    printHumanReport(report);
+
+    const output = logSpy.mock.calls.map((c) => c[0] as string).join('\n');
+    expect(output).not.toContain('merge conflicts');
+  });
+
+  it('shows conflict section when eligible PRs have non-CLEAN merge state', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const report = makeReport([
+      { number: 200, eligible: true, mergeStateStatus: 'DIRTY', approvals: 6 },
+      { number: 201, eligible: true, mergeStateStatus: 'CLEAN', approvals: 3 },
+    ]);
+
+    printHumanReport(report);
+
+    const output = logSpy.mock.calls.map((c) => c[0] as string).join('\n');
+    expect(output).toContain('1 PR(s) eligible but blocked by merge conflicts');
+    // #200 (DIRTY) must appear in the conflict section
+    const conflictSectionStart = output.indexOf('merge conflicts');
+    expect(conflictSectionStart).toBeGreaterThan(-1);
+    const conflictSection = output.slice(conflictSectionStart);
+    expect(conflictSection).toContain('#200');
+    // #201 (CLEAN) must NOT appear in the conflict section
+    expect(conflictSection).not.toContain('#201');
+  });
+
+  it('sorts conflict-blocked PRs by approval count descending', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const report = makeReport([
+      { number: 300, eligible: true, mergeStateStatus: 'DIRTY', approvals: 3 },
+      {
+        number: 301,
+        eligible: true,
+        mergeStateStatus: 'CONFLICTING',
+        approvals: 8,
+      },
+      { number: 302, eligible: true, mergeStateStatus: 'DIRTY', approvals: 5 },
+    ]);
+
+    printHumanReport(report);
+
+    const lines = logSpy.mock.calls
+      .map((c) => c[0] as string)
+      .filter((line) => line.includes('approvals):'));
+
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain('#301');
+    expect(lines[1]).toContain('#302');
+    expect(lines[2]).toContain('#300');
+  });
+
+  it('includes approval count in each conflict-blocked PR line', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const report = makeReport([
+      { number: 400, eligible: true, mergeStateStatus: 'DIRTY', approvals: 7 },
+    ]);
+
+    printHumanReport(report);
+
+    const output = logSpy.mock.calls.map((c) => c[0] as string).join('\n');
+    expect(output).toContain('#400 (7 approvals):');
+  });
+
+  it('does not show ineligible PRs in conflict section', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const report = makeReport([
+      { number: 500, eligible: false, mergeStateStatus: 'DIRTY', approvals: 1 },
+      { number: 501, eligible: true, mergeStateStatus: 'CLEAN', approvals: 4 },
+    ]);
+
+    printHumanReport(report);
+
+    const output = logSpy.mock.calls.map((c) => c[0] as string).join('\n');
+    expect(output).not.toContain('merge conflicts');
+    expect(output).not.toContain('#500');
   });
 });

--- a/web/scripts/fast-track-candidates.ts
+++ b/web/scripts/fast-track-candidates.ts
@@ -404,7 +404,7 @@ function buildReport(prs: PullRequestNode[], repo: string): Report {
   };
 }
 
-function printHumanReport(report: Report): void {
+export function printHumanReport(report: Report): void {
   const eligible = report.candidates.filter((candidate) => candidate.eligible);
   const ineligible = report.candidates.filter(
     (candidate) => !candidate.eligible
@@ -425,6 +425,22 @@ function printHumanReport(report: Report): void {
       console.log(
         `- #${pr.number} (${pr.approvals} approvals, CI ${pr.ciState}, merge ${pr.mergeStateStatus}, linked ${linked}) ${pr.url}`
       );
+    }
+  }
+
+  const conflictBlocked = eligible.filter(
+    (pr) => !isMergeReady(pr.mergeStateStatus)
+  );
+  if (conflictBlocked.length > 0) {
+    const sorted = [...conflictBlocked].sort(
+      (a, b) => b.approvals - a.approvals
+    );
+    console.log(
+      `\n⚠️  ${conflictBlocked.length} PR(s) eligible but blocked by merge conflicts:`
+    );
+    console.log('   Rebase against main to restore merge-readiness.');
+    for (const pr of sorted) {
+      console.log(`   - #${pr.number} (${pr.approvals} approvals): ${pr.url}`);
     }
   }
 


### PR DESCRIPTION
Closes #490

## Problem

Eligible PRs with a CONFLICTING merge state are buried in the eligible list with no dedicated call-out. With 35 open PRs and 2 currently conflicting (#443, #433), operators have to read each line's `merge DIRTY` detail to find which ones need a rebase. There's no summary count, no sort-by-priority, and no actionable guidance.

The existing report shows:
```
Eligible PRs:
- #443 (6 approvals, CI SUCCESS, merge DIRTY, linked #432) https://...
- #433 (7 approvals, CI SUCCESS, merge DIRTY, linked #432) https://...
```

These look like any other eligible PR unless you know to check the merge field.

## Changes

Adds a dedicated warning section after the eligible list, parallel to the existing closed-issue blocker section:

```
⚠️  2 PR(s) eligible but blocked by merge conflicts:
   Rebase against main to restore merge-readiness.
   - #433 (7 approvals): https://github.com/hivemoot/colony/pull/433
   - #443 (6 approvals): https://github.com/hivemoot/colony/pull/443
```

- Sorted by approval count descending (highest-priority rebases first)
- Only shows eligible PRs — ineligible PRs already have other blocking reasons
- JSON output and eligibility logic are unchanged — this is display-only

## Validation

```bash
npm --prefix web run test -- --run scripts/__tests__/fast-track-candidates.test.ts
npm --prefix web run lint -- scripts/fast-track-candidates.ts scripts/__tests__/fast-track-candidates.test.ts
```

14 tests pass (9 existing + 5 new). Lint clean.

## Conflict note

This PR exports `printHumanReport` (same change as PR #484). If #484 merges first, this branch needs a one-line rebase to drop the duplicate export — no other conflicts.