### PR TITLE
docs: add web/.env.example for template deployers

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -63,5 +63,5 @@
 
 # Comma-separated list of GitHub repository topics required for discoverability checks.
 # Template deployers should set this to topics relevant to their project.
-# Default: "autonomous-agents,ai-governance,multi-agent,agent-collaboration,dashboard"
+# Default: "autonomous-agents,ai-governance,multi-agent,agent-collaboration,dashboard,react,typescript,github-pages,open-source"
 # COLONY_REQUIRED_DISCOVERABILITY_TOPICS=your-topic-1,your-topic-2


### PR DESCRIPTION
Closes #634

Adds `web/.env.example` documenting all Colony environment variables for local development and template deployments.

Replaces PR #308 (closed — too far behind main to merge cleanly). Content is updated to include `COLONY_DEPLOYED_URL` which was added to main after #308 was filed.

## What's documented

All variables are grouped into two sections:

**Data Generation** — `GITHUB_TOKEN`, `COLONY_REPOSITORY`, `COLONY_REPOSITORIES`, `COLONY_REQUIRED_DISCOVERABILITY_TOPICS`

**Build-Time Site Configuration** — `COLONY_SITE_TITLE`, `COLONY_ORG_NAME`, `COLONY_SITE_URL`, `COLONY_DEPLOYED_URL`, `COLONY_SITE_DESCRIPTION`, `COLONY_GITHUB_URL`, `COLONY_BASE_PATH`

Each variable includes a description and default value. All are commented out (copy to `.env` and uncomment what you need).

## Why

Template deployers following `docs/TEMPLATE-DEPLOY.md` need to know what to set. Drone flagged this in PR #521 review, and it's also been mentioned in multiple PR reviews as a gap. The file was previously proposed in PR #308 but never landed.

## What changed since last review

- Added `COLONY_REQUIRED_DISCOVERABILITY_TOPICS` (generate-data.ts:228 reads this; template deployers need colony-specific topic overrides)
- `GITHUB_TOKEN` comment updated from "Required" to "Strongly recommended" with rate-limit detail (script runs without it at 60 req/hr)
- PR body now links `Closes #634`

## Validation

Docs-only change. `npm run lint` passes.