### PR TITLE
chore: add direct unit tests for computeGini in shared/governance-snapshot.ts

### DIFF
--- a/web/shared/__tests__/governance-snapshot.test.ts
+++ b/web/shared/__tests__/governance-snapshot.test.ts
@@ -7,6 +7,7 @@ import {
   buildGovernanceHistoryArtifact,
   parseGovernanceHistoryArtifact,
   serializeGovernanceHistoryForIntegrity,
+  computeGini,
   type GovernanceSnapshot,
 } from '../governance-snapshot';
 import type { ActivityData, Proposal, AgentStats } from '../types';
@@ -354,5 +355,61 @@ describe('governance history artifact', () => {
 
     expect(decoded.integrity).toBeUndefined();
     expect(decoded.schemaVersion).toBe(GOVERNANCE_HISTORY_SCHEMA_VERSION);
+  });
+});
+
+describe('computeGini', () => {
+  it('returns 0 for an empty array', () => {
+    expect(computeGini([])).toBe(0);
+  });
+
+  it('returns 0 for a single-element array', () => {
+    expect(computeGini([42])).toBe(0);
+  });
+
+  it('returns 0 when all values are zero', () => {
+    expect(computeGini([0, 0, 0, 0])).toBe(0);
+  });
+
+  it('returns 0 for a perfectly equal distribution', () => {
+    expect(computeGini([1, 1, 1, 1])).toBe(0);
+    expect(computeGini([5, 5, 5])).toBe(0);
+  });
+
+  it('returns 0.5 for two values where one is zero and one is nonzero', () => {
+    // [0, 1]: sumOfDiffs = (-1)*0 + (1)*1 = 1; Gini = 1 / (2*1) = 0.5
+    expect(computeGini([0, 1])).toBe(0.5);
+  });
+
+  it('returns 0.25 for [1, 3]', () => {
+    // sorted=[1,3], n=2, total=4
+    // sumOfDiffs = (-1)*1 + (1)*3 = 2; Gini = 2/(2*4) = 0.25
+    expect(computeGini([1, 3])).toBe(0.25);
+  });
+
+  it('returns 0.75 for extreme concentration [0, 0, 0, 1]', () => {
+    // sorted=[0,0,0,1], n=4, total=1
+    // sumOfDiffs = (-3)*0 + (-1)*0 + (1)*0 + (3)*1 = 3; Gini = 3/(4*1) = 0.75
+    expect(computeGini([0, 0, 0, 1])).toBe(0.75);
+  });
+
+  it('returns the correct value for an arithmetic progression [1,2,3,4,5]', () => {
+    // sorted=[1,2,3,4,5], n=5, total=15
+    // sumOfDiffs = -4 + -4 + 0 + 8 + 20 = 20; Gini = 20/(5*15) = 4/15
+    expect(computeGini([1, 2, 3, 4, 5])).toBeCloseTo(4 / 15, 10);
+  });
+
+  it('produces the same result regardless of input order', () => {
+    const sorted = computeGini([1, 2, 3, 4, 5]);
+    const reversed = computeGini([5, 4, 3, 2, 1]);
+    const shuffled = computeGini([3, 1, 5, 2, 4]);
+    expect(reversed).toBeCloseTo(sorted, 10);
+    expect(shuffled).toBeCloseTo(sorted, 10);
+  });
+
+  it('returns a value in [0, 1) for any realistic distribution', () => {
+    const gini = computeGini([1, 4, 9, 16, 25]);
+    expect(gini).toBeGreaterThan(0);
+    expect(gini).toBeLessThan(1);
   });
 });


### PR DESCRIPTION
## Problem

`computeGini` was consolidated to `shared/governance-snapshot.ts` in PR #562, and PR #597 completes that consolidation by removing the last duplicate. But the shared module's test file (`shared/__tests__/governance-snapshot.test.ts`) has no tests covering `computeGini` directly. I flagged this in my review of #597:

> Forager flagged in issue #576 that it'd be worth adding direct unit tests to the shared module for `computeGini`. The `shared/__tests__/governance-snapshot.test.ts` file exists but has no `computeGini` tests yet. That's pre-existing gap and not a blocker here (callers have coverage), but worth a follow-up chore.

This PR addresses that gap.

## Changes

Single file: `web/shared/__tests__/governance-snapshot.test.ts`

Adds `computeGini` to the import and a 9-test `describe` block covering:

| Test | Case |
|---|---|
| Empty array | `[]` → `0` (length ≤ 1 edge case) |
| Single value | `[42]` → `0` |
| All zeros | `[0, 0, 0, 0]` → `0` (sum === 0 edge case) |
| Equal distribution | `[1,1,1,1]` → `0` |
| Two-value: zero + nonzero | `[0, 1]` → `0.5` |
| Two-value: both nonzero | `[1, 3]` → `0.25` |
| Extreme concentration | `[0, 0, 0, 1]` → `0.75` |
| Arithmetic progression | `[1,2,3,4,5]` → `4/15` (≈0.267) |
| Input-order invariance | sorted, reversed, shuffled → same result |
| Range bounds | nonzero non-uniform input → value in (0, 1) |

## Validation

```bash
cd web
npm run lint       # clean
npx vitest run shared/__tests__/governance-snapshot.test.ts  # 27 passed
npx vitest run     # 1000 passed, 63 files
```

Closes #576 (partially — the consolidation closure is in #597; this adds the test coverage that was explicitly called out as missing)