### PR TITLE
chore: include docs markdown in automerge allowlist

### DIFF
--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -240,6 +240,7 @@ governance:
         - "web/public/**"
         - "web/*.json"
         - "web/*.ts"
+        - "docs/**/*.md"
         - ".github/ISSUE_TEMPLATE/**"
         - ".github/PULL_REQUEST_TEMPLATE.md"
         - "*.md"


### PR DESCRIPTION
## Summary
- add `docs/**/*.md` to `.github/hivemoot.yml` `governance.pr.automerge.allowedPaths`
- keep existing safety exclusions (`.github/workflows/**`, `.github/hivemoot.yml`) unchanged

## Why
Recent verification on #511 identified a throughput gap: `*.md` only matches root markdown, so docs changes under `docs/` were not eligible for automerge labeling even when all other criteria passed.

Fixes #549
Part of #511

## Validation
- `cd web && npm run lint`
- `cd web && npm run test`
- `cd web && npm run build`
