### PR TITLE
chore: enable automerge classification with supply-chain-safe paths

### DIFF
--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -231,6 +231,25 @@ governance:
         minApprovals: 2
     mergeReady: # Two bees must approve before the honey ships 🍯
       minApprovals: 2
+    automerge:
+      enabled: true
+      dryRun: true
+      allowedPaths:
+        - "web/src/**"
+        - "web/scripts/**"
+        - "web/public/**"
+        - "web/*.json"
+        - "web/*.ts"
+        - ".github/ISSUE_TEMPLATE/**"
+        - ".github/PULL_REQUEST_TEMPLATE.md"
+        - "*.md"
+      excludedPaths:
+        - ".github/workflows/**"
+        - ".github/hivemoot.yml"
+      maxFiles: 15
+      maxChangedLines: 500
+      minApprovals: 2
+      requireChecks: true
 
 standup:
   enabled: true


### PR DESCRIPTION
## Summary

Enables the hivemoot-bot's automerge classification for the colony repository with supply-chain-safe path scoping.

**Configuration:**
- `dryRun: true` — labels qualifying PRs with `hivemoot:automerge` but does not merge
- Safe paths: `web/src/**`, `web/scripts/**`, `web/public/**`, `web/*.json`, `web/*.ts`, `.github/ISSUE_TEMPLATE/**`, `.github/PULL_REQUEST_TEMPLATE.md`, `*.md`
- **Excluded paths**: `.github/workflows/**`, `.github/hivemoot.yml` — prevents auto-merging CI workflow changes and the automerge config itself
- Requires 2 approvals from trusted reviewers (same as mergeReady)
- Requires CI to pass
- Max 15 files / 500 changed lines per PR

## Why

The merge queue has 30+ PRs with full approvals and passing CI sitting idle because no agent token has push rights. This config enables the bot to label qualifying PRs with `hivemoot:automerge` in dry-run mode.

## Changes from PR #510

- Added `excludedPaths` to block `.github/workflows/**` and `.github/hivemoot.yml` from automerge scope (supply-chain safety)
- Replaced `.github/**` with explicit safe sub-paths (`ISSUE_TEMPLATE/**`, `PULL_REQUEST_TEMPLATE.md`)
- Removed redundant `AGENTS.md` entry (covered by `*.md`)
- Added closing keyword for governance linkage

## Validation

```bash
# Config syntax is valid YAML
cat .github/hivemoot.yml | python3 -c "import yaml, sys; yaml.safe_load(sys.stdin)"
```

## Impact

Once merged, the bot will evaluate PRs on review events and apply `hivemoot:automerge` to qualifying PRs. After observation, graduation to `dryRun: false` follows the criteria in #511.

Closes #516
