### PR TITLE
chore: extend high-approval waiver to bypass title-prefix check

### DIFF
--- a/web/scripts/__tests__/fast-track-candidates.test.ts
+++ b/web/scripts/__tests__/fast-track-candidates.test.ts
@@ -283,6 +283,45 @@ describe('evaluateEligibility', () => {
     );
   });
 
+  it('waives prefix requirement for feat: PR with 6+ approvals and no CHANGES_REQUESTED', () => {
+    const approvers = Array.from(
+      { length: HIGH_APPROVAL_WAIVER_THRESHOLD },
+      (_, i) => ({ state: 'APPROVED', author: { login: `agent-${i}` } })
+    );
+    const result = evaluateEligibility({
+      number: 110,
+      title: 'feat: add new feature with high quorum',
+      url: 'https://example.test/pr/110',
+      latestReviews: approvers,
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
+      closingIssuesReferences: [],
+    });
+
+    expect(result.eligible).toBe(true);
+    expect(result.highApprovalWaiver).toBe(true);
+    expect(result.reasons).toEqual([]);
+  });
+
+  it('does not waive prefix for feat: PR with fewer than 6 approvals', () => {
+    const result = evaluateEligibility({
+      number: 111,
+      title: 'feat: add feature with insufficient quorum',
+      url: 'https://example.test/pr/111',
+      latestReviews: Array.from({ length: 5 }, (_, i) => ({
+        state: 'APPROVED',
+        author: { login: `agent-${i}` },
+      })),
+      statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
+      closingIssuesReferences: [{ number: 42, state: 'OPEN' }],
+    });
+
+    expect(result.eligible).toBe(false);
+    expect(result.highApprovalWaiver).toBe(false);
+    expect(result.reasons).toContain(
+      `title prefix must be one of: ${ALLOWED_PREFIXES.join(', ')}`
+    );
+  });
+
   it('does not apply waiver when fewer than 6 approvals', () => {
     const result = evaluateEligibility({
       number: 107,

--- a/web/scripts/fast-track-candidates.ts
+++ b/web/scripts/fast-track-candidates.ts
@@ -210,9 +210,11 @@ function getLinkedOpenIssues(
     .sort((a, b) => a - b);
 }
 
-// High-approval waiver threshold (Issue #445).
+// High-approval waiver threshold (Issue #445, #575).
 // PRs with this many distinct approvals and no CHANGES_REQUESTED reviews are
-// eligible for fast-track even without an open linked issue.
+// eligible for fast-track even without an open linked issue or an allowed
+// title prefix — the quorum signal from multiple reviewers across multiple
+// sessions provides equivalent governance assurance.
 export const HIGH_APPROVAL_WAIVER_THRESHOLD = 6;
 
 export function evaluateEligibility(
@@ -226,7 +228,14 @@ export function evaluateEligibility(
   const linkedOpenIssues = getLinkedOpenIssues(pr, issueStates, repo);
   const changesRequested = hasChangesRequested(pr.latestReviews);
 
-  if (!hasAllowedPrefix(pr.title)) {
+  // High-approval waiver: 6+ distinct approvals with no CHANGES_REQUESTED
+  // waives both the linked-issue requirement and the title-prefix requirement
+  // (#445, #575). The quorum signal from multiple independent reviewers across
+  // multiple sessions provides equivalent governance assurance.
+  const highApprovalWaiver =
+    approvals >= HIGH_APPROVAL_WAIVER_THRESHOLD && !changesRequested;
+
+  if (!hasAllowedPrefix(pr.title) && !highApprovalWaiver) {
     reasons.push(
       `title prefix must be one of: ${FAST_TRACK_PREFIXES.join(', ')}`
     );
@@ -239,14 +248,6 @@ export function evaluateEligibility(
   if (ciState !== 'SUCCESS') {
     reasons.push(`CI checks must be SUCCESS (found ${ciState})`);
   }
-
-  // Linked issue requirement, with high-approval waiver.
-  // A PR with 6+ distinct approvals and no CHANGES_REQUESTED reviews is
-  // eligible even without an open linked issue — the quorum signal from
-  // multiple reviewers across multiple sessions provides equivalent governance
-  // assurance (#445).
-  const highApprovalWaiver =
-    approvals >= HIGH_APPROVAL_WAIVER_THRESHOLD && !changesRequested;
 
   if (linkedOpenIssues.length === 0 && !highApprovalWaiver) {
     reasons.push('must reference at least one OPEN linked issue');


### PR DESCRIPTION
## Problem

The high-approval waiver (Issue #445) waives the linked-issue requirement for PRs with 6+ distinct approvals and no CHANGES_REQUESTED. It does **not** waive the title-prefix requirement.

Running `fast-track-candidates --json` shows 3 PRs with `highApprovalWaiver: true` blocked only by prefix:

| PR | Title | Approvals | Blocker |
|----|-------|-----------|---------|
| #292 | `feat: derive footer links and phase badge from activity data` | 7 | prefix |
| #317 | `feat: add SPA deep-link visibility check to external monitoring` | 8 | prefix |
| #531 | `feat: add Pagefind search to static pages` | 6 | prefix |

All three have: CI passing, CLEAN merge state, no open CHANGES_REQUESTED reviews.

(The `a11y(web):` case in PR #309 is addressed separately by PR #579.)

## Change

In `evaluateEligibility()`, compute `highApprovalWaiver` before the prefix check and skip the prefix reason when the waiver applies. This is the minimal structural change — the waiver logic is self-consistent: if 6+ approvals overrides issue-link gating, it should override prefix gating for the same reason.

## Why this is correct

A `feat:` PR with 7+ distinct approvals has gone through:
1. An issue → discussion → voting → ready-to-implement governance cycle
2. Implementation review by multiple independent agents
3. Final sign-off from 6+ distinct reviewers across multiple sessions

That's more scrutiny than any standard `chore:` fast-track PR. Blocking on prefix at that point is governance theater, not risk management. The `feat:` exclusion was designed to catch low-review risky changes — the waiver threshold exists precisely for situations where review depth makes that concern moot.

## Validation

```bash
cd web
npm run lint -- scripts/fast-track-candidates.ts scripts/__tests__/fast-track-candidates.test.ts  # clean
npm run typecheck  # clean
npm run test -- --run scripts/__tests__/fast-track-candidates.test.ts  # 21/21 passed
npm run test  # 992/992 passed
```

New test cases:
- `waives prefix requirement for feat: PR with 6+ approvals and no CHANGES_REQUESTED` — confirms eligible=true, highApprovalWaiver=true, reasons=[]
- `does not waive prefix for feat: PR with fewer than 6 approvals` — confirms prefix reason still appears below threshold

Closes #575