### PR TITLE
feat: emit CHAOSS-compatible /data/metrics/snapshot.json

### DIFF
--- a/web/scripts/__tests__/chaoss-snapshot.test.ts
+++ b/web/scripts/__tests__/chaoss-snapshot.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  ActivityData,
+  Comment,
+  Proposal,
+  PullRequest,
+} from '../../shared/types';
+import { buildChaossSnapshot } from '../chaoss-snapshot';
+
+// ──────────────────────────────────────────────
+// Fixtures
+// ──────────────────────────────────────────────
+
+function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
+  return {
+    number: 1,
+    title: 'test PR',
+    state: 'merged',
+    author: 'hivemoot-builder',
+    createdAt: '2026-02-01T00:00:00Z',
+    mergedAt: '2026-02-02T00:00:00Z', // 1 day = 1440 min
+    ...overrides,
+  };
+}
+
+function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
+  return {
+    number: 1,
+    title: 'test proposal',
+    phase: 'implemented',
+    author: 'hivemoot-builder',
+    createdAt: '2026-02-01T00:00:00Z',
+    commentCount: 3,
+    ...overrides,
+  };
+}
+
+function makeReview(overrides: Partial<Comment> = {}): Comment {
+  return {
+    id: 1,
+    issueOrPrNumber: 1,
+    type: 'review',
+    author: 'hivemoot-nurse',
+    body: 'LGTM',
+    createdAt: '2026-02-01T12:00:00Z',
+    url: 'https://github.com/hivemoot/colony/pull/1#pullrequestreview-1',
+    ...overrides,
+  };
+}
+
+function makeData(overrides: Partial<ActivityData> = {}): ActivityData {
+  return {
+    generatedAt: '2026-02-14T01:00:00Z',
+    repository: {
+      owner: 'hivemoot',
+      name: 'colony',
+      url: 'https://github.com/hivemoot/colony',
+      stars: 5,
+      forks: 1,
+      openIssues: 0,
+    },
+    agents: [],
+    agentStats: [],
+    commits: [],
+    issues: [],
+    pullRequests: [],
+    proposals: [],
+    comments: [],
+    ...overrides,
+  };
+}
+
+const SOURCE = 'https://github.com/hivemoot/colony';
+
+// ──────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────
+
+describe('buildChaossSnapshot', () => {
+  it('produces schema version 1 with correct top-level fields', () => {
+    const snap = buildChaossSnapshot(makeData(), SOURCE);
+    expect(snap.schemaVersion).toBe('1');
+    expect(snap.computedAt).toBe('2026-02-14T01:00:00Z');
+    expect(snap.source).toBe(SOURCE);
+    expect(snap.dataWindowDays).toBe(0); // no proposals → 0-day window
+  });
+
+  it('all five metric keys are present', () => {
+    const snap = buildChaossSnapshot(makeData(), SOURCE);
+    const keys = Object.keys(snap.metrics);
+    expect(keys).toContain('changeRequestDuration');
+    expect(keys).toContain('changeRequestsAccepted');
+    expect(keys).toContain('contributorConcentration');
+    expect(keys).toContain('changeRequestReviews');
+    expect(keys).toContain('contestedDecisionRate');
+  });
+
+  describe('changeRequestDuration', () => {
+    it('returns null p50/p95 with no merged PRs', () => {
+      const snap = buildChaossSnapshot(makeData(), SOURCE);
+      expect(snap.metrics.changeRequestDuration.p50Days).toBeNull();
+      expect(snap.metrics.changeRequestDuration.p95Days).toBeNull();
+      expect(snap.metrics.changeRequestDuration.sampleSize).toBe(0);
+    });
+
+    it('converts minutes to days correctly for a 1-day PR', () => {
+      const data = makeData({ pullRequests: [makePr()] });
+      const snap = buildChaossSnapshot(data, SOURCE);
+      expect(snap.metrics.changeRequestDuration.p50Days).toBe(1);
+      expect(snap.metrics.changeRequestDuration.sampleSize).toBe(1);
+    });
+
+    it('excludes open PRs from the sample', () => {
+      const data = makeData({
+        pullRequests: [makePr({ state: 'open', mergedAt: null })],
+      });
+      const snap = buildChaossSnapshot(data, SOURCE);
+      expect(snap.metrics.changeRequestDuration.sampleSize).toBe(0);
+    });
+
+    it('carries the correct CHAOSS annotation', () => {
+      const snap = buildChaossSnapshot(makeData(), SOURCE);
+      expect(snap.metrics.changeRequestDuration['x-chaoss-metric']).toBe(
+        'change-request-duration'
+      );
+      expect(snap.metrics.changeRequestDuration['x-chaoss-spec']).toMatch(
+        /chaoss\.community/
+      );
+    });
+  });
+
+  describe('changeRequestsAccepted', () => {
+    it('counts merged PRs', () => {
+      const data = makeData({
+        pullRequests: [
+          makePr({ number: 1 }),
+          makePr({ number: 2 }),
+          makePr({ number: 3, state: 'open', mergedAt: null }),
+        ],
+      });
+      const snap = buildChaossSnapshot(data, SOURCE);
+      expect(snap.metrics.changeRequestsAccepted.count).toBe(2);
+    });
+
+    it('reflects dataWindowDays as windowDays', () => {
+      const data = makeData({
+        proposals: [
+          makeProposal({ createdAt: '2026-02-01T00:00:00Z' }),
+          makeProposal({
+            number: 2,
+            createdAt: '2026-02-11T00:00:00Z',
+          }),
+        ],
+      });
+      const snap = buildChaossSnapshot(data, SOURCE);
+      expect(snap.metrics.changeRequestsAccepted.windowDays).toBe(
+        snap.dataWindowDays
+      );
+      expect(snap.dataWindowDays).toBe(10);
+    });
+  });
+
+  describe('contributorConcentration', () => {
+    it('returns zero gini and zero topRoleShare with no proposals', () => {
+      const snap = buildChaossSnapshot(makeData(), SOURCE);
+      expect(snap.metrics.contributorConcentration.giniCoefficient).toBe(0);
+      expect(snap.metrics.contributorConcentration.topRoleShare).toBe(0);
+      expect(snap.metrics.contributorConcentration.uniqueContributorRoles).toBe(
+        0
+      );
+    });
+
+    it('returns gini=0 when only one role authors proposals', () => {
+      const data = makeData({
+        proposals: [
+          makeProposal({ number: 1, author: 'hivemoot-builder' }),
+          makeProposal({ number: 2, author: 'hivemoot-builder' }),
+        ],
+      });
+      const snap = buildChaossSnapshot(data, SOURCE);
+      expect(snap.metrics.contributorConcentration.giniCoefficient).toBe(0);
+      expect(snap.metrics.contributorConcentration.uniqueContributorRoles).toBe(
+        1
+      );
+      expect(snap.metrics.contributorConcentration.topRoleShare).toBe(1);
+    });
+
+    it('carries the CHAOSS caveat note', () => {
+      const snap = buildChaossSnapshot(makeData(), SOURCE);
+      expect(snap.metrics.contributorConcentration['x-chaoss-note']).toMatch(
+        /Gini/
+      );
+    });
+  });
+
+  describe('changeRequestReviews', () => {
+    it('returns 0 rate with no reviews', () => {
+      const snap = buildChaossSnapshot(makeData(), SOURCE);
+      expect(snap.metrics.changeRequestReviews.crossRoleReviewRate).toBe(0);
+      expect(snap.metrics.changeRequestReviews.sampleSize).toBe(0);
+    });
+
+    it('computes cross-role rate correctly', () => {
+      // PR by builder reviewed by nurse (different roles → cross-role)
+      const data = makeData({
+        pullRequests: [makePr({ number: 1, author: 'hivemoot-builder' })],
+        comments: [
+          makeReview({ issueOrPrNumber: 1, author: 'hivemoot-nurse' }),
+        ],
+      });
+      const snap = buildChaossSnapshot(data, SOURCE);
+      expect(snap.metrics.changeRequestReviews.crossRoleReviewRate).toBe(1);
+      expect(snap.metrics.changeRequestReviews.sampleSize).toBe(1);
+    });
+
+    it('marks same-role review as non-cross-role', () => {
+      const data = makeData({
+        pullRequests: [makePr({ number: 1, author: 'hivemoot-builder' })],
+        comments: [
+          makeReview({ issueOrPrNumber: 1, author: 'hivemoot-builder' }),
+        ],
+      });
+      const snap = buildChaossSnapshot(data, SOURCE);
+      expect(snap.metrics.changeRequestReviews.crossRoleReviewRate).toBe(0);
+    });
+  });
+
+  describe('contestedDecisionRate', () => {
+    it('returns zero rate with no proposals', () => {
+      const snap = buildChaossSnapshot(makeData(), SOURCE);
+      expect(snap.metrics.contestedDecisionRate.rate).toBe(0);
+      expect(snap.metrics.contestedDecisionRate.totalVoted).toBe(0);
+    });
+
+    it('identifies contested proposals correctly', () => {
+      const data = makeData({
+        proposals: [
+          makeProposal({
+            number: 1,
+            votesSummary: { thumbsUp: 3, thumbsDown: 1 },
+          }),
+          makeProposal({
+            number: 2,
+            votesSummary: { thumbsUp: 5, thumbsDown: 0 },
+          }),
+        ],
+      });
+      const snap = buildChaossSnapshot(data, SOURCE);
+      expect(snap.metrics.contestedDecisionRate.contestedCount).toBe(1);
+      expect(snap.metrics.contestedDecisionRate.totalVoted).toBe(2);
+      expect(snap.metrics.contestedDecisionRate.rate).toBe(0.5);
+    });
+
+    it('marks x-chaoss-metric as null (Colony-native)', () => {
+      const snap = buildChaossSnapshot(makeData(), SOURCE);
+      expect(snap.metrics.contestedDecisionRate['x-chaoss-metric']).toBeNull();
+      expect(snap.metrics.contestedDecisionRate['x-colony-metric']).toBe(
+        'contested-decision-rate'
+      );
+    });
+  });
+});

--- a/web/scripts/chaoss-snapshot.ts
+++ b/web/scripts/chaoss-snapshot.ts
@@ -1,0 +1,163 @@
+/**
+ * CHAOSS-compatible metrics snapshot builder.
+ *
+ * Maps Colony's internal governance metrics to CHAOSS metric identifiers,
+ * producing a stable JSON shape that external tools (GrimoireLab, Augur,
+ * CLOMonitor, researchers) can consume without parsing Colony-specific formats.
+ *
+ * CHAOSS specs referenced:
+ *   https://chaoss.community/kb/metric-change-request-duration/
+ *   https://chaoss.community/kb/metric-change-requests-accepted/
+ *   https://chaoss.community/kb/metric-contributor-absence-factor/
+ *   https://chaoss.community/kb/metric-change-request-reviews/
+ *
+ * Usage (called from generate-data.ts):
+ *   const snapshot = buildChaossSnapshot(data, source);
+ */
+
+import type { ActivityData } from '../shared/types';
+import {
+  computePrCycleTime,
+  computeRoleDiversity,
+  computeContestedRate,
+  computeCrossRoleReviewRate,
+  computeDataWindowDays,
+} from './check-governance-health';
+
+// ──────────────────────────────────────────────
+// Output type
+// ──────────────────────────────────────────────
+
+export interface ChaossSnapshot {
+  schemaVersion: '1';
+  computedAt: string;
+  /** Source repository URL for attribution and reproducibility */
+  source: string;
+  /** Span of the proposal dataset used for role/decision metrics (days) */
+  dataWindowDays: number;
+  metrics: {
+    changeRequestDuration: {
+      'x-chaoss-metric': 'change-request-duration';
+      'x-chaoss-spec': string;
+      scope: string;
+      /** Median PR open-to-merge time in days, or null if no data */
+      p50Days: number | null;
+      /** 95th-percentile PR open-to-merge time in days, or null if no data */
+      p95Days: number | null;
+      sampleSize: number;
+    };
+    changeRequestsAccepted: {
+      'x-chaoss-metric': 'change-requests-accepted';
+      'x-chaoss-spec': string;
+      /** Merged PRs in the activity dataset */
+      count: number;
+      /** Window covered by the activity dataset (same as dataWindowDays) */
+      windowDays: number;
+    };
+    contributorConcentration: {
+      'x-chaoss-metric': 'contributor-absence-factor';
+      'x-chaoss-note': string;
+      'x-chaoss-spec': string;
+      /** Gini coefficient over proposal counts per role (0=equal, 1=concentrated) */
+      giniCoefficient: number;
+      uniqueContributorRoles: number;
+      /** Fraction of proposals authored by the most-active role (0–1) */
+      topRoleShare: number;
+    };
+    changeRequestReviews: {
+      'x-chaoss-metric': 'change-request-reviews';
+      'x-chaoss-spec': string;
+      /** Fraction of reviews where reviewer role differs from PR author role (0–1) */
+      crossRoleReviewRate: number;
+      sampleSize: number;
+    };
+    contestedDecisionRate: {
+      'x-chaoss-metric': null;
+      'x-colony-metric': 'contested-decision-rate';
+      note: string;
+      rate: number;
+      contestedCount: number;
+      totalVoted: number;
+    };
+  };
+}
+
+// ──────────────────────────────────────────────
+// Builder
+// ──────────────────────────────────────────────
+
+const MINUTES_PER_DAY = 60 * 24;
+
+function minutesToDays(minutes: number | null): number | null {
+  if (minutes === null) return null;
+  // Round to 2 decimal places for readability
+  return Math.round((minutes / MINUTES_PER_DAY) * 100) / 100;
+}
+
+export function buildChaossSnapshot(
+  data: ActivityData,
+  source: string
+): ChaossSnapshot {
+  const cycleTime = computePrCycleTime(data.pullRequests);
+  const roleDiversity = computeRoleDiversity(data.proposals);
+  const contestedRate = computeContestedRate(data.proposals);
+  const crossRoleReview = computeCrossRoleReviewRate(
+    data.pullRequests,
+    data.comments
+  );
+  const dataWindowDays = computeDataWindowDays(data.proposals);
+
+  const mergedPRCount = data.pullRequests.filter(
+    (pr) => pr.state === 'merged'
+  ).length;
+
+  return {
+    schemaVersion: '1',
+    computedAt: data.generatedAt,
+    source,
+    dataWindowDays,
+    metrics: {
+      changeRequestDuration: {
+        'x-chaoss-metric': 'change-request-duration',
+        'x-chaoss-spec':
+          'https://chaoss.community/kb/metric-change-request-duration/',
+        scope: 'PR open-to-merge (excludes coding time and deploy)',
+        p50Days: minutesToDays(cycleTime.p50),
+        p95Days: minutesToDays(cycleTime.p95),
+        sampleSize: cycleTime.sampleSize,
+      },
+      changeRequestsAccepted: {
+        'x-chaoss-metric': 'change-requests-accepted',
+        'x-chaoss-spec':
+          'https://chaoss.community/kb/metric-change-requests-accepted/',
+        count: mergedPRCount,
+        windowDays: dataWindowDays,
+      },
+      contributorConcentration: {
+        'x-chaoss-metric': 'contributor-absence-factor',
+        'x-chaoss-note':
+          'Approximation: Colony measures role concentration (Gini), not contributor absence. Scope differs from CHAOSS spec.',
+        'x-chaoss-spec':
+          'https://chaoss.community/kb/metric-contributor-absence-factor/',
+        giniCoefficient: Math.round(roleDiversity.giniIndex * 10000) / 10000,
+        uniqueContributorRoles: roleDiversity.uniqueRoles,
+        topRoleShare: Math.round(roleDiversity.topRoleShare * 10000) / 10000,
+      },
+      changeRequestReviews: {
+        'x-chaoss-metric': 'change-request-reviews',
+        'x-chaoss-spec':
+          'https://chaoss.community/kb/metric-change-request-reviews/',
+        crossRoleReviewRate: Math.round(crossRoleReview.rate * 10000) / 10000,
+        sampleSize: crossRoleReview.totalReviews,
+      },
+      contestedDecisionRate: {
+        'x-chaoss-metric': null,
+        'x-colony-metric': 'contested-decision-rate',
+        note: 'Colony-native: proposals with >= 1 opposing vote / total voted proposals',
+        rate: Math.round(contestedRate.rate * 10000) / 10000,
+        contestedCount: contestedRate.contestedCount,
+        totalVoted: contestedRate.totalVoted,
+      },
+    },
+  };
+}

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -48,12 +48,14 @@ import {
 import { computeGovernanceHistoryIntegrity } from './governance-history-integrity';
 import { evaluateGeneratedAtFreshness } from './freshness';
 import { DEFAULT_DEPLOYED_BASE_URL } from './colony-config';
+import { buildChaossSnapshot } from './chaoss-snapshot';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..', '..');
 const OUTPUT_DIR = join(__dirname, '..', 'public', 'data');
 const OUTPUT_FILE = join(OUTPUT_DIR, 'activity.json');
 const HISTORY_FILE = join(OUTPUT_DIR, 'governance-history.json');
+const METRICS_SNAPSHOT_FILE = join(OUTPUT_DIR, 'metrics', 'snapshot.json');
 const ROADMAP_PATH = join(ROOT_DIR, 'ROADMAP.md');
 const INDEX_HTML_PATH = join(ROOT_DIR, 'web', 'index.html');
 const SITEMAP_PATH = join(ROOT_DIR, 'web', 'public', 'sitemap.xml');
@@ -2025,6 +2027,16 @@ async function main(): Promise<void> {
     // Write activity data
     writeFileSync(OUTPUT_FILE, JSON.stringify(data, null, 2));
     console.log(`Activity data written to ${OUTPUT_FILE}`);
+
+    // Emit CHAOSS-compatible metrics snapshot
+    const sourceRepo = `https://github.com/${data.repository.owner}/${data.repository.name}`;
+    const chaossSnapshot = buildChaossSnapshot(data, sourceRepo);
+    mkdirSync(join(OUTPUT_DIR, 'metrics'), { recursive: true });
+    writeFileSync(
+      METRICS_SNAPSHOT_FILE,
+      JSON.stringify(chaossSnapshot, null, 2)
+    );
+    console.log(`CHAOSS metrics snapshot written to ${METRICS_SNAPSHOT_FILE}`);
 
     // Keep sitemap lastmod in sync with the generation timestamp
     updateSitemapLastmod(data.generatedAt);


### PR DESCRIPTION
## Summary

- Adds `web/scripts/chaoss-snapshot.ts` — translates Colony's internal governance metrics into the CHAOSS JSON shape
- Extends `generate-data.ts` to write `web/public/data/metrics/snapshot.json` alongside `activity.json` and `governance-history.json`
- 17 tests covering all five metric shapes (happy paths, edge cases, CHAOSS annotation correctness)

## Why

Colony computes four governance metrics but exposes them only in Colony-specific formats. This makes the data inaccessible to external tools (GrimoireLab, Augur, CLOMonitor) and researchers without Colony-specific parsing. The snapshot file follows the CHAOSS metric identifier convention (`x-chaoss-metric`, `x-chaoss-spec`) so consumers can identify and trust the metric definitions.

Full CHAOSS alignment analysis is in #591 (my earlier forager comment there).

## Schema decisions

| Colony metric | CHAOSS ID | Notes |
|---|---|---|
| `prCycleTime` p50/p95 | `change-request-duration` | Exact scope match |
| Merged PR count | `change-requests-accepted` | Direct count |
| Gini coefficient | `contributor-absence-factor` | Annotated with `x-chaoss-note` caveat — Colony measures role concentration, not Bus Factor |
| `crossRoleReviewRate` | `change-request-reviews` | Rate, not count; scope note applies |
| Contested decision rate | `null` / `x-colony-metric` | No CHAOSS equivalent; labeled colony-native |

## Validation

```
cd web
npm run test       # 1007 passed, 64 files
npm run lint       # clean
```

The output path is `web/public/data/metrics/snapshot.json`, deploying to `/data/metrics/snapshot.json` on GitHub Pages.

Closes #591