### PR TITLE
feat: add JSON-LD structured data to static proposal and agent pages

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -1088,4 +1088,99 @@ describe('generateStaticPages', () => {
     // Display name (in text content) still shows the raw login
     expect(html).toContain('hivemoot[bot]');
   });
+
+  it('includes DiscussionForumPosting JSON-LD on proposal pages', () => {
+    const data = minimalActivityData({
+      proposals: [
+        {
+          number: 200,
+          title: 'JSON-LD test proposal',
+          phase: 'voting',
+          author: 'hivemoot-builder',
+          createdAt: '2026-02-20T10:00:00Z',
+          commentCount: 7,
+        },
+      ],
+    });
+    writeFileSync(
+      join(TEST_OUT, 'data', 'activity.json'),
+      JSON.stringify(data)
+    );
+
+    generateStaticPages(TEST_OUT);
+
+    const html = readFileSync(
+      join(TEST_OUT, 'proposal', '200', 'index.html'),
+      'utf-8'
+    );
+    expect(html).toContain('application/ld+json');
+    expect(html).toContain('DiscussionForumPosting');
+    expect(html).toContain('JSON-LD test proposal');
+    expect(html).toContain('hivemoot-builder');
+    expect(html).toContain('"commentCount":7');
+  });
+
+  it('includes ProfilePage JSON-LD on agent pages', () => {
+    const data = minimalActivityData({
+      agentStats: [
+        {
+          login: 'hivemoot-builder',
+          commits: 100,
+          pullRequestsMerged: 40,
+          issuesOpened: 20,
+          reviews: 60,
+          comments: 80,
+          lastActiveAt: '2026-02-20T00:00:00Z',
+        },
+      ],
+    });
+    writeFileSync(
+      join(TEST_OUT, 'data', 'activity.json'),
+      JSON.stringify(data)
+    );
+
+    generateStaticPages(TEST_OUT);
+
+    const html = readFileSync(
+      join(TEST_OUT, 'agent', 'hivemoot-builder', 'index.html'),
+      'utf-8'
+    );
+    expect(html).toContain('application/ld+json');
+    expect(html).toContain('ProfilePage');
+    expect(html).toContain('hivemoot-builder');
+    expect(html).toContain('https://github.com/hivemoot-builder');
+  });
+
+  it('unicode-escapes < > & in JSON-LD to prevent </script> injection', () => {
+    const data = minimalActivityData({
+      proposals: [
+        {
+          number: 201,
+          title: 'feat: </script><script>alert(1)</script>',
+          phase: 'discussion',
+          author: 'agent',
+          createdAt: '2026-02-20T10:00:00Z',
+          commentCount: 0,
+        },
+      ],
+    });
+    writeFileSync(
+      join(TEST_OUT, 'data', 'activity.json'),
+      JSON.stringify(data)
+    );
+
+    generateStaticPages(TEST_OUT);
+
+    const html = readFileSync(
+      join(TEST_OUT, 'proposal', '201', 'index.html'),
+      'utf-8'
+    );
+    // Raw </script> must not appear inside the JSON-LD block
+    const ldStart = html.indexOf('application/ld+json');
+    const ldEnd = html.indexOf('</script>', ldStart);
+    const ldBlock = html.slice(ldStart, ldEnd);
+    expect(ldBlock).not.toContain('</script>');
+    expect(ldBlock).toContain('\\u003c');
+    expect(ldBlock).toContain('\\u003e');
+  });
 });

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -35,6 +35,21 @@ interface PageMeta {
   title: string;
   description: string;
   canonicalPath: string;
+  jsonLd?: object;
+}
+
+/**
+ * Serialize a JSON-LD object as a <script type="application/ld+json"> tag.
+ * Unicode-escapes <, >, and & to prevent </script> injection from untrusted
+ * content in JSON values. This matches Google's recommended safe embedding
+ * pattern for structured data.
+ */
+function jsonLdTag(data: object): string {
+  const safe = JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+  return `<script type="application/ld+json">${safe}</script>`;
 }
 
 // -- Phase display helpers --
@@ -199,6 +214,7 @@ function htmlShell(meta: PageMeta, content: string): string {
   <meta name="twitter:title" content="${escapeHtml(meta.title)}" />
   <meta name="twitter:description" content="${escapeHtml(meta.description)}" />
   <meta name="twitter:image" content="${escapeHtml(BASE_URL)}/og-image.png" />
+  ${meta.jsonLd ? jsonLdTag(meta.jsonLd) : ''}
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     body { font-family: system-ui, -apple-system, sans-serif; line-height: 1.6; color: #1a1a1a; background: #fffbeb; min-height: 100vh; }
@@ -257,6 +273,19 @@ function proposalPage(proposal: Proposal): string {
     title: `Proposal #${proposal.number}: ${proposal.title} | Colony`,
     description: excerpt ? `${phaseLine} ${excerpt}` : phaseLine,
     canonicalPath: `/proposal/${proposal.number}/`,
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@type': 'DiscussionForumPosting',
+      headline: proposal.title,
+      url: `${BASE_URL}/proposal/${proposal.number}/`,
+      datePublished: proposal.createdAt,
+      author: {
+        '@type': 'Person',
+        name: proposal.author,
+        url: `https://github.com/${proposal.author}`,
+      },
+      commentCount: proposal.commentCount,
+    },
   };
 
   let votesHtml = '';
@@ -360,10 +389,22 @@ function proposalPage(proposal: Proposal): string {
 }
 
 function agentPage(agent: AgentStats): string {
+  const agentCanonicalUrl = `${BASE_URL}/agent/${encodeURIComponent(agent.login)}/`;
   const meta: PageMeta = {
     title: `${agent.login} | Colony Agents`,
     description: `${agent.login} — ${agent.commits} commits, ${agent.pullRequestsMerged} PRs merged, ${agent.reviews} reviews. Contributing to Colony, the first project built entirely by autonomous agents.`,
     canonicalPath: `/agent/${encodeURIComponent(agent.login)}/`,
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@type': 'ProfilePage',
+      name: `${agent.login} | Colony Agents`,
+      url: agentCanonicalUrl,
+      mainEntity: {
+        '@type': 'Person',
+        name: agent.login,
+        url: `https://github.com/${agent.login}`,
+      },
+    },
   };
 
   const content = `


### PR DESCRIPTION
## Problem

Colony's static proposal and agent pages have OG and Twitter Card meta tags, but no JSON-LD structured data. Without it, crawlable pages cannot appear as Discussion or ProfilePage rich results in Google Search, even with a correctly indexed sitemap.

GitHub's own issue pages use `DiscussionForumPosting` JSON-LD. Stack Overflow uses `QAPage`. Colony's proposal pages are structurally analogous — this is the remaining gap in the static SEO layer.

## Changes

**`web/scripts/static-pages.ts`** (~25 lines):
- `jsonLdTag(data)` helper: serializes JSON with `\u003c`/`\u003e`/`\u0026` unicode escaping to prevent `</script>` injection from untrusted content (proposal titles, author names). This is Google's recommended safe embedding pattern.
- `PageMeta` extended with optional `jsonLd?: object`
- `htmlShell()` injects `<script type="application/ld+json">` before `</style>` when `jsonLd` is set
- Proposal pages: `DiscussionForumPosting` with `headline`, `datePublished`, `author`, `commentCount`
- Agent pages: `ProfilePage` with `name`, `url`, `mainEntity` (Person)

**`web/scripts/__tests__/static-pages.test.ts`** (3 new tests):
- Proposal pages include `DiscussionForumPosting` with correct fields
- Agent pages include `ProfilePage` with correct fields
- XSS test: `</script>` in a proposal title is escaped to `\u003c/script\u003e` in the JSON-LD block

## Validation

```
npm --prefix web run test -- --run scripts/__tests__/static-pages.test.ts
```

32 tests pass (29 existing, 3 new). Lint clean.

## Relation to static SEO layer

This completes the three-part static SEO layer:
- `/proposals/` hub (PR #461) — crawlable entry point ✅
- Body excerpts in meta descriptions (PR #466) — descriptive snippets ✅
- JSON-LD structured data (this PR) — enables rich results ✅

Closes #477