### PR TITLE
fix: HTML-escape avatar size param in static agent page

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -124,6 +124,9 @@ describe('generateStaticPages', () => {
     expect(html).toContain('50'); // commits
     expect(html).toContain('20'); // PRs merged
     expect(html).toContain('30'); // reviews
+    // Avatar size param must be HTML-escaped: & → &amp; so the src attribute is valid HTML
+    expect(html).toContain('src="https://avatars.example.com/1&amp;s=64"');
+    expect(html).not.toContain('src="https://avatars.example.com/1&s=64"');
   });
 
   it('generates expanded sitemap with all pages', () => {

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -374,7 +374,7 @@ function agentPage(agent: AgentStats): string {
     </nav>
 
     <h1 style="display: flex; align-items: center; gap: 0.75rem;">
-      ${agent.avatarUrl ? `<img src="${escapeHtml(agent.avatarUrl)}&s=64" alt="" width="48" height="48" style="border-radius: 50%;" />` : ''}
+      ${agent.avatarUrl ? `<img src="${escapeHtml(agent.avatarUrl + '&s=64')}" alt="" width="48" height="48" style="border-radius: 50%;" />` : ''}
       ${escapeHtml(agent.login)}
     </h1>
     <div class="meta">


### PR DESCRIPTION
## What

In `agentPage()` in `static-pages.ts`, the avatar `src` attribute was built as:

```html
src="${escapeHtml(agent.avatarUrl)}&s=64"
```

This produces invalid HTML — the `&` in `&s=64` is a raw ampersand in an HTML attribute value and must be `&amp;s=64` per the HTML spec.

The fix passes the full URL (including size param) to `escapeHtml`:

```html
src="${escapeHtml(agent.avatarUrl + '&s=64')}"
```

For a real GitHub avatar URL `https://avatars.githubusercontent.com/u/123?v=4`, the output is now `src="https://avatars.githubusercontent.com/u/123?v=4&amp;s=64"` — valid HTML. Browsers decode `&amp;` back to `&` when resolving the src, so image loading is unchanged.

## Why

HTML validators flag unescaped `&` in attribute values. More importantly, the pattern was inconsistent with the rest of the file where `escapeHtml` is always applied to the complete content being inserted into HTML context, not just part of it.

## Validation

```bash
cd web
npm run lint
npm run test -- scripts/__tests__/static-pages.test.ts
npm run test
```

Added two assertions to the existing `generates agent pages` test:
- `src="https://avatars.example.com/1&amp;s=64"` is present (valid HTML)
- `src="https://avatars.example.com/1&s=64"` is absent (old invalid form)

913 tests pass, lint clean, typecheck clean.

Fixes #554