### PR TITLE
fix: generate robots.txt with deployment-specific sitemap URL

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -1189,4 +1189,52 @@ describe('generateStaticPages', () => {
     // Display name (in text content) still shows the raw login
     expect(html).toContain('hivemoot[bot]');
   });
+
+  it('generates robots.txt with correct default sitemap URL', () => {
+    const data = minimalActivityData();
+    writeFileSync(
+      join(TEST_OUT, 'data', 'activity.json'),
+      JSON.stringify(data)
+    );
+
+    generateStaticPages(TEST_OUT);
+
+    const robotsTxt = readFileSync(join(TEST_OUT, 'robots.txt'), 'utf-8');
+    expect(robotsTxt).toContain('User-agent: *');
+    expect(robotsTxt).toContain('Allow: /');
+    expect(robotsTxt).toContain(
+      'Sitemap: https://hivemoot.github.io/colony/sitemap.xml'
+    );
+  });
+
+  it('generates robots.txt with custom COLONY_DEPLOYED_URL sitemap', async () => {
+    const savedUrl = process.env.COLONY_DEPLOYED_URL;
+    process.env.COLONY_DEPLOYED_URL = 'https://my-org.github.io/my-project';
+    vi.resetModules();
+
+    try {
+      const { generateStaticPages: generate } = await import('../static-pages');
+
+      const data = minimalActivityData();
+      writeFileSync(
+        join(TEST_OUT, 'data', 'activity.json'),
+        JSON.stringify(data)
+      );
+
+      generate(TEST_OUT);
+
+      const robotsTxt = readFileSync(join(TEST_OUT, 'robots.txt'), 'utf-8');
+      expect(robotsTxt).toContain(
+        'Sitemap: https://my-org.github.io/my-project/sitemap.xml'
+      );
+      expect(robotsTxt).not.toContain('hivemoot.github.io');
+    } finally {
+      if (savedUrl === undefined) {
+        delete process.env.COLONY_DEPLOYED_URL;
+      } else {
+        process.env.COLONY_DEPLOYED_URL = savedUrl;
+      }
+      vi.resetModules();
+    }
+  });
 });

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -654,7 +654,13 @@ export function generateStaticPages(outDir: string): void {
   );
   writeFileSync(join(outDir, 'sitemap.xml'), sitemap);
 
+  // Generate robots.txt with deployment-specific sitemap URL so template
+  // deployments (issue #515) point crawlers to the correct sitemap instead
+  // of the hardcoded hivemoot URL in web/public/robots.txt.
+  const robotsTxt = `User-agent: *\nAllow: /\n\nSitemap: ${BASE_URL}/sitemap.xml\n`;
+  writeFileSync(join(outDir, 'robots.txt'), robotsTxt);
+
   console.log(
-    `[static-pages] Generated ${proposalCount} proposal pages, ${agentCount} agent pages, proposals index, agents index, and updated sitemap.xml`
+    `[static-pages] Generated ${proposalCount} proposal pages, ${agentCount} agent pages, proposals index, agents index, sitemap.xml, and robots.txt`
   );
 }


### PR DESCRIPTION
## What

Adds robots.txt generation to `generateStaticPages()` in `static-pages.ts`, parallel to the existing sitemap.xml generation.

**Before:** `web/public/robots.txt` is copied as-is to `dist/` with the hardcoded hivemoot URL:
```
Sitemap: https://hivemoot.github.io/colony/sitemap.xml
```

**After:** `generateStaticPages()` writes `dist/robots.txt` with the URL resolved from `COLONY_DEPLOYED_URL`:
```
Sitemap: https://my-org.github.io/my-project/sitemap.xml
```

For the original hivemoot deployment the output is identical to the static file, so there is no behavior change.

## Why

Template deployments (Horizon 3, issue #515 / PR #521) set `COLONY_DEPLOYED_URL` to their own domain. `sitemap.xml` is already generated dynamically with the correct base URL. `robots.txt` was not — crawlers following its `Sitemap:` directive would land on the hivemoot sitemap instead of the deployer's. This breaks search indexing for any non-hivemoot Colony instance.

The fix is consistent with how `sitemap.xml` already works: both are now written by `generateStaticPages()` using `BASE_URL` (resolved from `COLONY_DEPLOYED_URL` at module load, line 16).

## Validation

```bash
cd web
npm run lint                                          # clean
npm run test -- scripts/__tests__/static-pages.test.ts  # 31 tests pass (+2 new)
```

New tests:
- `generates robots.txt with correct default sitemap URL` — verifies default content matches current static file
- `generates robots.txt with custom COLONY_DEPLOYED_URL sitemap` — verifies robots.txt reflects custom deployment URL and does not contain hivemoot domain

Fixes #539