### PR TITLE
fix: scope fast-track issue-URL parsing to github.com hosts only

### DIFF
--- a/web/scripts/__tests__/fast-track-candidates.test.ts
+++ b/web/scripts/__tests__/fast-track-candidates.test.ts
@@ -334,4 +334,34 @@ describe('evaluateEligibility', () => {
       'must reference at least one OPEN linked issue'
     );
   });
+
+  it('ignores non-github issue URL hosts and falls back to default repo', () => {
+    const result = evaluateEligibility(
+      {
+        number: 108,
+        title: 'fix: ignore non-github linked issue URLs',
+        url: 'https://example.test/pr/108',
+        latestReviews: [
+          { state: 'APPROVED', author: { login: 'hivemoot-scout' } },
+          { state: 'APPROVED', author: { login: 'hivemoot-builder' } },
+        ],
+        statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
+        closingIssuesReferences: [
+          {
+            number: 556,
+            state: 'OPEN',
+            url: 'https://malicious.example/hivemoot/hivemoot/issues/556',
+          },
+        ],
+      },
+      new Map([
+        ['hivemoot/colony#556', 'OPEN'],
+        ['hivemoot/hivemoot#556', 'CLOSED'],
+      ]),
+      'hivemoot/colony'
+    );
+
+    expect(result.eligible).toBe(true);
+    expect(result.reasons).toHaveLength(0);
+  });
 });

--- a/web/scripts/fast-track-candidates.ts
+++ b/web/scripts/fast-track-candidates.ts
@@ -343,6 +343,9 @@ function parseIssueRefFromUrl(
 
   try {
     const parsed = new URL(url);
+    if (parsed.hostname.toLowerCase() !== 'github.com') {
+      return null;
+    }
     const pathParts = parsed.pathname.split('/');
     const owner = pathParts[1];
     const repo = pathParts[2];


### PR DESCRIPTION
## Summary
- reject non-`github.com` hosts in `parseIssueRefFromUrl` when deriving linked issue repo keys
- preserve existing behavior for valid GitHub issue URLs
- add regression test proving external host lookalikes are ignored and default-repo scoping is used

Fixes #556

## Validation
- `cd web && npm run test -- fast-track-candidates`
- `cd web && npm run lint`
- `cd web && npm run fast-track-candidates -- --limit=5 --json`
