### PR TITLE
feat: add Pagefind search to static pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,16 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify Pagefind artifacts
+        run: |
+          if [ -d dist/proposals ] || [ -d dist/proposal ] || [ -d dist/agent ]; then
+            test -f dist/_pagefind/pagefind.js
+            test -f dist/_pagefind/pagefind-entry.json
+            find dist/_pagefind -type f -name '*.pf_meta' | grep -q .
+          else
+            echo "No generated static pages found; skipping Pagefind artifact assertion."
+          fi
+
       - name: Visibility guardrail (non-blocking)
         run: npm run check-visibility
         continue-on-error: true

--- a/web/index.html
+++ b/web/index.html
@@ -54,7 +54,7 @@
       }
     </style>
   </head>
-  <body>
+  <body data-pagefind-ignore>
     <div id="root">
       <div class="fallback-bg" style="font-family: system-ui, -apple-system, sans-serif; display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; padding: 2rem; text-align: center; background: linear-gradient(to bottom, #fffbeb, #fef3c7); transition: background-color 0.3s ease;">
         <div style="font-size: 4rem; margin-bottom: 1.5rem;" role="img" aria-label="bee">🐝</div>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "jsdom": "^27.4.0",
+        "pagefind": "^1.4.0",
         "prettier": "^3.8.1",
         "tailwindcss": "^4.1.18",
         "tsx": "^4.20.3",
@@ -1254,6 +1255,90 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
+      "integrity": "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz",
+      "integrity": "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
+      "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
+      "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
@@ -5537,6 +5622,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pagefind": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz",
+      "integrity": "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.4.0",
+        "@pagefind/darwin-x64": "1.4.0",
+        "@pagefind/freebsd-x64": "1.4.0",
+        "@pagefind/linux-arm64": "1.4.0",
+        "@pagefind/linux-x64": "1.4.0",
+        "@pagefind/windows-x64": "1.4.0"
       }
     },
     "node_modules/parent-module": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "postbuild": "tsx scripts/build-pagefind.ts",
     "build:with-data": "npm run generate-data && npm run build",
     "preview": "vite preview",
     "test": "vitest run",
@@ -48,6 +49,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^27.4.0",
+    "pagefind": "^1.4.0",
     "prettier": "^3.8.1",
     "tailwindcss": "^4.1.18",
     "tsx": "^4.20.3",

--- a/web/public/static-page-search.js
+++ b/web/public/static-page-search.js
@@ -1,0 +1,223 @@
+(() => {
+  const panel = document.querySelector('.search-panel[data-base-path]');
+  if (!(panel instanceof HTMLElement)) {
+    return;
+  }
+
+  const input = document.getElementById('archive-search-input');
+  const status = document.getElementById('archive-search-status');
+  const results = document.getElementById('archive-search-results');
+
+  if (
+    !(input instanceof HTMLInputElement) ||
+    !(status instanceof HTMLElement) ||
+    !(results instanceof HTMLElement)
+  ) {
+    return;
+  }
+
+  function normalizeBasePath(rawValue) {
+    const raw = (rawValue || '/').trim();
+    if (!raw) {
+      return '/';
+    }
+
+    let normalized = raw;
+    if (!normalized.startsWith('/')) {
+      normalized = `/${normalized}`;
+    }
+    if (!normalized.endsWith('/')) {
+      normalized = `${normalized}/`;
+    }
+    return normalized;
+  }
+
+  function toPlainText(value) {
+    return String(value || '')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  const basePath = normalizeBasePath(panel.dataset.basePath);
+  const pagefindScriptUrl = `${basePath}_pagefind/pagefind.js`;
+
+  let pagefindModulePromise;
+  let activeSearch = 0;
+  let debounceTimer = 0;
+
+  function setStatus(message) {
+    status.textContent = message;
+  }
+
+  function clearResults() {
+    results.innerHTML = '';
+  }
+
+  function normalizeResultUrl(rawUrl) {
+    const value = String(rawUrl || '').trim();
+    if (!value) {
+      return basePath;
+    }
+
+    if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value)) {
+      return value;
+    }
+
+    if (value.startsWith(basePath)) {
+      return value;
+    }
+
+    return `${basePath}${value.replace(/^\/+/, '')}`;
+  }
+
+  function resolvePagefindApi(moduleValue) {
+    if (moduleValue && typeof moduleValue.search === 'function') {
+      return moduleValue;
+    }
+
+    if (
+      moduleValue &&
+      moduleValue.default &&
+      typeof moduleValue.default.search === 'function'
+    ) {
+      return moduleValue.default;
+    }
+
+    throw new Error('Pagefind search API not found in module export.');
+  }
+
+  function renderResults(entries) {
+    clearResults();
+
+    const fragment = document.createDocumentFragment();
+
+    for (const entry of entries) {
+      const item = document.createElement('li');
+      item.className = 'search-result';
+
+      const link = document.createElement('a');
+      link.className = 'search-result-link';
+      link.href = entry.url;
+      link.textContent = entry.title;
+      item.appendChild(link);
+
+      if (entry.metaLine) {
+        const meta = document.createElement('p');
+        meta.className = 'search-result-meta';
+        meta.textContent = entry.metaLine;
+        item.appendChild(meta);
+      }
+
+      if (entry.snippet) {
+        const snippet = document.createElement('p');
+        snippet.className = 'search-result-snippet';
+        snippet.textContent = entry.snippet;
+        item.appendChild(snippet);
+      }
+
+      fragment.appendChild(item);
+    }
+
+    results.appendChild(fragment);
+  }
+
+  async function loadPagefind() {
+    if (!pagefindModulePromise) {
+      pagefindModulePromise = import(pagefindScriptUrl);
+    }
+
+    const loadedModule = await pagefindModulePromise;
+    return resolvePagefindApi(loadedModule);
+  }
+
+  async function runSearch(query) {
+    const searchId = ++activeSearch;
+
+    setStatus('Searching...');
+
+    try {
+      const pagefind = await loadPagefind();
+      const searchResponse = await pagefind.search(query);
+      const resultItems = await Promise.all(
+        (searchResponse.results || []).slice(0, 8).map(async (result) => {
+          const data = await result.data();
+          const meta = data.meta || {};
+          const title =
+            toPlainText(meta.title) ||
+            toPlainText(data.excerpt) ||
+            normalizeResultUrl(data.url);
+
+          const metaParts = [];
+          if (meta.phase) {
+            metaParts.push(toPlainText(meta.phase));
+          }
+          if (meta.author) {
+            metaParts.push(`by ${toPlainText(meta.author)}`);
+          }
+          if (meta.agent && !meta.author) {
+            metaParts.push(`agent ${toPlainText(meta.agent)}`);
+          }
+
+          return {
+            url: normalizeResultUrl(data.url),
+            title,
+            metaLine: metaParts.join(' | '),
+            snippet: toPlainText(data.excerpt || data.content).slice(0, 180),
+          };
+        })
+      );
+
+      if (searchId !== activeSearch) {
+        return;
+      }
+
+      if (resultItems.length === 0) {
+        clearResults();
+        setStatus('No results found.');
+        return;
+      }
+
+      renderResults(resultItems);
+      setStatus(`Showing ${resultItems.length} result${resultItems.length === 1 ? '' : 's'}.`);
+    } catch (_error) {
+      if (searchId !== activeSearch) {
+        return;
+      }
+      clearResults();
+      setStatus('Search is temporarily unavailable.');
+    }
+  }
+
+  input.addEventListener('focus', () => {
+    void loadPagefind().catch(() => {
+      if (!status.textContent) {
+        setStatus('Search is temporarily unavailable.');
+      }
+    });
+  });
+
+  input.addEventListener('input', () => {
+    const query = input.value.trim();
+
+    if (debounceTimer) {
+      window.clearTimeout(debounceTimer);
+    }
+
+    if (!query) {
+      clearResults();
+      setStatus('');
+      return;
+    }
+
+    if (query.length < 2) {
+      clearResults();
+      setStatus('Type at least 2 characters to search.');
+      return;
+    }
+
+    debounceTimer = window.setTimeout(() => {
+      void runSearch(query);
+    }, 180);
+  });
+})();

--- a/web/public/static-page-search.js
+++ b/web/public/static-page-search.js
@@ -60,15 +60,33 @@
       return basePath;
     }
 
-    if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value)) {
-      return value;
+    let parsedUrl;
+    try {
+      parsedUrl = new URL(value, window.location.origin);
+    } catch (_error) {
+      return basePath;
     }
 
-    if (value.startsWith(basePath)) {
-      return value;
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return basePath;
     }
 
-    return `${basePath}${value.replace(/^\/+/, '')}`;
+    if (parsedUrl.origin !== window.location.origin) {
+      return basePath;
+    }
+
+    const path = parsedUrl.pathname.startsWith(basePath)
+      ? parsedUrl.pathname
+      : `${basePath}${parsedUrl.pathname.replace(/^\/+/, '')}`;
+
+    return `${path}${parsedUrl.search}${parsedUrl.hash}`;
+  }
+
+  if (panel.dataset.exposeInternals === 'true') {
+    window.__COLONY_STATIC_SEARCH_TEST__ = {
+      normalizeBasePath,
+      normalizeResultUrl,
+    };
   }
 
   function resolvePagefindApi(moduleValue) {

--- a/web/scripts/__tests__/static-page-search.test.ts
+++ b/web/scripts/__tests__/static-page-search.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SEARCH_SCRIPT_PATH = resolve(
+  __dirname,
+  '../../public/static-page-search.js'
+);
+const SEARCH_SCRIPT_SOURCE = readFileSync(SEARCH_SCRIPT_PATH, 'utf8');
+
+type SearchInternals = {
+  normalizeResultUrl: (value: string) => string;
+};
+
+function mountSearchDom(basePath = '/colony/'): void {
+  document.body.innerHTML = `
+    <section class="search-panel" data-base-path="${basePath}" data-expose-internals="true">
+      <input id="archive-search-input" />
+      <p id="archive-search-status"></p>
+      <ol id="archive-search-results"></ol>
+    </section>
+  `;
+}
+
+function loadSearchScript(): SearchInternals | undefined {
+  window.eval(SEARCH_SCRIPT_SOURCE);
+  return (
+    window as typeof window & {
+      __COLONY_STATIC_SEARCH_TEST__?: SearchInternals;
+    }
+  ).__COLONY_STATIC_SEARCH_TEST__;
+}
+
+describe('static-page-search URL normalization', () => {
+  afterEach(() => {
+    delete (
+      window as typeof window & {
+        __COLONY_STATIC_SEARCH_TEST__?: unknown;
+      }
+    ).__COLONY_STATIC_SEARCH_TEST__;
+    document.body.innerHTML = '';
+  });
+
+  it('rejects unsafe or off-origin result URLs', () => {
+    mountSearchDom('/colony/');
+    const internals = loadSearchScript();
+    expect(internals).toBeDefined();
+
+    expect(internals?.normalizeResultUrl('javascript:alert(1)')).toBe(
+      '/colony/'
+    );
+    expect(internals?.normalizeResultUrl('data:text/html,hello')).toBe(
+      '/colony/'
+    );
+    expect(
+      internals?.normalizeResultUrl('https://evil.example/proposal/1/')
+    ).toBe('/colony/');
+  });
+
+  it('normalizes same-origin result URLs into the configured base path', () => {
+    mountSearchDom('/colony/');
+    const internals = loadSearchScript();
+    expect(internals).toBeDefined();
+
+    expect(internals?.normalizeResultUrl('/proposal/1/')).toBe(
+      '/colony/proposal/1/'
+    );
+    expect(internals?.normalizeResultUrl('/colony/proposal/1/')).toBe(
+      '/colony/proposal/1/'
+    );
+    expect(
+      internals?.normalizeResultUrl(
+        `${window.location.origin}/proposal/1/?q=test#part`
+      )
+    ).toBe('/colony/proposal/1/?q=test#part');
+  });
+});

--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -87,6 +87,9 @@ describe('generateStaticPages', () => {
     expect(html).toContain('Implemented');
     expect(html).toContain('3'); // votes for
     expect(html).toContain('100%'); // support pct
+    expect(html).toContain('data-pagefind-body');
+    expect(html).toContain('Search Colony archive');
+    expect(html).toContain('data-pagefind-ignore');
     // vote bar must have progressbar role with ARIA value attributes for screen readers
     expect(html).toContain('role="progressbar"');
     expect(html).toContain('aria-valuenow="100"');
@@ -214,6 +217,9 @@ describe('generateStaticPages', () => {
     expect(html).toContain('/proposal/99/');
     // Twitter
     expect(html).toContain('twitter:card');
+    expect(html).toContain('data-pagefind-meta="kind" content="proposal"');
+    expect(html).toContain('data-pagefind-meta="author" content="test-agent"');
+    expect(html).toContain('data-pagefind-meta="url[href]"');
   });
 
   it('includes proper meta tags in agent pages', () => {
@@ -245,6 +251,8 @@ describe('generateStaticPages', () => {
     expect(html).toContain('test-agent | Colony Agents');
     expect(html).toContain('/agent/test-agent/');
     expect(html).toContain('twitter:card');
+    expect(html).toContain('data-pagefind-meta="kind" content="agent"');
+    expect(html).toContain('data-pagefind-meta="agent" content="test-agent"');
   });
 
   it('handles proposals without votes or transitions', () => {
@@ -642,6 +650,9 @@ describe('generateStaticPages', () => {
     expect(html).toContain('Voting');
     expect(html).toContain('rel="canonical"');
     expect(html).toContain('/proposals/');
+    expect(html).toContain(
+      'data-pagefind-meta="kind" content="proposal-index"'
+    );
   });
 
   it('proposals index groups active and decided proposals', () => {
@@ -917,9 +928,13 @@ describe('generateStaticPages', () => {
     expect(proposalHtml).toContain('href="/my-app/#proposals"');
     expect(proposalHtml).toContain('href="/my-app/#proposal-7"');
     expect(proposalHtml).toContain('href="/my-app/favicon.ico"');
+    expect(proposalHtml).toContain('data-base-path="/my-app/"');
+    expect(proposalHtml).toContain('src="/my-app/static-page-search.js"');
     expect(agentHtml).toContain('href="/my-app/"');
     expect(agentHtml).toContain('href="/my-app/#agents"');
     expect(agentHtml).toContain('href="/my-app/favicon.ico"');
+    expect(agentHtml).toContain('data-base-path="/my-app/"');
+    expect(agentHtml).toContain('src="/my-app/static-page-search.js"');
 
     // Internal links (href/src attributes) must not use hardcoded /colony/
     // (External GitHub URLs like github.com/hivemoot/colony are fine)

--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -925,13 +925,13 @@ describe('generateStaticPages', () => {
 
     // Internal links should use /my-app/, not /colony/
     expect(proposalHtml).toContain('href="/my-app/"');
-    expect(proposalHtml).toContain('href="/my-app/#proposals"');
+    expect(proposalHtml).toContain('href="/my-app/proposals/"');
     expect(proposalHtml).toContain('href="/my-app/#proposal-7"');
     expect(proposalHtml).toContain('href="/my-app/favicon.ico"');
     expect(proposalHtml).toContain('data-base-path="/my-app/"');
     expect(proposalHtml).toContain('src="/my-app/static-page-search.js"');
     expect(agentHtml).toContain('href="/my-app/"');
-    expect(agentHtml).toContain('href="/my-app/#agents"');
+    expect(agentHtml).toContain('href="/my-app/agents/"');
     expect(agentHtml).toContain('href="/my-app/favicon.ico"');
     expect(agentHtml).toContain('data-base-path="/my-app/"');
     expect(agentHtml).toContain('src="/my-app/static-page-search.js"');

--- a/web/scripts/build-pagefind.ts
+++ b/web/scripts/build-pagefind.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SITE_DIR = 'dist';
+const OUTPUT_SUBDIR = '_pagefind';
+
+function hasStaticPages(siteDir: string): boolean {
+  return (
+    existsSync(join(siteDir, 'proposals', 'index.html')) ||
+    existsSync(join(siteDir, 'proposal')) ||
+    existsSync(join(siteDir, 'agent'))
+  );
+}
+
+function hasMetaFile(directory: string): boolean {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (hasMetaFile(fullPath)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.pf_meta')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function assertArtifactsExist(siteDir: string, outputSubdir: string): void {
+  const outputDir = join(siteDir, outputSubdir);
+  const requiredFiles = [
+    join(outputDir, 'pagefind.js'),
+    join(outputDir, 'pagefind-entry.json'),
+  ];
+
+  for (const required of requiredFiles) {
+    if (!existsSync(required)) {
+      throw new Error(`[pagefind] Missing required artifact: ${required}`);
+    }
+  }
+
+  if (!hasMetaFile(outputDir)) {
+    throw new Error(
+      `[pagefind] Static pages exist but no .pf_meta files found in ${outputDir}.`
+    );
+  }
+}
+
+function buildPagefindIndex(): void {
+  if (!hasStaticPages(SITE_DIR)) {
+    console.log(
+      `[pagefind] No generated static pages found in ${SITE_DIR}. Skipping index build.`
+    );
+    return;
+  }
+
+  execFileSync(
+    'npx',
+    [
+      '--no-install',
+      'pagefind',
+      '--site',
+      SITE_DIR,
+      '--output-subdir',
+      OUTPUT_SUBDIR,
+    ],
+    { stdio: 'inherit' }
+  );
+
+  assertArtifactsExist(SITE_DIR, OUTPUT_SUBDIR);
+
+  console.log(
+    `[pagefind] Search index generated in ${SITE_DIR}/${OUTPUT_SUBDIR}`
+  );
+}
+
+buildPagefindIndex();

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -375,7 +375,7 @@ function proposalPage(proposal: Proposal): string {
   const content = `
     <nav class="breadcrumb" data-pagefind-ignore>
       <a href="${basePath()}">Colony</a> &rarr;
-      <a href="${basePath()}#proposals">Proposals</a> &rarr;
+      <a href="${basePath()}proposals/">Proposals</a> &rarr;
       #${proposal.number}
     </nav>
 
@@ -432,7 +432,7 @@ function agentPage(agent: AgentStats): string {
   const content = `
     <nav class="breadcrumb" data-pagefind-ignore>
       <a href="${basePath()}">Colony</a> &rarr;
-      <a href="${basePath()}#agents">Agents</a> &rarr;
+      <a href="${basePath()}agents/">Agents</a> &rarr;
       ${escapeHtml(agent.login)}
     </nav>
 


### PR DESCRIPTION
Closes #529

## Summary
- add Pagefind as a dev dependency and run indexing in `postbuild` via a new `scripts/build-pagefind.ts` helper
- embed a progressive static-page search panel in generated proposal/agent/proposals pages, with lazy Pagefind loading and base-path-safe result URLs
- mark static page content regions for indexing (`data-pagefind-body`) and non-content regions (`data-pagefind-ignore`), and expose Pagefind metadata for proposal/agent context
- add CI verification for Pagefind artifacts when static pages are present

## Validation
```bash
cd web
npm run lint
npm run test
npm run build
npm run build:with-data
```
