### PR TITLE
fix: apply sanitizeUrl to remaining dynamic hrefs in SPA

### DIFF
--- a/web/src/components/ActivityTimeline.test.tsx
+++ b/web/src/components/ActivityTimeline.test.tsx
@@ -160,6 +160,25 @@ describe('ActivityTimeline', () => {
     expect(link.className).toContain('motion-safe:transition-colors');
   });
 
+  it('sanitizes unsafe event URLs before rendering links', () => {
+    const events: ActivityEvent[] = [
+      {
+        id: 'comment-1',
+        type: 'comment',
+        summary: 'Commented',
+        title: 'Unsafe event URL',
+        url: 'javascript:alert(1)',
+        actor: 'worker',
+        createdAt: '2026-02-05T10:00:00Z',
+      },
+    ];
+
+    render(<ActivityTimeline events={events} />);
+
+    const link = screen.getByRole('link', { name: 'Unsafe event URL' });
+    expect(link).toHaveAttribute('href', '#');
+  });
+
   it('includes focus ring offset on event links', () => {
     const events: ActivityEvent[] = [
       {

--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -1,6 +1,7 @@
 import type { ActivityEvent, ActivityEventType } from '../types/activity';
 import { formatTimeAgo } from '../utils/time';
 import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
+import { sanitizeUrl } from '../utils/markdown';
 
 interface ActivityTimelineProps {
   events: ActivityEvent[];
@@ -102,7 +103,7 @@ export function ActivityTimeline({
               </div>
               {event.url ? (
                 <a
-                  href={event.url}
+                  href={sanitizeUrl(event.url)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="mt-1 block text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-200 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"

--- a/web/src/components/AgentProfilePanel.test.tsx
+++ b/web/src/components/AgentProfilePanel.test.tsx
@@ -286,6 +286,30 @@ describe('AgentProfilePanel', () => {
     expect(screen.queryByText('Other agent commit')).not.toBeInTheDocument();
   });
 
+  it('sanitizes unsafe recent activity URLs', () => {
+    render(
+      <AgentProfilePanel
+        data={makeData()}
+        events={[
+          {
+            id: 'unsafe-1',
+            type: 'comment',
+            summary: 'Unsafe activity link',
+            title: 'Unsafe',
+            actor: 'builder',
+            createdAt: '2026-02-07T10:00:00Z',
+            url: 'javascript:alert(1)',
+          },
+        ]}
+        agentLogin="builder"
+        onClose={vi.fn()}
+      />
+    );
+
+    const link = screen.getByRole('link', { name: 'Unsafe activity link' });
+    expect(link).toHaveAttribute('href', '#');
+  });
+
   it('renders avatar with accessible alt text', () => {
     render(
       <AgentProfilePanel

--- a/web/src/components/AgentProfilePanel.tsx
+++ b/web/src/components/AgentProfilePanel.tsx
@@ -10,6 +10,7 @@ import {
   type AgentRole,
   type AgentRoleProfile,
 } from '../utils/governance';
+import { sanitizeUrl } from '../utils/markdown';
 import { formatTimeAgo } from '../utils/time';
 import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
 import { AgentSpecialization } from './AgentSpecialization';
@@ -362,7 +363,7 @@ function RecentActivity({
             <span className="text-sm text-amber-800 dark:text-amber-200">
               {event.url ? (
                 <a
-                  href={event.url}
+                  href={sanitizeUrl(event.url)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="hover:text-amber-600 dark:hover:text-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900 rounded"

--- a/web/src/components/CommentList.test.tsx
+++ b/web/src/components/CommentList.test.tsx
@@ -139,4 +139,23 @@ describe('CommentList', () => {
     const link = screen.getByRole('link');
     expect(link.className).toContain('focus-visible:ring-2');
   });
+
+  it('sanitizes unsafe comment URLs before rendering links', () => {
+    const comments: Comment[] = [
+      {
+        id: 1,
+        issueOrPrNumber: 10,
+        type: 'issue',
+        author: 'agent-1',
+        body: 'Unsafe',
+        createdAt: new Date().toISOString(),
+        url: 'javascript:alert(1)',
+      },
+    ];
+
+    render(<CommentList comments={comments} />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '#');
+  });
 });

--- a/web/src/components/CommentList.tsx
+++ b/web/src/components/CommentList.tsx
@@ -1,6 +1,7 @@
 import type { Comment } from '../types/activity';
 import { formatTimeAgo } from '../utils/time';
 import { handleAvatarError, getGitHubAvatarUrl } from '../utils/avatar';
+import { sanitizeUrl } from '../utils/markdown';
 
 function formatCommentAction(type: Comment['type']): string {
   switch (type) {
@@ -39,7 +40,7 @@ export function CommentList({
       {comments.map((comment) => (
         <li key={`${comment.type}-${comment.id}`} className="text-sm">
           <a
-            href={comment.url}
+            href={sanitizeUrl(comment.url)}
             target="_blank"
             rel="noopener noreferrer"
             className="group block bg-amber-50/30 dark:bg-neutral-800/30 rounded p-2.5 border border-amber-100/50 dark:border-neutral-700/50 hover:border-amber-300 dark:hover:border-neutral-500 motion-safe:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"

--- a/web/src/components/GovernanceOps.test.tsx
+++ b/web/src/components/GovernanceOps.test.tsx
@@ -133,4 +133,30 @@ describe('GovernanceOps', () => {
       screen.getByText(/no open governance incidents detected/i)
     ).toBeInTheDocument();
   });
+
+  it('sanitizes unsafe incident source URLs', () => {
+    render(
+      <GovernanceOps
+        data={{
+          ...mockData,
+          governanceIncidents: [
+            {
+              id: 'incident-unsafe',
+              category: 'automation-failure',
+              severity: 'high',
+              title: 'Unsafe link incident',
+              detectedAt: '2026-02-11T11:30:00Z',
+              sourceUrl: 'javascript:alert(1)',
+              status: 'open',
+            },
+          ],
+        }}
+      />
+    );
+
+    expect(screen.getByRole('link', { name: /source/i })).toHaveAttribute(
+      'href',
+      '#'
+    );
+  });
 });

--- a/web/src/components/GovernanceOps.tsx
+++ b/web/src/components/GovernanceOps.tsx
@@ -9,6 +9,7 @@ import {
   type GovernanceSLOStatus,
   type ReliabilityMode,
 } from '../utils/governance-ops';
+import { sanitizeUrl } from '../utils/markdown';
 
 interface GovernanceOpsProps {
   data: ActivityData;
@@ -174,7 +175,7 @@ export function GovernanceOps({
                 <span className="font-medium">{incident.title}</span>
                 {incident.sourceUrl && (
                   <a
-                    href={incident.sourceUrl}
+                    href={sanitizeUrl(incident.sourceUrl)}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="ml-1 underline decoration-dotted underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900 rounded"

--- a/web/src/components/ProposalList.test.tsx
+++ b/web/src/components/ProposalList.test.tsx
@@ -458,6 +458,45 @@ describe('ProposalList', () => {
     );
   });
 
+  it('sanitizes unsafe proposal discussion comment URLs', () => {
+    const proposals: Proposal[] = [
+      {
+        number: 9,
+        title: 'Unsafe discussion URL',
+        phase: 'discussion',
+        author: 'worker',
+        createdAt: '2026-02-05T09:00:00Z',
+        commentCount: 1,
+        repo: 'hivemoot/colony',
+      },
+    ];
+    const comments = [
+      {
+        id: 901,
+        issueOrPrNumber: 9,
+        type: 'issue' as const,
+        repo: 'hivemoot/colony',
+        author: 'scout',
+        body: 'Unsafe URL payload',
+        createdAt: '2026-02-05T09:30:00Z',
+        url: 'javascript:alert(1)',
+      },
+    ];
+
+    render(
+      <ProposalList
+        proposals={proposals}
+        comments={comments}
+        repoUrl={repoUrl}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /#9/i }));
+    expect(
+      screen.getByRole('link', { name: /view on github/i })
+    ).toHaveAttribute('href', '#');
+  });
+
   it('clamps long discussion comments and supports expand/collapse', () => {
     const proposals: Proposal[] = [
       {

--- a/web/src/components/ProposalList.tsx
+++ b/web/src/components/ProposalList.tsx
@@ -6,7 +6,7 @@ import {
   buildDecisionSnapshot,
   getProposalHash,
 } from '../utils/decision-explorer';
-import { renderMarkdown } from '../utils/markdown';
+import { renderMarkdown, sanitizeUrl } from '../utils/markdown';
 
 interface ProposalListProps {
   proposals: Proposal[];
@@ -398,7 +398,7 @@ export function ProposalList({
                                 ·
                               </span>
                               <a
-                                href={comment.url}
+                                href={sanitizeUrl(comment.url)}
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 className="text-xs text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-100 underline decoration-dotted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-neutral-800 rounded"


### PR DESCRIPTION
Fixes #500

## Summary
- apply `sanitizeUrl` to dynamic `href` values in SPA components that still rendered raw URLs:
  - `ActivityTimeline` event links
  - `AgentProfilePanel` recent activity links
  - `CommentList` comment links
  - `ProposalList` discussion "View on GitHub" links
  - `GovernanceOps` incident source links
- keep existing behavior for valid GitHub/http(s) links while downgrading unsafe or malformed URLs to `#`
- add focused regression tests for each updated surface using an unsafe `javascript:` URL payload

## Validation
- `cd web && npm run lint`
- `cd web && npm run test`
- `cd web && npm run build`
