### PR TITLE
fix: apply encodeURIComponent to GitHub profile URL construction in React components

### DIFF
--- a/web/src/components/ActivityTimeline.tsx
+++ b/web/src/components/ActivityTimeline.tsx
@@ -123,7 +123,7 @@ export function ActivityTimeline({
                   onError={handleAvatarError}
                 />
                 <a
-                  href={`https://github.com/${event.actor}`}
+                  href={`https://github.com/${encodeURIComponent(event.actor)}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-xs text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"

--- a/web/src/components/AgentLeaderboard.tsx
+++ b/web/src/components/AgentLeaderboard.tsx
@@ -102,7 +102,7 @@ export function AgentLeaderboard({
                       onError={handleAvatarError}
                     />
                     <a
-                      href={`https://github.com/${agent.login}`}
+                      href={`https://github.com/${encodeURIComponent(agent.login)}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="relative z-20 font-medium text-amber-900 dark:text-amber-100 hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"

--- a/web/src/components/AgentList.test.tsx
+++ b/web/src/components/AgentList.test.tsx
@@ -36,7 +36,7 @@ describe('AgentList', () => {
     expect(links[1]).toHaveAttribute('href', 'https://github.com/agent-2');
     expect(links[2]).toHaveAttribute(
       'href',
-      'https://github.com/hivemoot[bot]'
+      'https://github.com/hivemoot%5Bbot%5D'
     );
   });
 

--- a/web/src/components/AgentList.tsx
+++ b/web/src/components/AgentList.tsx
@@ -73,7 +73,7 @@ export function AgentList({
               </div>
             </button>
             <a
-              href={`https://github.com/${agent.login}`}
+              href={`https://github.com/${encodeURIComponent(agent.login)}`}
               target="_blank"
               rel="noopener noreferrer"
               className="text-xs mt-1 text-amber-900 dark:text-amber-100 font-medium hover:text-amber-600 dark:hover:text-amber-400 motion-safe:transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900"

--- a/web/src/components/ColonyLiveMode.tsx
+++ b/web/src/components/ColonyLiveMode.tsx
@@ -193,7 +193,7 @@ export function ColonyLiveMode({
                       }}
                     >
                       <a
-                        href={`https://github.com/${node.login}`}
+                        href={`https://github.com/${encodeURIComponent(node.login)}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="group flex flex-col items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-neutral-900 rounded-md"


### PR DESCRIPTION
## Summary

Four React components built GitHub profile URLs by interpolating agent login names directly, producing syntactically invalid URLs for bot accounts like `hivemoot[bot]`:

| File | Before | After |
|------|--------|-------|
| `AgentList.tsx:76` | `https://github.com/${agent.login}` | `https://github.com/${encodeURIComponent(agent.login)}` |
| `ColonyLiveMode.tsx:196` | `https://github.com/${node.login}` | `https://github.com/${encodeURIComponent(node.login)}` |
| `AgentLeaderboard.tsx:105` | `https://github.com/${agent.login}` | `https://github.com/${encodeURIComponent(agent.login)}` |
| `ActivityTimeline.tsx:126` | `https://github.com/${event.actor}` | `https://github.com/${encodeURIComponent(event.actor)}` |

`[` and `]` are RFC 3986 gen-delimiters reserved in the path component and must be percent-encoded. This is the same fix already applied in `avatar.ts:13` for avatar URLs and `static-pages.ts` for sitemap/canonical URLs.

The existing `AgentList.test.tsx` assertion that expected the un-encoded bot URL is updated to the corrected form.

## Validation

```bash
cd web
npm run lint   # clean
npm run test   # 829 passed
```

Closes #504

---

**Validation commands:**
```bash
cd web && npm run lint && npm run test
```