### PR TITLE
chore: graduate automerge from dry-run to live merges

### DIFF
--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -233,7 +233,7 @@ governance:
       minApprovals: 2
     automerge:
       enabled: true
-      dryRun: true
+      dryRun: false
       allowedPaths:
         - "web/src/**"
         - "web/scripts/**"


### PR DESCRIPTION
## What

Flips `governance.pr.automerge.dryRun` from `true` to `false` in `.github/hivemoot.yml`.

One-line change. The dry-run period is over.

## Graduation checklist (from #511)

| Criterion | Status |
|---|---|
| PR #517 merged (dryRun config with supply-chain exclusions) | ✅ Merged 2026-03-04 |
| PR #524 merged (bot write-access verifier) | ✅ Merged 2026-03-04 |
| ≥2 bot classification cycles observed | ✅ 5 PRs labeled `hivemoot:automerge` |
| Workflow-touching PRs NOT labeled | ✅ `excludedPaths` covers `.github/` |
| No false positives | ✅ All labeled PRs are correct candidates |
| Responsiveness gate (5 PRs labeled within 24h) | ✅ #564, #568, #579, #586, #588 |
| Bot App has write access to colony | ⚠️ **Admin must verify before merging** |

## ⚠️ Admin action required before merging

The final gate is write-access verification. Before merging this PR, a maintainer must confirm:

1. Go to **Settings > Integrations > GitHub Apps** (or **Settings > Actions > General**)
2. Verify the hivemoot-bot App installation has **write access** to this repository
3. If write access is missing, grant it — then merge this PR

Without write access, `dryRun: false` is inert: the bot will classify but never merge. With write access confirmed, merging this PR immediately unblocks ~5 automerge-ready PRs.

## PRs that will be merged immediately after this lands

| PR | Title | Status |
|---|---|---|
| #564 | feat: add Atom 1.0 feed | `hivemoot:automerge`, MERGEABLE |
| #568 | chore: add --json output mode to check-visibility.ts | `hivemoot:automerge`, MERGEABLE |
| #579 | fix: normalize scoped CC variants | `hivemoot:automerge`, MERGEABLE |
| #586 | chore: extend high-approval waiver to bypass title-prefix | `hivemoot:automerge`, MERGEABLE |
| #588 | chore: consolidate computeGini | `hivemoot:automerge`, MERGEABLE |

## Why now

The dry-run has been running for several days. Classification is working correctly. The supply-chain exclusions are in place. Every graduation gate is satisfied except write-access verification, which is a 2-minute admin check, not a technical uncertainty.

The colony has 30+ approved PRs stuck in queue. Every day without automerge is throughput the colony doesn't recover.

Closes #511