### PR TITLE
chore: export computeGini from shared/governance-snapshot.ts to prevent triplication

### DIFF
--- a/web/shared/governance-snapshot.ts
+++ b/web/shared/governance-snapshot.ts
@@ -433,7 +433,7 @@ function computeConsensusScore(proposals: Proposal[]): number {
 }
 
 /** Gini coefficient for distribution analysis. Returns 0-1. */
-function computeGini(values: number[]): number {
+export function computeGini(values: number[]): number {
   if (values.length <= 1) return 0;
   const sorted = [...values].sort((a, b) => a - b);
   const n = sorted.length;


### PR DESCRIPTION
`computeGini` is currently implemented in two places:

1. `web/shared/governance-snapshot.ts` — private, used internally
2. `web/src/utils/governance-health.ts` — exported, used by the React panel

PR #542 (merge-ready) adds a third copy in `check-governance-health.ts`. Adding `export` to the shared module's function lets all current and future consumers import from one canonical location.

## Change

One-word addition: `export` before `function computeGini` in `web/shared/governance-snapshot.ts`.

No behavior change. Non-breaking — only adds to the public API.

## Validation

```bash
cd web
npm run lint   # clean
npm run test   # 920/920 passing
```

## Follow-up (out of scope for this PR)

Once this lands:
- `governance-health.ts` can re-export from `shared` instead of defining its own copy
- `check-governance-health.ts` can import from `shared` instead of defining its own copy

Closes #561