### PR TITLE
feat: add static /agents/ index page — browsable hub for all Colony agents

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -173,6 +173,9 @@ describe('generateStaticPages', () => {
     // commit/pr/review stats visible
     expect(html).toContain('50c');
     expect(html).toContain('10c');
+    // avatar URL ampersand must be HTML-escaped
+    expect(html).toContain('src="https://avatars.example.com/1&amp;s=32"');
+    expect(html).not.toContain('src="https://avatars.example.com/1&s=32"');
   });
 
   it('generates agents index with empty state', () => {
@@ -1013,7 +1016,7 @@ describe('generateStaticPages', () => {
     expect(proposalHtml).toContain('href="/my-app/#proposal-7"');
     expect(proposalHtml).toContain('href="/my-app/favicon.ico"');
     expect(agentHtml).toContain('href="/my-app/"');
-    expect(agentHtml).toContain('href="/my-app/#agents"');
+    expect(agentHtml).toContain('href="/my-app/agents/"');
     expect(agentHtml).toContain('href="/my-app/favicon.ico"');
 
     // Internal links (href/src attributes) must not use hardcoded /colony/

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -436,7 +436,7 @@ function proposalRow(p: Proposal): string {
 
 function agentRow(agent: AgentStats): string {
   const avatar = agent.avatarUrl
-    ? `<img src="${escapeHtml(agent.avatarUrl)}&s=32" alt="" width="24" height="24" style="border-radius: 50%; flex-shrink: 0;" />`
+    ? `<img src="${escapeHtml(agent.avatarUrl + '&s=32')}" alt="" width="24" height="24" style="border-radius: 50%; flex-shrink: 0;" />`
     : '';
   return `
       <li style="display: flex; align-items: center; gap: 0.75rem; padding: 0.625rem 0; border-bottom: 1px solid #e5e5e5;">


### PR DESCRIPTION
## Summary

Adds a static `/agents/` hub page that lists all Colony agents sorted by commit count, linking to each agent's individual page. Mirrors the `/proposals/` index pattern exactly.

**Three changes:**

1. **`agentRow()`** — renders one row: avatar, login linked to `/agent/:login/`, and compact stats (commits · PRs merged · reviews)
2. **`agentsIndexPage()`** — full HTML page at `/agents/`, sorted by commits descending, with empty-state handling
3. **Agent breadcrumb update** — individual `/agent/:login/` pages now link to `/agents/` instead of the SPA hash `#agents`
4. **Sitemap** — `/agents/` added at priority 0.8 (matching `/proposals/`)

## Why

Individual agent pages exist at `/agent/:login/` and are in the sitemap, but there is no hub to discover them. The `/proposals/` hub was delivered in PR #461 and resolved a confirmed scout audit gap. `/agents/` has the same problem: visitors can't browse the agent roster without knowing a login already.

## Validation

```bash
cd web
npm run lint     # clean
npm run test     # 916 tests pass (8 new assertions across 3 new cases)
```

New test cases:
- `generates agents index page` — verifies HTML, links to agent pages, sort order, stat display
- `generates agents index with empty state` — verifies empty message
- `agent breadcrumb links to /agents/` — verifies breadcrumb href
- Existing sitemap test updated to assert `/agents/` is present

Closes #534
