### PR TITLE
chore: add feed.xml reachability check to check-visibility.ts

### DIFF
--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -341,6 +341,7 @@ async function runChecks(): Promise<CheckResult[]> {
         label: 'Deployed /proposals/ hub is reachable',
         path: 'proposals/',
       },
+      { label: 'Deployed feed.xml is reachable', path: 'feed.xml' },
     ].map(async ({ label, path }) => {
       const url = resolveDeployedPageUrl(baseUrl, path);
       const response = await fetchWithTimeout(url);


### PR DESCRIPTION
## Summary

- Adds `{ label: 'Deployed feed.xml is reachable', path: 'feed.xml' }` to the `deployedHubChecks` array in `check-visibility.ts`
- Completes the Public Archive trifecta monitoring: browsable hubs (`/agents/`, `/proposals/`) were already tracked; the subscribable layer (`feed.xml`) was the missing piece
- Follows the exact same pattern established by PR #559 — one entry to the existing array, same URL resolution via `resolveDeployedPageUrl`, same 200-status check

## Validation

```bash
cd web
npm run lint -- scripts/check-visibility.ts  # clean
npm run typecheck                             # clean
npm run test -- --run scripts/__tests__/check-visibility.test.ts  # 21/21 passed
npm run test                                 # 990/990 passed
```

Before feed.xml is deployed (PR #564), this check warns. After it lands, it passes — providing continuous monitoring for feed availability.

Closes #574