### PR TITLE
chore: add --json output mode to check-visibility.ts

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -8,6 +8,8 @@ import {
   resolveRepositoryHomepage,
   resolveVisibilityRepository,
   resolveVisibilityUserAgent,
+  type CheckResult,
+  type VisibilityReport,
 } from '../check-visibility';
 
 describe('resolveVisibilityUserAgent', () => {
@@ -178,5 +180,34 @@ describe('hasTwitterImageAltText', () => {
 
   it('rejects blank alt text', () => {
     expect(hasTwitterImageAltText('   ')).toBe(false);
+  });
+});
+
+describe('VisibilityReport', () => {
+  it('has the expected shape with summary and checks fields', () => {
+    const checks: CheckResult[] = [
+      { label: 'Index HTML exists', ok: true },
+      { label: 'Sitemap present', ok: false, details: 'sitemap.xml not found' },
+    ];
+
+    const report: VisibilityReport = {
+      generatedAt: '2026-03-05T00:00:00.000Z',
+      summary: {
+        total: checks.length,
+        passed: checks.filter((c) => c.ok).length,
+        failed: checks.filter((c) => !c.ok).length,
+      },
+      checks,
+    };
+
+    expect(report.summary.total).toBe(2);
+    expect(report.summary.passed).toBe(1);
+    expect(report.summary.failed).toBe(1);
+    expect(report.checks[0]).toEqual({ label: 'Index HTML exists', ok: true });
+    expect(report.checks[1]).toMatchObject({
+      label: 'Sitemap present',
+      ok: false,
+      details: 'sitemap.xml not found',
+    });
   });
 });

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -18,10 +18,28 @@ const SITEMAP_PATH = join(ROOT_DIR, 'public', 'sitemap.xml');
 const ROBOTS_PATH = join(ROOT_DIR, 'public', 'robots.txt');
 const DEFAULT_VISIBILITY_USER_AGENT = 'colony-visibility-check';
 
-interface CheckResult {
+export interface CheckResult {
   label: string;
   ok: boolean;
   details?: string;
+}
+
+export interface VisibilityReport {
+  generatedAt: string;
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+  };
+  checks: CheckResult[];
+}
+
+interface CliOptions {
+  json: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  return { json: argv.includes('--json') };
 }
 
 export function resolveVisibilityUserAgent(
@@ -707,8 +725,24 @@ async function runChecks(): Promise<CheckResult[]> {
 }
 
 async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
   const results = await runChecks();
   const failed = results.filter((result) => !result.ok);
+
+  if (options.json) {
+    const report: VisibilityReport = {
+      generatedAt: new Date().toISOString(),
+      summary: {
+        total: results.length,
+        passed: results.length - failed.length,
+        failed: failed.length,
+      },
+      checks: results,
+    };
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(0);
+    return;
+  }
 
   console.log('External visibility checks');
   for (const result of results) {


### PR DESCRIPTION
## Problem

`check-visibility.ts` is the only CLI script in `scripts/` without `--json` output. Every other script supports it:

| Script | `--json` |
|---|---|
| `external-outreach-metrics.ts` | ✅ |
| `fast-track-candidates.ts` | ✅ |
| `replay-governance.ts` | ✅ |
| `check-benchmarks.ts` | ✅ (PR #566) |
| `check-governance-health.ts` | ✅ (PR #542) |
| `check-visibility.ts` | ❌ → **fixed here** |

The scout audit invokes `npm run check-visibility -- --json` but the flag was silently ignored — the script always emitted human-readable text, requiring the scout to infer check counts from text parsing.

## Changes

**`web/scripts/check-visibility.ts`**:
- Export `CheckResult` and new `VisibilityReport` interfaces
- Add `CliOptions` interface and `parseArgs()` (handles `--json` flag)
- `main()` emits `JSON.stringify(VisibilityReport, null, 2)` when `--json` is passed; human-readable output is unchanged otherwise

**`web/scripts/__tests__/check-visibility.test.ts`**:
- Import `CheckResult` and `VisibilityReport` types
- Add `VisibilityReport` shape test (summary counts, checks array)

## Validation

```bash
cd web
npm run lint -- scripts/check-visibility.ts scripts/__tests__/check-visibility.test.ts  # clean
npm run typecheck  # clean
npm run test -- --run scripts/__tests__/check-visibility.test.ts  # 22/22 passed
npm run test  # 921/921 passed
```

Fixes #567