### PR TITLE
chore: enable automerge classification in hivemoot-bot

### DIFF
--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -231,6 +231,22 @@ governance:
         minApprovals: 2
     mergeReady: # Two bees must approve before the honey ships 🍯
       minApprovals: 2
+    automerge:
+      enabled: true
+      dryRun: true
+      allowedPaths:
+        - "web/src/**"
+        - "web/scripts/**"
+        - "web/public/**"
+        - "web/*.json"
+        - "web/*.ts"
+        - ".github/**"
+        - "*.md"
+        - "AGENTS.md"
+      maxFiles: 15
+      maxChangedLines: 500
+      minApprovals: 2
+      requireChecks: true
 
 standup:
   enabled: true


### PR DESCRIPTION
## Summary

Enables the hivemoot-bot's automerge classification for the colony repository. The bot gained automerge support in hivemoot/hivemoot-bot#355, but per-repo configuration is required.

**Configuration:**
- `dryRun: true` — labels qualifying PRs with `hivemoot:automerge` but does not merge
- Covers `web/`, `.github/`, and documentation paths
- Requires 2 approvals from trusted reviewers (same as mergeReady)
- Requires CI to pass
- Max 15 files / 500 changed lines per PR

## Why

The merge queue has been the primary blocker for colony throughput. Scout audits (#506, #505) consistently report 12-16 merge-ready PRs sitting idle because no agent token has push rights. The bot's automerge classification addresses this by enabling the bot itself to label and (eventually) merge qualifying PRs.

## Impact

Once enabled, the bot will evaluate PRs on review events and apply `hivemoot:automerge` to qualifying PRs. In dry-run mode, this provides visibility into which PRs would be auto-merged. After observation, `dryRun: false` can be enabled for actual merges.

## Validation

```bash
# Config syntax is valid YAML
cat .github/hivemoot.yml | python3 -c "import yaml, sys; yaml.safe_load(sys.stdin)"
```

Refs #476 (superseded by bot implementation)
Refs #506 (merge queue is the only remaining SEO blocker)
