### PR TITLE
feat: governance health Phase 2 — metrics artifact + StructuralHealthPanel

### DIFF
--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -20,6 +20,7 @@ import {
   deduplicateAgents,
   extractPhaseTransitions,
   filterAndMapProposals,
+  computeGovernanceHealthMetrics,
   type GitHubCommit,
   type GitHubEvent,
   type GitHubTimelineEvent,
@@ -2267,5 +2268,186 @@ describe('extractPhaseTransitions with hivemoot:* labels', () => {
       { phase: 'voting', enteredAt: '2026-01-02T00:00:00Z' },
       { phase: 'implemented', enteredAt: '2026-01-03T00:00:00Z' },
     ]);
+  });
+});
+
+describe('computeGovernanceHealthMetrics', () => {
+  function makeActivityData(
+    overrides: Partial<import('../../shared/types').ActivityData> = {}
+  ): import('../../shared/types').ActivityData {
+    return {
+      generatedAt: '2026-03-05T00:00:00Z',
+      repository: {
+        owner: 'hivemoot',
+        name: 'colony',
+        url: 'https://github.com/hivemoot/colony',
+        stars: 1,
+        forks: 0,
+        openIssues: 0,
+      },
+      agents: [],
+      agentStats: [],
+      commits: [],
+      issues: [],
+      pullRequests: [],
+      comments: [],
+      proposals: [],
+      ...overrides,
+    };
+  }
+
+  it('returns zero/empty metrics for an empty dataset', () => {
+    const result = computeGovernanceHealthMetrics(
+      makeActivityData(),
+      '2026-03-05T00:00:00Z'
+    );
+    expect(result.computedAt).toBe('2026-03-05T00:00:00Z');
+    expect(result.mergedPrsSampled).toBe(0);
+    expect(result.metrics.prCycleTime.sampleSize).toBe(0);
+    expect(result.metrics.roleDiversity.sampleSize).toBe(0);
+    expect(result.metrics.contestedDecisionRate.totalVoted).toBe(0);
+    expect(result.metrics.crossAgentReviewRate.totalReviews).toBe(0);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('computes PR cycle time from merged PRs', () => {
+    const data = makeActivityData({
+      pullRequests: [
+        {
+          number: 1,
+          title: 'PR 1',
+          state: 'merged',
+          author: 'agent-a',
+          createdAt: '2026-01-01T00:00:00Z',
+          mergedAt: '2026-01-03T00:00:00Z', // 2 days
+        },
+        {
+          number: 2,
+          title: 'PR 2',
+          state: 'merged',
+          author: 'agent-b',
+          createdAt: '2026-01-05T00:00:00Z',
+          mergedAt: '2026-01-06T00:00:00Z', // 1 day
+        },
+        {
+          number: 3,
+          title: 'Open PR',
+          state: 'open',
+          author: 'agent-a',
+          createdAt: '2026-01-10T00:00:00Z',
+        },
+      ],
+    });
+    const result = computeGovernanceHealthMetrics(data, '2026-03-05T00:00:00Z');
+    expect(result.mergedPrsSampled).toBe(2);
+    expect(result.metrics.prCycleTime.sampleSize).toBe(2);
+    // p50 of [1, 2] = 1.5
+    expect(result.metrics.prCycleTime.p50Days).toBe(1.5);
+  });
+
+  it('computes Gini coefficient for role diversity', () => {
+    const data = makeActivityData({
+      agentStats: [
+        {
+          login: 'agent-a',
+          commits: 10,
+          pullRequestsMerged: 5,
+          issuesOpened: 2,
+          reviews: 3,
+          comments: 1,
+          lastActiveAt: '2026-03-01T00:00:00Z',
+        },
+        {
+          login: 'agent-b',
+          commits: 10,
+          pullRequestsMerged: 5,
+          issuesOpened: 2,
+          reviews: 3,
+          comments: 1,
+          lastActiveAt: '2026-03-01T00:00:00Z',
+        },
+      ],
+    });
+    const result = computeGovernanceHealthMetrics(data, '2026-03-05T00:00:00Z');
+    // Equal contributions → Gini = 0
+    expect(result.metrics.roleDiversity.gini).toBe(0);
+    expect(result.metrics.roleDiversity.sampleSize).toBe(2);
+  });
+
+  it('computes contested decision rate from proposals with votes', () => {
+    const data = makeActivityData({
+      proposals: [
+        {
+          number: 1,
+          title: 'P1',
+          phase: 'implemented',
+          author: 'agent-a',
+          createdAt: '2026-01-01T00:00:00Z',
+          commentCount: 0,
+          votesSummary: { thumbsUp: 5, thumbsDown: 1 }, // contested
+        },
+        {
+          number: 2,
+          title: 'P2',
+          phase: 'implemented',
+          author: 'agent-b',
+          createdAt: '2026-01-02T00:00:00Z',
+          commentCount: 0,
+          votesSummary: { thumbsUp: 4, thumbsDown: 0 }, // not contested
+        },
+        {
+          number: 3,
+          title: 'P3',
+          phase: 'discussion',
+          author: 'agent-a',
+          createdAt: '2026-01-03T00:00:00Z',
+          commentCount: 0,
+          // no votesSummary — not counted
+        },
+      ],
+    });
+    const result = computeGovernanceHealthMetrics(data, '2026-03-05T00:00:00Z');
+    expect(result.metrics.contestedDecisionRate.totalVoted).toBe(2);
+    expect(result.metrics.contestedDecisionRate.contestedCount).toBe(1);
+    expect(result.metrics.contestedDecisionRate.rate).toBe(0.5);
+  });
+
+  it('computes cross-agent review rate', () => {
+    const data = makeActivityData({
+      pullRequests: [
+        {
+          number: 10,
+          title: 'PR',
+          state: 'merged',
+          author: 'agent-a',
+          createdAt: '2026-01-01T00:00:00Z',
+          mergedAt: '2026-01-02T00:00:00Z',
+        },
+      ],
+      comments: [
+        {
+          id: 1,
+          issueOrPrNumber: 10,
+          type: 'review',
+          author: 'agent-b', // different agent → cross-agent
+          body: 'LGTM',
+          createdAt: '2026-01-01T12:00:00Z',
+          url: 'https://example.com/1',
+        },
+        {
+          id: 2,
+          issueOrPrNumber: 10,
+          type: 'review',
+          author: 'agent-a', // same agent → self-review, not cross-agent
+          body: 'Updating',
+          createdAt: '2026-01-01T13:00:00Z',
+          url: 'https://example.com/2',
+        },
+      ],
+    });
+    const result = computeGovernanceHealthMetrics(data, '2026-03-05T00:00:00Z');
+    expect(result.metrics.crossAgentReviewRate.totalReviews).toBe(2);
+    expect(result.metrics.crossAgentReviewRate.crossAgentCount).toBe(1);
+    expect(result.metrics.crossAgentReviewRate.rate).toBe(0.5);
   });
 });

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -48,12 +48,14 @@ import {
 import { computeGovernanceHistoryIntegrity } from './governance-history-integrity';
 import { evaluateGeneratedAtFreshness } from './freshness';
 import { DEFAULT_DEPLOYED_BASE_URL } from './colony-config';
+import type { GovernanceHealthMetrics } from '../shared/governance-health-metrics.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..', '..');
 const OUTPUT_DIR = join(__dirname, '..', 'public', 'data');
 const OUTPUT_FILE = join(OUTPUT_DIR, 'activity.json');
 const HISTORY_FILE = join(OUTPUT_DIR, 'governance-history.json');
+const HEALTH_METRICS_FILE = join(OUTPUT_DIR, 'governance-health-metrics.json');
 const ROADMAP_PATH = join(ROOT_DIR, 'ROADMAP.md');
 const INDEX_HTML_PATH = join(ROOT_DIR, 'web', 'index.html');
 const SITEMAP_PATH = join(ROOT_DIR, 'web', 'public', 'sitemap.xml');
@@ -2011,6 +2013,164 @@ function toRepoTag(repo: { owner: string; name: string }): string {
   return `${repo.owner}/${repo.name}`;
 }
 
+// ---------------------------------------------------------------------------
+// Governance Health Metrics (CHAOSS-aligned, computed from ActivityData)
+// ---------------------------------------------------------------------------
+
+/** Gini coefficient for a distribution. Returns 0–1 (0 = equal, 1 = monopoly). */
+function computeGiniCoefficient(values: number[]): number {
+  if (values.length <= 1) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const sum = sorted.reduce((acc, v) => acc + v, 0);
+  if (sum === 0) return 0;
+  let numerator = 0;
+  for (let i = 0; i < n; i++) {
+    numerator += (2 * (i + 1) - n - 1) * sorted[i];
+  }
+  return numerator / (n * sum);
+}
+
+/**
+ * Linear-interpolation percentile for an already-sorted numeric array.
+ * Returns 0 if the array is empty.
+ */
+function computePercentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const idx = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+
+/** Compute all four CHAOSS-aligned governance health metrics from ActivityData. */
+export function computeGovernanceHealthMetrics(
+  data: ActivityData,
+  computedAt: string
+): GovernanceHealthMetrics {
+  const warnings: string[] = [];
+
+  // 1. PR Cycle Time (p50 / p95) — time from PR open to merge, in days
+  const mergedPrs = data.pullRequests.filter(
+    (pr) => pr.state === 'merged' && pr.mergedAt
+  );
+  const cycleTimes = mergedPrs
+    .map(
+      (pr) =>
+        (new Date(pr.mergedAt ?? '').getTime() -
+          new Date(pr.createdAt).getTime()) /
+        86_400_000
+    )
+    .filter((d) => d >= 0)
+    .sort((a, b) => a - b);
+
+  if (cycleTimes.length < 5) {
+    warnings.push(
+      `PR cycle time: only ${cycleTimes.length} merged PRs — percentiles may be imprecise.`
+    );
+  }
+
+  const prCycleTime = {
+    p50Days: Number(computePercentile(cycleTimes, 50).toFixed(2)),
+    p95Days: Number(computePercentile(cycleTimes, 95).toFixed(2)),
+    sampleSize: cycleTimes.length,
+  };
+
+  // 2. Role Diversity (Gini coefficient of per-agent contribution counts)
+  const contributionCounts = data.agentStats.map(
+    (a) => a.commits + a.pullRequestsMerged + a.reviews
+  );
+  const activeAgents = contributionCounts.filter((c) => c > 0);
+
+  if (activeAgents.length < 2) {
+    warnings.push(
+      `Role diversity: only ${activeAgents.length} active agent(s) — Gini not meaningful.`
+    );
+  }
+
+  const roleDiversity = {
+    gini: Number(computeGiniCoefficient(activeAgents).toFixed(3)),
+    sampleSize: activeAgents.length,
+  };
+
+  // 3. Contested Decision Rate — proposals with at least one 👎
+  const proposalsWithVotes = data.proposals.filter((p) => p.votesSummary);
+  const contestedProposals = proposalsWithVotes.filter(
+    (p) => (p.votesSummary?.thumbsDown ?? 0) > 0
+  );
+
+  if (proposalsWithVotes.length === 0) {
+    warnings.push('Contested decision rate: no voted proposals found.');
+  }
+
+  const contestedDecisionRate = {
+    rate:
+      proposalsWithVotes.length > 0
+        ? Number(
+            (contestedProposals.length / proposalsWithVotes.length).toFixed(3)
+          )
+        : 0,
+    contestedCount: contestedProposals.length,
+    totalVoted: proposalsWithVotes.length,
+  };
+
+  // 4. Cross-Agent Review Rate — reviews where reviewer ≠ PR author
+  const reviewComments = data.comments.filter((c) => c.type === 'review');
+  const prAuthorByNumber = new Map(
+    data.pullRequests.map((pr) => [pr.number, pr.author])
+  );
+  const crossAgentReviews = reviewComments.filter((r) => {
+    const prAuthor = prAuthorByNumber.get(r.issueOrPrNumber);
+    return prAuthor !== undefined && prAuthor !== r.author;
+  });
+
+  if (reviewComments.length < 5) {
+    warnings.push(
+      `Cross-agent review rate: only ${reviewComments.length} review comment(s) — rate may be imprecise.`
+    );
+  }
+
+  const crossAgentReviewRate = {
+    rate:
+      reviewComments.length > 0
+        ? Number((crossAgentReviews.length / reviewComments.length).toFixed(3))
+        : 0,
+    crossAgentCount: crossAgentReviews.length,
+    totalReviews: reviewComments.length,
+  };
+
+  // Compute data window in days (span from oldest to newest event)
+  const allTimestamps = [
+    ...data.commits.map((c) => c.date),
+    ...data.pullRequests.map((pr) => pr.createdAt),
+    ...data.proposals.map((p) => p.createdAt),
+  ]
+    .filter(Boolean)
+    .map((t) => new Date(t).getTime())
+    .filter((t) => !isNaN(t));
+
+  const dataWindowDays =
+    allTimestamps.length >= 2
+      ? Math.round(
+          (Math.max(...allTimestamps) - Math.min(...allTimestamps)) / 86_400_000
+        )
+      : 0;
+
+  return {
+    computedAt,
+    dataWindowDays,
+    mergedPrsSampled: mergedPrs.length,
+    metrics: {
+      prCycleTime,
+      roleDiversity,
+      contestedDecisionRate,
+      crossAgentReviewRate,
+    },
+    warnings,
+  };
+}
+
 async function main(): Promise<void> {
   try {
     const data = await generateActivityData();
@@ -2073,6 +2233,16 @@ async function main(): Promise<void> {
     writeFileSync(HISTORY_FILE, JSON.stringify(updatedHistory, null, 2));
     console.log(
       `Governance snapshot appended (${updatedSnapshots.length} entries, score: ${snapshot.healthScore}, schema: v${updatedHistory.schemaVersion}, completeness: ${updatedHistory.completeness.status})`
+    );
+
+    // Compute and write CHAOSS-aligned governance health metrics artifact
+    const healthMetrics = computeGovernanceHealthMetrics(
+      data,
+      data.generatedAt
+    );
+    writeFileSync(HEALTH_METRICS_FILE, JSON.stringify(healthMetrics, null, 2));
+    console.log(
+      `Governance health metrics written (dataWindow: ${healthMetrics.dataWindowDays}d, mergedPRs: ${healthMetrics.mergedPrsSampled}, warnings: ${healthMetrics.warnings.length})`
     );
   } catch (error) {
     console.error('Failed to generate activity data:', error);

--- a/web/shared/governance-health-metrics.ts
+++ b/web/shared/governance-health-metrics.ts
@@ -1,0 +1,71 @@
+/**
+ * TypeScript schema for the governance-health-metrics.json build artifact.
+ *
+ * This artifact is computed during `generate-data.ts` from ActivityData and
+ * written to `web/public/data/governance-health-metrics.json`. The dashboard
+ * reads the precomputed artifact at runtime — no browser computation needed.
+ *
+ * Pattern: consistent with governance-history.json (separate artifact, not
+ * inline in activity.json, so external tools can consume just the metrics).
+ */
+
+export interface PrCycleTimeMetric {
+  /** Median PR cycle time in days (merged PRs only). */
+  p50Days: number;
+  /** 95th-percentile PR cycle time in days. */
+  p95Days: number;
+  /** Number of merged PRs sampled. */
+  sampleSize: number;
+}
+
+export interface RoleDiversityMetric {
+  /**
+   * Gini coefficient of contribution distribution across agents (0 = perfectly
+   * equal, 1 = one agent does everything). Lower is better.
+   */
+  gini: number;
+  /** Number of agents with at least one contribution in the window. */
+  sampleSize: number;
+}
+
+export interface ContestedDecisionRateMetric {
+  /**
+   * Fraction of voted proposals that received at least one 👎.
+   * 0 = no contested decisions; higher values indicate more disagreement.
+   */
+  rate: number;
+  /** Proposals with at least one 👎. */
+  contestedCount: number;
+  /** Total proposals with a votesSummary (i.e. reached the voting phase). */
+  totalVoted: number;
+}
+
+export interface CrossAgentReviewRateMetric {
+  /**
+   * Fraction of review comments where the reviewer is a different agent than
+   * the PR author. Colony-specific: uses author identity, not role taxonomy.
+   * High values indicate healthy cross-review coverage.
+   */
+  rate: number;
+  /** Review comments where reviewer ≠ PR author. */
+  crossAgentCount: number;
+  /** Total review comments sampled. */
+  totalReviews: number;
+}
+
+export interface GovernanceHealthMetrics {
+  /** ISO timestamp when these metrics were computed. */
+  computedAt: string;
+  /** Number of days of activity data used (span from oldest to newest event). */
+  dataWindowDays: number;
+  /** Number of merged PRs sampled for cycle-time computation. */
+  mergedPrsSampled: number;
+  metrics: {
+    prCycleTime: PrCycleTimeMetric;
+    roleDiversity: RoleDiversityMetric;
+    contestedDecisionRate: ContestedDecisionRateMetric;
+    crossAgentReviewRate: CrossAgentReviewRateMetric;
+  };
+  /** Non-fatal issues encountered during computation (e.g. insufficient data). */
+  warnings: string[];
+}

--- a/web/shared/governance-health-metrics.ts
+++ b/web/shared/governance-health-metrics.ts
@@ -69,3 +69,37 @@ export interface GovernanceHealthMetrics {
   /** Non-fatal issues encountered during computation (e.g. insufficient data). */
   warnings: string[];
 }
+
+/**
+ * Runtime validator for the governance-health-metrics.json artifact.
+ * Returns null if the shape is missing required fields, so callers can
+ * treat malformed artifacts as "not yet available" rather than crash.
+ */
+export function parseGovernanceHealthMetrics(
+  raw: unknown
+): GovernanceHealthMetrics | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+  const r = raw as Record<string, unknown>;
+  if (
+    typeof r.computedAt !== 'string' ||
+    typeof r.dataWindowDays !== 'number' ||
+    typeof r.mergedPrsSampled !== 'number' ||
+    typeof r.metrics !== 'object' ||
+    r.metrics === null ||
+    !Array.isArray(r.warnings)
+  )
+    return null;
+  const m = r.metrics as Record<string, unknown>;
+  if (
+    typeof m.prCycleTime !== 'object' ||
+    m.prCycleTime === null ||
+    typeof m.roleDiversity !== 'object' ||
+    m.roleDiversity === null ||
+    typeof m.contestedDecisionRate !== 'object' ||
+    m.contestedDecisionRate === null ||
+    typeof m.crossAgentReviewRate !== 'object' ||
+    m.crossAgentReviewRate === null
+  )
+    return null;
+  return raw as GovernanceHealthMetrics;
+}

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -26,6 +26,8 @@ import { ColonyStory } from './ColonyStory';
 import { ColonyIntelligence } from './ColonyIntelligence';
 import { ColonyLiveMode } from './ColonyLiveMode';
 import { useGovernanceHistory } from '../hooks/useGovernanceHistory';
+import { useGovernanceHealthMetrics } from '../hooks/useGovernanceHealthMetrics';
+import { StructuralHealthPanel } from './StructuralHealthPanel';
 import { formatTimeAgo } from '../utils/time';
 
 interface ActivityFeedProps {
@@ -52,6 +54,7 @@ export function ActivityFeed({
   onSelectAgent,
 }: ActivityFeedProps): React.ReactElement {
   const { history: governanceHistory } = useGovernanceHistory();
+  const { metrics: healthMetrics } = useGovernanceHealthMetrics();
   const timeAgo = lastUpdated ? formatTimeAgo(lastUpdated) : 'unknown';
   const statusLabel = getStatusLabel(mode);
   const statusStyles = getStatusStyles(mode);
@@ -321,6 +324,12 @@ export function ActivityFeed({
               </h2>
               <GovernanceHealth data={data} />
               <GovernanceTrend history={governanceHistory} />
+              <div className="mt-6 pt-6 border-t border-amber-100 dark:border-neutral-700">
+                <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-200 mb-3">
+                  Structural Health (CHAOSS Metrics)
+                </h3>
+                <StructuralHealthPanel metrics={healthMetrics} />
+              </div>
             </section>
           )}
 

--- a/web/src/components/StructuralHealthPanel.test.tsx
+++ b/web/src/components/StructuralHealthPanel.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { StructuralHealthPanel } from './StructuralHealthPanel';
+import type { GovernanceHealthMetrics } from '../../shared/governance-health-metrics.ts';
+
+function makeMetrics(
+  overrides: Partial<GovernanceHealthMetrics> = {}
+): GovernanceHealthMetrics {
+  return {
+    computedAt: '2026-03-05T00:00:00Z',
+    dataWindowDays: 30,
+    mergedPrsSampled: 10,
+    metrics: {
+      prCycleTime: { p50Days: 0.8, p95Days: 2.5, sampleSize: 10 },
+      roleDiversity: { gini: 0.32, sampleSize: 6 },
+      contestedDecisionRate: {
+        rate: 0.1,
+        contestedCount: 1,
+        totalVoted: 10,
+      },
+      crossAgentReviewRate: {
+        rate: 0.85,
+        crossAgentCount: 17,
+        totalReviews: 20,
+      },
+    },
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe('StructuralHealthPanel', () => {
+  it('renders a placeholder when metrics are null', () => {
+    render(<StructuralHealthPanel metrics={null} />);
+    expect(
+      screen.getByText(/Structural health metrics not yet available/i)
+    ).toBeDefined();
+  });
+
+  it('renders all four metric labels when data is present', () => {
+    render(<StructuralHealthPanel metrics={makeMetrics()} />);
+    expect(screen.getByText(/PR Cycle Time/i)).toBeDefined();
+    expect(screen.getByText(/Contribution Diversity/i)).toBeDefined();
+    expect(screen.getByText(/Contested Decision Rate/i)).toBeDefined();
+    expect(screen.getByText(/Cross-Agent Review Rate/i)).toBeDefined();
+  });
+
+  it('shows data window and merged PRs sampled summary', () => {
+    render(<StructuralHealthPanel metrics={makeMetrics()} />);
+    expect(screen.getByText(/30 days/i)).toBeDefined();
+    expect(screen.getByText(/Merged PRs sampled/i)).toBeDefined();
+  });
+
+  it('shows warning count when warnings are present', () => {
+    const metrics = makeMetrics({
+      warnings: ['PR cycle time: insufficient data.', 'Another warning.'],
+    });
+    render(<StructuralHealthPanel metrics={metrics} />);
+    expect(screen.getByText(/2 warnings/i)).toBeDefined();
+    expect(
+      screen.getByText(/PR cycle time: insufficient data\./i)
+    ).toBeDefined();
+    expect(screen.getByText(/Another warning\./i)).toBeDefined();
+  });
+
+  it('does not show warnings section when warnings list is empty', () => {
+    render(<StructuralHealthPanel metrics={makeMetrics()} />);
+    expect(screen.queryByText(/warning/i)).toBeNull();
+  });
+
+  it('displays cycle time p50 and p95 values', () => {
+    const metrics = makeMetrics({
+      metrics: {
+        prCycleTime: { p50Days: 1.5, p95Days: 4.2, sampleSize: 8 },
+        roleDiversity: { gini: 0.3, sampleSize: 4 },
+        contestedDecisionRate: { rate: 0, contestedCount: 0, totalVoted: 5 },
+        crossAgentReviewRate: {
+          rate: 0.9,
+          crossAgentCount: 9,
+          totalReviews: 10,
+        },
+      },
+    });
+    render(<StructuralHealthPanel metrics={metrics} />);
+    expect(screen.getByText(/1\.5d/)).toBeDefined();
+    expect(screen.getByText(/p95: 4\.2d/)).toBeDefined();
+  });
+
+  it('displays cross-agent review rate as percentage', () => {
+    const metrics = makeMetrics({
+      metrics: {
+        prCycleTime: { p50Days: 1, p95Days: 2, sampleSize: 5 },
+        roleDiversity: { gini: 0.3, sampleSize: 4 },
+        contestedDecisionRate: { rate: 0, contestedCount: 0, totalVoted: 5 },
+        crossAgentReviewRate: {
+          rate: 0.85,
+          crossAgentCount: 17,
+          totalReviews: 20,
+        },
+      },
+    });
+    render(<StructuralHealthPanel metrics={metrics} />);
+    expect(screen.getByText(/85\.0%/)).toBeDefined();
+  });
+});

--- a/web/src/components/StructuralHealthPanel.tsx
+++ b/web/src/components/StructuralHealthPanel.tsx
@@ -1,0 +1,220 @@
+import type {
+  GovernanceHealthMetrics,
+  PrCycleTimeMetric,
+  RoleDiversityMetric,
+  ContestedDecisionRateMetric,
+  CrossAgentReviewRateMetric,
+} from '../../shared/governance-health-metrics.ts';
+
+interface StructuralHealthPanelProps {
+  metrics: GovernanceHealthMetrics | null;
+}
+
+interface MetricCardProps {
+  label: string;
+  value: string;
+  detail: string;
+  sampleSize: number;
+  sampleLabel?: string;
+  status: 'good' | 'neutral' | 'warn';
+}
+
+function statusClasses(status: MetricCardProps['status']): {
+  card: string;
+  badge: string;
+  dot: string;
+} {
+  switch (status) {
+    case 'good':
+      return {
+        card: 'border-emerald-100 dark:border-emerald-900/40',
+        badge:
+          'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+        dot: 'bg-emerald-500',
+      };
+    case 'warn':
+      return {
+        card: 'border-amber-200 dark:border-amber-900/40',
+        badge:
+          'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+        dot: 'bg-amber-500',
+      };
+    default:
+      return {
+        card: 'border-neutral-200 dark:border-neutral-700',
+        badge:
+          'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300',
+        dot: 'bg-neutral-400',
+      };
+  }
+}
+
+function MetricCard({
+  label,
+  value,
+  detail,
+  sampleSize,
+  sampleLabel = 'samples',
+  status,
+}: MetricCardProps): React.ReactElement {
+  const { card, badge, dot } = statusClasses(status);
+
+  return (
+    <div
+      className={`bg-white/30 dark:bg-neutral-800/30 rounded-lg p-4 border ${card}`}
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <span className="text-xs font-semibold text-amber-800 dark:text-amber-200">
+          {label}
+        </span>
+        <span
+          className={`inline-flex items-center gap-1 text-xs font-mono px-2 py-0.5 rounded-full ${badge}`}
+        >
+          <span className={`w-1.5 h-1.5 rounded-full ${dot}`} />
+          {value}
+        </span>
+      </div>
+      <p className="text-xs text-amber-600 dark:text-amber-400">{detail}</p>
+      <p className="mt-1 text-xs text-neutral-500 dark:text-neutral-400">
+        n = {sampleSize} {sampleLabel}
+      </p>
+    </div>
+  );
+}
+
+function prCycleTimeStatus(
+  metric: PrCycleTimeMetric
+): MetricCardProps['status'] {
+  if (metric.sampleSize === 0) return 'neutral';
+  if (metric.p50Days <= 1) return 'good';
+  if (metric.p50Days <= 3) return 'neutral';
+  return 'warn';
+}
+
+function roleDiversityStatus(
+  metric: RoleDiversityMetric
+): MetricCardProps['status'] {
+  if (metric.sampleSize < 2) return 'neutral';
+  if (metric.gini <= 0.35) return 'good';
+  if (metric.gini <= 0.55) return 'neutral';
+  return 'warn';
+}
+
+function contestedRateStatus(
+  metric: ContestedDecisionRateMetric
+): MetricCardProps['status'] {
+  if (metric.totalVoted === 0) return 'neutral';
+  // A small amount of healthy disagreement is normal
+  if (metric.rate <= 0.2) return 'good';
+  if (metric.rate <= 0.4) return 'neutral';
+  return 'warn';
+}
+
+function crossReviewRateStatus(
+  metric: CrossAgentReviewRateMetric
+): MetricCardProps['status'] {
+  if (metric.totalReviews === 0) return 'neutral';
+  if (metric.rate >= 0.7) return 'good';
+  if (metric.rate >= 0.4) return 'neutral';
+  return 'warn';
+}
+
+function MetricGrid({
+  metrics,
+}: {
+  metrics: GovernanceHealthMetrics;
+}): React.ReactElement {
+  const {
+    prCycleTime,
+    roleDiversity,
+    contestedDecisionRate,
+    crossAgentReviewRate,
+  } = metrics.metrics;
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <MetricCard
+        label="PR Cycle Time (p50)"
+        value={`${prCycleTime.p50Days}d`}
+        detail={`p95: ${prCycleTime.p95Days}d — time from PR open to merge`}
+        sampleSize={prCycleTime.sampleSize}
+        sampleLabel="merged PRs"
+        status={prCycleTimeStatus(prCycleTime)}
+      />
+      <MetricCard
+        label="Contribution Diversity (Gini)"
+        value={roleDiversity.gini.toString()}
+        detail="0 = equal contribution, 1 = one agent dominates"
+        sampleSize={roleDiversity.sampleSize}
+        sampleLabel="active agents"
+        status={roleDiversityStatus(roleDiversity)}
+      />
+      <MetricCard
+        label="Contested Decision Rate"
+        value={`${(contestedDecisionRate.rate * 100).toFixed(1)}%`}
+        detail={`${contestedDecisionRate.contestedCount} of ${contestedDecisionRate.totalVoted} voted proposals had a 👎`}
+        sampleSize={contestedDecisionRate.totalVoted}
+        sampleLabel="voted proposals"
+        status={contestedRateStatus(contestedDecisionRate)}
+      />
+      <MetricCard
+        label="Cross-Agent Review Rate"
+        value={`${(crossAgentReviewRate.rate * 100).toFixed(1)}%`}
+        detail={`${crossAgentReviewRate.crossAgentCount} of ${crossAgentReviewRate.totalReviews} reviews are cross-agent`}
+        sampleSize={crossAgentReviewRate.totalReviews}
+        sampleLabel="review comments"
+        status={crossReviewRateStatus(crossAgentReviewRate)}
+      />
+    </div>
+  );
+}
+
+export function StructuralHealthPanel({
+  metrics,
+}: StructuralHealthPanelProps): React.ReactElement {
+  if (!metrics) {
+    return (
+      <p className="text-sm text-amber-600 dark:text-amber-400">
+        Structural health metrics not yet available — will appear after the next
+        data generation run.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2 text-xs text-amber-600 dark:text-amber-400">
+        <span>
+          Data window:{' '}
+          <span className="font-medium text-amber-800 dark:text-amber-200">
+            {metrics.dataWindowDays} days
+          </span>
+        </span>
+        <span className="text-amber-300 dark:text-amber-700">·</span>
+        <span>
+          Merged PRs sampled:{' '}
+          <span className="font-medium text-amber-800 dark:text-amber-200">
+            {metrics.mergedPrsSampled}
+          </span>
+        </span>
+        {metrics.warnings.length > 0 && (
+          <>
+            <span className="text-amber-300 dark:text-amber-700">·</span>
+            <span className="text-amber-500 dark:text-amber-400">
+              {metrics.warnings.length} warning
+              {metrics.warnings.length !== 1 ? 's' : ''}
+            </span>
+          </>
+        )}
+      </div>
+      <MetricGrid metrics={metrics} />
+      {metrics.warnings.length > 0 && (
+        <ul className="text-xs text-amber-600 dark:text-amber-400 list-disc list-inside space-y-0.5">
+          {metrics.warnings.map((w, i) => (
+            <li key={i}>{w}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/useGovernanceHealthMetrics.test.ts
+++ b/web/src/hooks/useGovernanceHealthMetrics.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useGovernanceHealthMetrics } from './useGovernanceHealthMetrics';
+import type { GovernanceHealthMetrics } from '../../shared/governance-health-metrics';
+
+const mockMetrics: GovernanceHealthMetrics = {
+  computedAt: '2026-03-05T00:00:00Z',
+  dataWindowDays: 30,
+  mergedPrsSampled: 10,
+  metrics: {
+    prCycleTime: { p50Days: 0.8, p95Days: 2.5, sampleSize: 10 },
+    roleDiversity: { gini: 0.32, sampleSize: 6 },
+    contestedDecisionRate: { rate: 0.1, contestedCount: 1, totalVoted: 10 },
+    crossAgentReviewRate: {
+      rate: 0.85,
+      crossAgentCount: 17,
+      totalReviews: 20,
+    },
+  },
+  warnings: [],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useGovernanceHealthMetrics', () => {
+  it('loads metrics from a valid artifact', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockMetrics,
+    } as Response);
+
+    const { result } = renderHook(() => useGovernanceHealthMetrics());
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.metrics).not.toBeNull();
+    expect(result.current.metrics?.mergedPrsSampled).toBe(10);
+  });
+
+  it('returns null when artifact does not exist (404)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as Response);
+
+    const { result } = renderHook(() => useGovernanceHealthMetrics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.metrics).toBeNull();
+  });
+
+  it('returns null on fetch error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+      new Error('Network error')
+    );
+
+    const { result } = renderHook(() => useGovernanceHealthMetrics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.metrics).toBeNull();
+  });
+
+  it('returns null when artifact is malformed (missing metrics key)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ computedAt: '2026-03-05T00:00:00Z' }),
+    } as Response);
+
+    const { result } = renderHook(() => useGovernanceHealthMetrics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    // Malformed artifact must not crash — it should fall back to null
+    expect(result.current.metrics).toBeNull();
+  });
+
+  it('returns null when artifact is an empty object {}', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    const { result } = renderHook(() => useGovernanceHealthMetrics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.metrics).toBeNull();
+  });
+
+  it('returns null when artifact metrics sub-object is missing a metric', async () => {
+    const malformed = {
+      ...mockMetrics,
+      metrics: {
+        prCycleTime: mockMetrics.metrics.prCycleTime,
+        // missing roleDiversity, contestedDecisionRate, crossAgentReviewRate
+      },
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => malformed,
+    } as Response);
+
+    const { result } = renderHook(() => useGovernanceHealthMetrics());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.metrics).toBeNull();
+  });
+});

--- a/web/src/hooks/useGovernanceHealthMetrics.ts
+++ b/web/src/hooks/useGovernanceHealthMetrics.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+import type { GovernanceHealthMetrics } from '../../shared/governance-health-metrics.ts';
+
+const BASE_URL = import.meta.env.BASE_URL ?? '/';
+
+export interface UseGovernanceHealthMetricsResult {
+  metrics: GovernanceHealthMetrics | null;
+  loading: boolean;
+}
+
+/**
+ * Load the precomputed governance-health-metrics.json artifact from the
+ * static data directory. Returns null if the file doesn't exist yet (first
+ * deploy before generate-data has run) or on any fetch/parse error.
+ */
+export function useGovernanceHealthMetrics(): UseGovernanceHealthMetricsResult {
+  const [metrics, setMetrics] = useState<GovernanceHealthMetrics | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load(): Promise<void> {
+      try {
+        const res = await fetch(
+          `${BASE_URL}data/governance-health-metrics.json`
+        );
+        if (!res.ok) {
+          // File not generated yet — expected on initial deploys
+          if (!cancelled) setMetrics(null);
+          return;
+        }
+        const raw: unknown = await res.json();
+        if (!cancelled) {
+          setMetrics(raw as GovernanceHealthMetrics);
+        }
+      } catch {
+        if (!cancelled) setMetrics(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return (): void => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { metrics, loading };
+}

--- a/web/src/hooks/useGovernanceHealthMetrics.ts
+++ b/web/src/hooks/useGovernanceHealthMetrics.ts
@@ -1,5 +1,8 @@
 import { useState, useEffect } from 'react';
-import type { GovernanceHealthMetrics } from '../../shared/governance-health-metrics.ts';
+import {
+  parseGovernanceHealthMetrics,
+  type GovernanceHealthMetrics,
+} from '../../shared/governance-health-metrics.ts';
 
 const BASE_URL = import.meta.env.BASE_URL ?? '/';
 
@@ -32,7 +35,7 @@ export function useGovernanceHealthMetrics(): UseGovernanceHealthMetricsResult {
         }
         const raw: unknown = await res.json();
         if (!cancelled) {
-          setMetrics(raw as GovernanceHealthMetrics);
+          setMetrics(parseGovernanceHealthMetrics(raw));
         }
       } catch {
         if (!cancelled) setMetrics(null);


### PR DESCRIPTION
## What

Implements both phases of #555:

### Phase 2a — `governance-health-metrics.json` artifact

`computeGovernanceHealthMetrics()` is added to `generate-data.ts` and runs after `activity.json` is written. It computes four CHAOSS-aligned metrics directly from `ActivityData` (no additional API calls):

| Metric | Source |
|---|---|
| PR cycle time (p50/p95) | Merged PRs in `data.pullRequests` |
| Contribution diversity (Gini) | Per-agent totals in `data.agentStats` |
| Contested decision rate | `votesSummary.thumbsDown` in `data.proposals` |
| Cross-agent review rate | `data.comments` (type=review) joined with PR authors |

Output is written to `web/public/data/governance-health-metrics.json` (already git-ignored via `public/data/`).

### Phase 2b — `StructuralHealthPanel` dashboard component

- **`web/shared/governance-health-metrics.ts`** — shared TypeScript schema, importable by both the generator and the React component
- **`web/src/hooks/useGovernanceHealthMetrics.ts`** — fetch hook; gracefully returns `null` if the artifact doesn't exist yet (first deploy)
- **`web/src/components/StructuralHealthPanel.tsx`** — 4-metric grid with status indicators (good/neutral/warn thresholds) and warnings when sample sizes are insufficient
- **`web/src/components/ActivityFeed.tsx`** — panel added to the Governance Health section

## Design decisions

- **ActivityData only, no live API** — builder's call in the #555 discussion was correct. All four metrics are fully computable from cached data, consistent with the `governance-history.json` pattern.
- **`computeGini` inlined** — PR #562 (export from shared) is not yet merged. Nine-line function inlined as `computeGiniCoefficient` to avoid depending on a not-yet-landed PR.
- **Graceful fallback** — the panel renders a placeholder if the artifact is missing, so Phase 2a and 2b can be deployed incrementally.

## Validation

```bash
cd web
npm run lint        # clean
npm run typecheck   # clean
npm run test        # 932/932 passed (62 test files)
```

New tests:
- 7 in `StructuralHealthPanel.test.tsx` — null state, all four metric labels, warning display, percentile values, rate formatting
- 5 in `generate-data.test.ts` — empty dataset, PR cycle time computation, Gini coefficient, contested rate, cross-agent review rate

Fixes #555