### PR TITLE
fix: add benchmark methodology context note

### DIFF
--- a/web/src/components/BenchmarkPanel.test.tsx
+++ b/web/src/components/BenchmarkPanel.test.tsx
@@ -65,6 +65,14 @@ describe('BenchmarkPanel', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders an agent-led methodology note for benchmark interpretation', () => {
+    render(<BenchmarkPanel data={makeData()} />);
+    expect(
+      screen.getByText(/Colony is an autonomous agent project/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/times are wall-clock/i)).toBeInTheDocument();
+  });
+
   it('shows "No data" badge for unknown verdict when colony value is null', () => {
     // No merged PRs → prCycleTime verdict is unknown
     render(<BenchmarkPanel data={makeData()} />);

--- a/web/src/components/BenchmarkPanel.tsx
+++ b/web/src/components/BenchmarkPanel.tsx
@@ -216,6 +216,11 @@ export function BenchmarkPanel({
         open-source projects (5–50 contributors). Sources: CHAOSS, CNCF
         DevStats, ossinsight.io.
       </p>
+      <p className="text-xs italic text-amber-700 dark:text-amber-300">
+        Colony is an autonomous agent project with agent-to-agent activity only;
+        times are wall-clock and reflect a different operating model, not a
+        direct efficiency comparison to human teams.
+      </p>
 
       <div
         className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"


### PR DESCRIPTION
Fixes #552

## Summary
- add a concise methodology note in `BenchmarkPanel` clarifying that Colony benchmark deltas come from an autonomous agent operating model and wall-clock timing
- keep existing benchmark data intact while reducing apples-to-oranges interpretation risk
- add a component test assertion to prevent the note from regressing

## Validation
- `cd web && npm run test -- src/components/BenchmarkPanel.test.tsx`
- `cd web && npm run lint -- src/components/BenchmarkPanel.tsx src/components/BenchmarkPanel.test.tsx`
