### PR TITLE
fix: proposal breadcrumb links to /proposals/ static hub

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -92,6 +92,9 @@ describe('generateStaticPages', () => {
     expect(html).toContain('aria-valuenow="100"');
     expect(html).toContain('aria-valuemin="0"');
     expect(html).toContain('aria-valuemax="100"');
+    // breadcrumb links to /proposals/ hub, not the SPA hash
+    expect(html).toContain('href="/colony/proposals/"');
+    expect(html).toContain('>Proposals<');
   });
 
   it('generates agent pages', () => {
@@ -914,7 +917,7 @@ describe('generateStaticPages', () => {
 
     // Internal links should use /my-app/, not /colony/
     expect(proposalHtml).toContain('href="/my-app/"');
-    expect(proposalHtml).toContain('href="/my-app/#proposals"');
+    expect(proposalHtml).toContain('href="/my-app/proposals/"');
     expect(proposalHtml).toContain('href="/my-app/#proposal-7"');
     expect(proposalHtml).toContain('href="/my-app/favicon.ico"');
     expect(agentHtml).toContain('href="/my-app/"');

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -319,7 +319,7 @@ function proposalPage(proposal: Proposal): string {
   const content = `
     <nav class="breadcrumb">
       <a href="${basePath()}">Colony</a> &rarr;
-      <a href="${basePath()}#proposals">Proposals</a> &rarr;
+      <a href="${basePath()}proposals/">Proposals</a> &rarr;
       #${proposal.number}
     </nav>
 


### PR DESCRIPTION
The individual proposal page breadcrumb linked to the SPA hash (`#proposals`) instead of the static `/proposals/` hub that already exists and is indexed in the sitemap.

This mirrors the same fix PR #535 applies to the agent page breadcrumb (`#agents` → `/agents/`). The `/proposals/` static hub has been live since PR #461. The breadcrumb should link there so static-page visitors can navigate to the hub without JavaScript.

## Changes

- `static-pages.ts`: `${basePath()}#proposals` → `${basePath()}proposals/` in proposal page breadcrumb
- Test: adds assertion pinning `href="/colony/proposals/"` in the breadcrumb
- Test: updates the custom base-path test which asserted the old `#proposals` value

## Validation

```
cd web
npm run lint     # clean
npm run test     # 913 tests pass (2 new/updated assertions)
```

Fixes #548