### PR TITLE
feat: Lighthouse CI Phase 1+2 — SPA and static page auditing with fixture data

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,58 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches: [main]
+
+# Separate concurrency group from main CI — Lighthouse audits should not be
+# cancelled by concurrent CI runs on the same PR (Lighthouse needs the server
+# to be running for the full audit duration).
+concurrency:
+  group: lighthouse-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Build
+        run: npm run build
+        working-directory: web
+
+      # Phase 2: Generate fixture-backed static proposal and agent pages.
+      # Uses web/scripts/__fixtures__/lighthouse-activity.json so the audit
+      # is deterministic and requires no GitHub API access.
+      - name: Generate fixture static pages
+        run: npm run generate-static-fixture
+        working-directory: web
+
+      - name: Start preview server
+        run: npm run preview &
+        working-directory: web
+
+      - name: Wait for preview server
+        run: timeout 30 bash -c 'until curl -sf http://localhost:4173/colony/ > /dev/null; do sleep 1; done'
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: |
+            http://localhost:4173/colony/
+            http://localhost:4173/colony/proposal/1/
+            http://localhost:4173/colony/agent/lighthouse-fixture-agent/
+          configPath: ./web/lighthouserc.json
+          temporaryPublicStorage: true
+        # Keep continue-on-error until Phase 2 baseline scores are confirmed.
+        continue-on-error: true

--- a/web/lighthouserc.json
+++ b/web/lighthouserc.json
@@ -1,0 +1,16 @@
+{
+  "ci": {
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["warn", { "minScore": 0.9 }],
+        "document-title": "error",
+        "meta-description": "error",
+        "html-has-lang": "error",
+        "canonical": "warn"
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,8 @@
     "check-visibility": "tsx scripts/check-visibility.ts",
     "external-outreach-metrics": "tsx scripts/external-outreach-metrics.ts",
     "fast-track-candidates": "tsx scripts/fast-track-candidates.ts",
-    "replay-governance": "tsx scripts/replay-governance.ts"
+    "replay-governance": "tsx scripts/replay-governance.ts",
+    "generate-static-fixture": "tsx scripts/generate-static-fixture.ts"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/web/scripts/__fixtures__/lighthouse-activity.json
+++ b/web/scripts/__fixtures__/lighthouse-activity.json
@@ -1,0 +1,46 @@
+{
+  "generatedAt": "2026-01-15T12:00:00Z",
+  "repository": {
+    "owner": "lighthouse-test-org",
+    "name": "lighthouse-test-repo",
+    "url": "https://github.com/lighthouse-test-org/lighthouse-test-repo",
+    "stars": 0,
+    "forks": 0,
+    "openIssues": 0
+  },
+  "agents": [
+    { "login": "lighthouse-fixture-agent" }
+  ],
+  "agentStats": [
+    {
+      "login": "lighthouse-fixture-agent",
+      "commits": 5,
+      "pullRequestsMerged": 3,
+      "issuesOpened": 2,
+      "reviews": 4,
+      "comments": 10,
+      "lastActiveAt": "2026-01-15T10:00:00Z"
+    }
+  ],
+  "commits": [],
+  "issues": [],
+  "pullRequests": [],
+  "proposals": [
+    {
+      "number": 1,
+      "title": "Lighthouse CI Phase 2 Fixture",
+      "body": "A fixture proposal used to generate static HTML pages for Lighthouse CI audits. This verifies that proposal pages have correct titles, meta descriptions, canonical URLs, and structured data.",
+      "phase": "implemented",
+      "author": "lighthouse-fixture-agent",
+      "createdAt": "2026-01-10T00:00:00Z",
+      "commentCount": 3,
+      "votesSummary": { "thumbsUp": 5, "thumbsDown": 0 },
+      "phaseTransitions": [
+        { "phase": "discussion", "enteredAt": "2026-01-10T00:00:00Z" },
+        { "phase": "voting", "enteredAt": "2026-01-11T00:00:00Z" },
+        { "phase": "implemented", "enteredAt": "2026-01-12T00:00:00Z" }
+      ]
+    }
+  ],
+  "comments": []
+}

--- a/web/scripts/generate-static-fixture.ts
+++ b/web/scripts/generate-static-fixture.ts
@@ -1,0 +1,40 @@
+/**
+ * Generate static HTML pages from fixture data for Lighthouse CI Phase 2 audits.
+ *
+ * Writes the fixture activity.json to dist/data/activity.json and calls
+ * generateStaticPages so the Lighthouse workflow can audit real static
+ * proposal and agent pages without a live GitHub API call.
+ *
+ * Run after `npm run build` in the Lighthouse CI workflow:
+ *   npm run generate-static-fixture
+ */
+
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generateStaticPages } from './static-pages';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(
+  SCRIPT_DIR,
+  '__fixtures__',
+  'lighthouse-activity.json'
+);
+const DIST_DIR = resolve(SCRIPT_DIR, '..', 'dist');
+const DATA_DIR = join(DIST_DIR, 'data');
+
+if (!existsSync(DIST_DIR)) {
+  console.error(
+    '[generate-static-fixture] dist/ not found — run `npm run build` first.'
+  );
+  process.exit(1);
+}
+
+mkdirSync(DATA_DIR, { recursive: true });
+copyFileSync(FIXTURE_PATH, join(DATA_DIR, 'activity.json'));
+console.log(
+  '[generate-static-fixture] Wrote fixture data to dist/data/activity.json'
+);
+
+generateStaticPages(DIST_DIR);
+console.log('[generate-static-fixture] Done.');


### PR DESCRIPTION
## What

Lighthouse CI Phase 1 + Phase 2 in a single PR.

**Phase 1** (from #480, same as PR #492): audits the SPA root (`http://localhost:4173/colony/`) on every PR.

**Phase 2** (from #494): extends Lighthouse coverage to static proposal and agent pages using deterministic fixture data — no GitHub API access required.

## Why combined

PR #492 (Phase 1 only) is merge-ready but stuck in the queue. Rather than waiting for it to merge before building Phase 2 on top, this PR ships both together and eliminates the dependency chain.

## How it works

1. `npm run build` — builds the SPA (no `generate-data` run, so no static pages yet)
2. `npm run generate-static-fixture` — writes `web/scripts/__fixtures__/lighthouse-activity.json` to `dist/data/activity.json`, then calls `generateStaticPages()` to produce fixture-backed proposal and agent pages
3. Preview server starts, Lighthouse audits three URLs:
   - `http://localhost:4173/colony/` — SPA root (Phase 1)
   - `http://localhost:4173/colony/proposal/1/` — static proposal page (Phase 2)
   - `http://localhost:4173/colony/agent/lighthouse-fixture-agent/` — static agent page (Phase 2)

## Fixture approach

The fixture (`web/scripts/__fixtures__/lighthouse-activity.json`) is a minimal valid `ActivityData` object checked into the repo. It contains one proposal and one agent with all required fields. Lighthouse results are deterministic across PRs and branches.

## Assertions

`web/lighthouserc.json` asserts:
- `categories:accessibility` ≥ 0.9 (warn)
- `document-title` — error
- `meta-description` — error
- `html-has-lang` — error
- `canonical` — warn

`continue-on-error: true` is kept until post-merge baseline scores are confirmed (per the Phase 2 issue guidance).

## Validation

```bash
cd web
npm run lint        # clean
npm run typecheck   # clean
npm run test        # 825/825 passing
```

Closes #494
Also closes #480 (supersedes PR #492 with Phase 2 included)
