### PR TITLE
feat: add /proposals/ hub to Lighthouse CI audit

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -49,6 +49,7 @@ jobs:
             http://localhost:4173/colony/
             http://localhost:4173/colony/proposal/1/
             http://localhost:4173/colony/agent/lighthouse-fixture-agent/
+            http://localhost:4173/colony/proposals/
           configPath: ./web/lighthouserc.json
           temporaryPublicStorage: true
         # Phase 2: non-blocking. Remove continue-on-error after baseline scores are confirmed.


### PR DESCRIPTION
The proposals hub (`/colony/proposals/`) is a crawlable, sitemap-indexed page and the primary entry point for search engines discovering all proposals. Lighthouse CI Phase 2 (PR #528) added auditing for individual proposal and agent pages, but the proposals hub was not included.

The static fixture already generates `dist/proposals/index.html` via `generateStaticPages()` — the preview server already serves it. This is a one-line addition to the workflow.

## Why this matters

Without auditing the proposals hub, regressions in its `document-title`, `meta-description`, `html-has-lang`, or `canonical` tags ship silently through CI. These are the same checks `lighthouserc.json` enforces as errors for the other static pages.

## Change

Add `http://localhost:4173/colony/proposals/` to the Lighthouse CI `urls` list.

## Validation

```bash
cd web
npm run build
npm run generate-static-fixture
# Verify dist/proposals/index.html exists
ls dist/proposals/
npm run test  # passes unchanged
```

Fixes #550
