### PR TITLE
chore: add bot write-access verification command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,20 @@ The script evaluates open PRs against the approved #307 criteria:
 
 Use `npm run fast-track-candidates -- --json` for machine-readable output.
 
+## Bot Write-Access Verification (Issue #511)
+
+Before graduating automerge from dry-run to real merges, verify the
+`hivemoot-bot` installation has `contents: write`:
+
+```bash
+cd web
+npm run check-bot-write-access
+```
+
+Use `npm run check-bot-write-access -- --json` for machine-readable output.
+If your token lacks org-admin visibility, the command exits with
+`BLOCKED: admin-required` and prints the exact admin verifier command to run.
+
 ## External Outreach Metrics
 
 Track weekly discoverability outcomes (accepted awesome-list links and star delta):

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "typecheck": "tsc --noEmit",
     "generate-data": "tsx scripts/generate-data.ts",
     "check-visibility": "tsx scripts/check-visibility.ts",
+    "check-bot-write-access": "tsx scripts/check-bot-write-access.ts",
     "external-outreach-metrics": "tsx scripts/external-outreach-metrics.ts",
     "fast-track-candidates": "tsx scripts/fast-track-candidates.ts",
     "replay-governance": "tsx scripts/replay-governance.ts"

--- a/web/scripts/__tests__/check-bot-write-access.test.ts
+++ b/web/scripts/__tests__/check-bot-write-access.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findInstallation,
+  formatTextResult,
+  hasContentsWritePermission,
+  normalizePermissionValue,
+  parseArgs,
+  verifyBotWriteAccess,
+} from '../check-bot-write-access';
+
+describe('parseArgs', () => {
+  it('uses defaults when no flags are provided', () => {
+    expect(parseArgs([])).toEqual({
+      org: 'hivemoot',
+      appSlug: 'hivemoot-bot',
+      json: false,
+    });
+  });
+
+  it('parses overrides', () => {
+    expect(
+      parseArgs(['--org=example-org', '--app-slug=example-bot', '--json'])
+    ).toEqual({
+      org: 'example-org',
+      appSlug: 'example-bot',
+      json: true,
+    });
+  });
+});
+
+describe('findInstallation', () => {
+  it('finds app installation by slug case-insensitively', () => {
+    const payload = {
+      installations: [{ app_slug: 'HiveMoot-Bot', permissions: {} }],
+    };
+
+    expect(findInstallation(payload, 'hivemoot-bot')).toEqual(
+      payload.installations[0]
+    );
+  });
+
+  it('returns null when installation payload is malformed', () => {
+    expect(findInstallation({}, 'hivemoot-bot')).toBeNull();
+    expect(findInstallation({ installations: {} }, 'hivemoot-bot')).toBeNull();
+  });
+});
+
+describe('normalizePermissionValue', () => {
+  it('normalizes permission strings', () => {
+    expect(normalizePermissionValue(' Write ')).toBe('write');
+  });
+
+  it('returns empty string for non-string values', () => {
+    expect(normalizePermissionValue(undefined)).toBe('');
+    expect(normalizePermissionValue(1)).toBe('');
+  });
+});
+
+describe('hasContentsWritePermission', () => {
+  it('accepts write and admin', () => {
+    expect(
+      hasContentsWritePermission({ permissions: { contents: 'write' } })
+    ).toEqual({ ok: true, permission: 'write' });
+    expect(
+      hasContentsWritePermission({ permissions: { contents: 'admin' } })
+    ).toEqual({ ok: true, permission: 'admin' });
+  });
+
+  it('rejects missing or read-only permissions', () => {
+    expect(
+      hasContentsWritePermission({ permissions: { contents: 'read' } })
+    ).toEqual({ ok: false, permission: 'read' });
+    expect(hasContentsWritePermission(null)).toEqual({
+      ok: false,
+      permission: '',
+    });
+  });
+});
+
+describe('verifyBotWriteAccess', () => {
+  it('returns verified when contents permission is write', () => {
+    const result = verifyBotWriteAccess(
+      { org: 'hivemoot', appSlug: 'hivemoot-bot', json: false },
+      () =>
+        JSON.stringify({
+          installations: [
+            {
+              id: 123,
+              app_slug: 'hivemoot-bot',
+              permissions: { contents: 'write' },
+            },
+          ],
+        })
+    );
+
+    expect(result.status).toBe('verified');
+    expect(result.reason).toBe('contents-write-confirmed');
+    expect(result.installationId).toBe(123);
+  });
+
+  it('returns blocked for missing app install', () => {
+    const result = verifyBotWriteAccess(
+      { org: 'hivemoot', appSlug: 'hivemoot-bot', json: false },
+      () => JSON.stringify({ installations: [] })
+    );
+    expect(result).toMatchObject({
+      status: 'blocked',
+      reason: 'app-not-installed',
+    });
+  });
+
+  it('returns blocked when gh api execution fails', () => {
+    const result = verifyBotWriteAccess(
+      { org: 'hivemoot', appSlug: 'hivemoot-bot', json: false },
+      () => {
+        throw new Error('HTTP 403');
+      }
+    );
+    expect(result).toMatchObject({
+      status: 'blocked',
+      reason: 'admin-required',
+    });
+  });
+});
+
+describe('formatTextResult', () => {
+  it('formats verified output', () => {
+    const text = formatTextResult({
+      status: 'verified',
+      reason: 'contents-write-confirmed',
+      org: 'hivemoot',
+      appSlug: 'hivemoot-bot',
+      command: 'gh api /orgs/hivemoot/installations',
+      installationId: 77,
+      contentsPermission: 'write',
+    });
+
+    expect(text).toContain('VERIFIED: bot write access confirmed');
+    expect(text).toContain('installationId=77');
+  });
+
+  it('formats blocked output with admin command', () => {
+    const text = formatTextResult({
+      status: 'blocked',
+      reason: 'admin-required',
+      org: 'hivemoot',
+      appSlug: 'hivemoot-bot',
+      command: 'gh api /orgs/hivemoot/installations',
+    });
+
+    expect(text).toContain('BLOCKED: admin-required');
+    expect(text).toContain('Admin verifier command:');
+    expect(text).toContain('select(.app_slug == "hivemoot-bot")');
+  });
+});

--- a/web/scripts/check-bot-write-access.ts
+++ b/web/scripts/check-bot-write-access.ts
@@ -1,0 +1,249 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_ORG = 'hivemoot';
+const DEFAULT_APP_SLUG = 'hivemoot-bot';
+
+interface CliOptions {
+  org: string;
+  appSlug: string;
+  json: boolean;
+}
+
+interface Installation {
+  app_slug?: unknown;
+  permissions?: unknown;
+}
+
+interface InstallationsResponse {
+  installations?: Installation[];
+}
+
+export interface BotPermissionResult {
+  status: 'verified' | 'blocked';
+  reason: string;
+  org: string;
+  appSlug: string;
+  command: string;
+  installationId?: number;
+  contentsPermission?: string;
+  error?: string;
+}
+
+function printHelp(): void {
+  console.log(
+    'Usage: npm run check-bot-write-access -- [--org=hivemoot] [--app-slug=hivemoot-bot] [--json]'
+  );
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    org: DEFAULT_ORG,
+    appSlug: DEFAULT_APP_SLUG,
+    json: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+
+    if (arg.startsWith('--org=')) {
+      const value = arg.slice('--org='.length).trim();
+      options.org = value || DEFAULT_ORG;
+      continue;
+    }
+
+    if (arg.startsWith('--app-slug=')) {
+      const value = arg.slice('--app-slug='.length).trim();
+      options.appSlug = value || DEFAULT_APP_SLUG;
+      continue;
+    }
+
+    if (arg === '--help') {
+      printHelp();
+      process.exit(0);
+    }
+  }
+
+  return options;
+}
+
+function asInstallationsResponse(value: unknown): InstallationsResponse {
+  if (typeof value !== 'object' || value === null) {
+    return {};
+  }
+  return value as InstallationsResponse;
+}
+
+export function findInstallation(
+  payload: unknown,
+  appSlug: string
+): Installation | null {
+  const parsed = asInstallationsResponse(payload);
+  if (!Array.isArray(parsed.installations)) {
+    return null;
+  }
+
+  const normalizedTarget = appSlug.trim().toLowerCase();
+  for (const installation of parsed.installations) {
+    if (typeof installation.app_slug !== 'string') {
+      continue;
+    }
+    if (installation.app_slug.trim().toLowerCase() === normalizedTarget) {
+      return installation;
+    }
+  }
+
+  return null;
+}
+
+function getInstallationId(installation: Installation): number | undefined {
+  if (
+    typeof (installation as { id?: unknown }).id === 'number' &&
+    Number.isFinite((installation as { id?: number }).id)
+  ) {
+    return (installation as { id: number }).id;
+  }
+  return undefined;
+}
+
+export function normalizePermissionValue(value: unknown): string {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  return value.trim().toLowerCase();
+}
+
+export function hasContentsWritePermission(installation: Installation | null): {
+  ok: boolean;
+  permission: string;
+} {
+  if (!installation || typeof installation.permissions !== 'object') {
+    return {
+      ok: false,
+      permission: '',
+    };
+  }
+
+  const rawPermission = (installation.permissions as { contents?: unknown })
+    .contents;
+  const permission = normalizePermissionValue(rawPermission);
+  return {
+    ok: permission === 'write' || permission === 'admin',
+    permission,
+  };
+}
+
+function buildInstallationsCommand(org: string): string {
+  return `gh api /orgs/${org}/installations`;
+}
+
+function blockedResult(
+  reason: string,
+  options: CliOptions,
+  extras: Partial<BotPermissionResult> = {}
+): BotPermissionResult {
+  return {
+    status: 'blocked',
+    reason,
+    org: options.org,
+    appSlug: options.appSlug,
+    command: buildInstallationsCommand(options.org),
+    ...extras,
+  };
+}
+
+export function verifyBotWriteAccess(
+  options: CliOptions,
+  runCommand: (args: string[]) => string = (args) =>
+    execFileSync('gh', args, { encoding: 'utf8' })
+): BotPermissionResult {
+  const args = ['api', `/orgs/${options.org}/installations`];
+
+  let raw = '';
+  try {
+    raw = runCommand(args);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return blockedResult('admin-required', options, { error: message });
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return blockedResult('invalid-response', options, { error: raw.trim() });
+  }
+
+  const installation = findInstallation(payload, options.appSlug);
+  if (!installation) {
+    return blockedResult('app-not-installed', options);
+  }
+
+  const { ok, permission } = hasContentsWritePermission(installation);
+  if (!ok) {
+    return blockedResult('missing-contents-write', options, {
+      installationId: getInstallationId(installation),
+      contentsPermission: permission,
+    });
+  }
+
+  return {
+    status: 'verified',
+    reason: 'contents-write-confirmed',
+    org: options.org,
+    appSlug: options.appSlug,
+    command: buildInstallationsCommand(options.org),
+    installationId: getInstallationId(installation),
+    contentsPermission: permission,
+  };
+}
+
+export function formatTextResult(result: BotPermissionResult): string {
+  if (result.status === 'verified') {
+    return [
+      'VERIFIED: bot write access confirmed',
+      `org=${result.org}`,
+      `app=${result.appSlug}`,
+      `installationId=${result.installationId ?? 'unknown'}`,
+      `contentsPermission=${result.contentsPermission || 'unknown'}`,
+    ].join('\n');
+  }
+
+  return [
+    `BLOCKED: ${result.reason}`,
+    `org=${result.org}`,
+    `app=${result.appSlug}`,
+    `command=${result.command}`,
+    result.error ? `error=${result.error}` : '',
+    'Admin verifier command:',
+    `${result.command} --jq '.installations[] | select(.app_slug == "${result.appSlug}") | {id, permissions: .permissions}'`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+function main(): void {
+  const options = parseArgs(process.argv.slice(2));
+  const result = verifyBotWriteAccess(options);
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatTextResult(result));
+  }
+
+  if (result.status !== 'verified') {
+    process.exitCode = 1;
+  }
+}
+
+const isMainModule =
+  typeof process.argv[1] === 'string' &&
+  process.argv[1] === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add `web/scripts/check-bot-write-access.ts` to verify `hivemoot-bot` installation permission state via `gh api /orgs/<org>/installations`
- return structured `verified` / `blocked` results and print a canonical admin verifier command when `admin:org` visibility is missing
- wire new command into `web/package.json` and document the workflow in `CONTRIBUTING.md` under Issue #511

## Why
Issue #511 requires a repeatable preflight check before switching automerge from dry-run to real merges. Today that check is ad hoc and repeatedly re-discovered in comments. This makes the check executable, machine-readable, and consistent across runs.

## Validation
- `npm --prefix web run test -- scripts/__tests__/check-bot-write-access.test.ts`
- `npm --prefix web run lint`
- `npm --prefix web run build`
- `npm --prefix web run check-bot-write-access -- --json` (expected blocked in non-admin token contexts)

Fixes #511
