### PR TITLE
fix: add deployed static hub visibility checks

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -4,6 +4,7 @@ import {
   hasTwitterImageAltText,
   isValidOpenGraphImageType,
   normalizeHttpsUrl,
+  resolveDeployedPageUrl,
   resolveRepositoryHomepage,
   resolveVisibilityRepository,
   resolveVisibilityUserAgent,
@@ -135,6 +136,26 @@ describe('buildRepositoryApiUrl', () => {
         repo: 'example-colony',
       })
     ).toBe('https://api.github.com/repos/example-org/example-colony');
+  });
+});
+
+describe('resolveDeployedPageUrl', () => {
+  it('resolves hub URLs from a root deployment base', () => {
+    expect(resolveDeployedPageUrl('https://example.org', 'agents/')).toBe(
+      'https://example.org/agents/'
+    );
+    expect(resolveDeployedPageUrl('https://example.org/', '/proposals/')).toBe(
+      'https://example.org/proposals/'
+    );
+  });
+
+  it('preserves nested base paths used by template deployments', () => {
+    expect(
+      resolveDeployedPageUrl('https://example.org/my-colony', 'agents/')
+    ).toBe('https://example.org/my-colony/agents/');
+    expect(
+      resolveDeployedPageUrl('https://example.org/my-colony/', '/proposals/')
+    ).toBe('https://example.org/my-colony/proposals/');
   });
 });
 

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -102,6 +102,15 @@ function getAbsoluteHttpsUrl(rawValue: string): string {
   return normalizeHttpsUrl(rawValue);
 }
 
+export function resolveDeployedPageUrl(
+  baseUrl: string,
+  pagePath: string
+): string {
+  const normalizedBase = `${baseUrl.replace(/\/+$/, '')}/`;
+  const normalizedPath = pagePath.replace(/^\/+/, '');
+  return new URL(normalizedPath, normalizedBase).toString();
+}
+
 export function isValidOpenGraphImageType(rawValue: string): boolean {
   const value = rawValue.trim().toLowerCase();
   return value.startsWith('image/');
@@ -324,6 +333,29 @@ async function runChecks(): Promise<CheckResult[]> {
     label: 'Deployed site is reachable',
     ok: rootRes?.status === 200,
   });
+
+  const deployedHubChecks = await Promise.all(
+    [
+      { label: 'Deployed /agents/ hub is reachable', path: 'agents/' },
+      {
+        label: 'Deployed /proposals/ hub is reachable',
+        path: 'proposals/',
+      },
+    ].map(async ({ label, path }) => {
+      const url = resolveDeployedPageUrl(baseUrl, path);
+      const response = await fetchWithTimeout(url);
+      const ok = response?.status === 200;
+      return {
+        label,
+        ok,
+        details: ok
+          ? `GET ${url} returned 200`
+          : `GET ${url} returned ${response?.status ?? 'no response'}`,
+      };
+    })
+  );
+
+  results.push(...deployedHubChecks);
 
   let deployedRootHtml = '';
   let deployedJsonLd = false;


### PR DESCRIPTION
## Summary
- add explicit deployed static-hub reachability checks for `/agents/` and `/proposals/` in `check-visibility.ts`
- include per-check HTTP status details to make failures actionable in CI output
- add unit tests for `resolveDeployedPageUrl` to cover root and nested base-path deployments

## Validation
- `cd web && npm run test -- scripts/__tests__/check-visibility.test.ts`
- `cd web && npm run check-visibility`

Fixes #544
