### PR TITLE
feat: append CHAOSS health metrics to governance-health-history.json

### DIFF
--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { writeFileSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -20,6 +20,12 @@ import {
   deduplicateAgents,
   extractPhaseTransitions,
   filterAndMapProposals,
+  buildGovernanceHealthEntry,
+  appendGovernanceHealthEntry,
+  loadGovernanceHealthHistory,
+  HEALTH_HISTORY_MAX_ENTRIES,
+  HEALTH_HISTORY_SCHEMA_VERSION,
+  type GovernanceHealthEntry,
   type GitHubCommit,
   type GitHubEvent,
   type GitHubTimelineEvent,
@@ -2266,5 +2272,144 @@ describe('extractPhaseTransitions with hivemoot:* labels', () => {
       { phase: 'voting', enteredAt: '2026-01-02T00:00:00Z' },
       { phase: 'implemented', enteredAt: '2026-01-03T00:00:00Z' },
     ]);
+  });
+});
+
+// ──────────────────────────────────────────────
+// Governance health history
+// ──────────────────────────────────────────────
+
+function makeHealthEntry(
+  overrides: Partial<GovernanceHealthEntry> = {}
+): GovernanceHealthEntry {
+  return {
+    timestamp: '2026-03-08T00:00:00Z',
+    prCycleTime: { p50: 1440, p95: 10080, sampleSize: 10 },
+    roleDiversity: {
+      uniqueRoles: 5,
+      giniIndex: 0.3,
+      topRole: 'builder',
+      topRoleShare: 0.4,
+    },
+    contestedDecisionRate: { contestedCount: 2, totalVoted: 10, rate: 0.2 },
+    crossRoleReviewRate: { crossRoleCount: 8, totalReviews: 10, rate: 0.8 },
+    warningCount: 0,
+    ...overrides,
+  };
+}
+
+describe('buildGovernanceHealthEntry', () => {
+  it('maps HealthReport fields correctly', () => {
+    const report = {
+      generatedAt: '2026-03-08T00:00:00Z',
+      dataWindowDays: 30,
+      metrics: {
+        prCycleTime: { p50: 720, p95: 5040, sampleSize: 5 },
+        roleDiversity: {
+          uniqueRoles: 3,
+          giniIndex: 0.25,
+          topRole: 'drone',
+          topRoleShare: 0.6,
+        },
+        contestedDecisionRate: { contestedCount: 1, totalVoted: 5, rate: 0.2 },
+        crossRoleReviewRate: { crossRoleCount: 4, totalReviews: 5, rate: 0.8 },
+      },
+      warnings: ['one warning'],
+    };
+    const entry = buildGovernanceHealthEntry(report);
+    expect(entry.timestamp).toBe('2026-03-08T00:00:00Z');
+    expect(entry.prCycleTime).toEqual({ p50: 720, p95: 5040, sampleSize: 5 });
+    expect(entry.roleDiversity.giniIndex).toBe(0.25);
+    expect(entry.contestedDecisionRate.rate).toBe(0.2);
+    expect(entry.crossRoleReviewRate.rate).toBe(0.8);
+    expect(entry.warningCount).toBe(1);
+  });
+});
+
+describe('appendGovernanceHealthEntry', () => {
+  it('appends a new entry to an empty list', () => {
+    const entry = makeHealthEntry();
+    const result = appendGovernanceHealthEntry([], entry);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(entry);
+  });
+
+  it('appends to an existing list', () => {
+    const existing = [makeHealthEntry({ timestamp: '2026-03-01T00:00:00Z' })];
+    const newEntry = makeHealthEntry({ timestamp: '2026-03-08T00:00:00Z' });
+    const result = appendGovernanceHealthEntry(existing, newEntry);
+    expect(result).toHaveLength(2);
+    expect(result[1].timestamp).toBe('2026-03-08T00:00:00Z');
+  });
+
+  it('caps at HEALTH_HISTORY_MAX_ENTRIES, dropping oldest', () => {
+    const entries = Array.from({ length: HEALTH_HISTORY_MAX_ENTRIES }, (_, i) =>
+      makeHealthEntry({
+        timestamp: `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
+      })
+    );
+    const newest = makeHealthEntry({ timestamp: '2026-04-30T00:00:00Z' });
+    const result = appendGovernanceHealthEntry(entries, newest);
+    expect(result).toHaveLength(HEALTH_HISTORY_MAX_ENTRIES);
+    expect(result[result.length - 1].timestamp).toBe('2026-04-30T00:00:00Z');
+    // Oldest entry (index 0) should have been dropped
+    expect(result[0].timestamp).toBe('2026-01-02T00:00:00Z');
+  });
+
+  it('preserves order oldest-to-newest', () => {
+    const e1 = makeHealthEntry({ timestamp: '2026-01-01T00:00:00Z' });
+    const e2 = makeHealthEntry({ timestamp: '2026-02-01T00:00:00Z' });
+    const result = appendGovernanceHealthEntry([e1], e2);
+    expect(result[0].timestamp).toBe('2026-01-01T00:00:00Z');
+    expect(result[1].timestamp).toBe('2026-02-01T00:00:00Z');
+  });
+});
+
+describe('loadGovernanceHealthHistory', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'health-history-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty history when file does not exist', () => {
+    const result = loadGovernanceHealthHistory(join(tmpDir, 'missing.json'));
+    expect(result.schemaVersion).toBe(HEALTH_HISTORY_SCHEMA_VERSION);
+    expect(result.snapshots).toEqual([]);
+  });
+
+  it('parses a valid history file', () => {
+    const filePath = join(tmpDir, 'health-history.json');
+    const entry = makeHealthEntry();
+    const stored = {
+      schemaVersion: HEALTH_HISTORY_SCHEMA_VERSION,
+      generatedAt: '2026-03-08T00:00:00Z',
+      snapshots: [entry],
+    };
+    writeFileSync(filePath, JSON.stringify(stored));
+    const result = loadGovernanceHealthHistory(filePath);
+    expect(result.snapshots).toHaveLength(1);
+    expect(result.snapshots[0].timestamp).toBe('2026-03-08T00:00:00Z');
+  });
+
+  it('returns empty history on corrupt JSON', () => {
+    const filePath = join(tmpDir, 'corrupt.json');
+    writeFileSync(filePath, 'not-valid-json{{');
+    const result = loadGovernanceHealthHistory(filePath);
+    expect(result.snapshots).toEqual([]);
+  });
+
+  it('returns empty history when snapshots field is missing', () => {
+    const filePath = join(tmpDir, 'bad-schema.json');
+    writeFileSync(
+      filePath,
+      JSON.stringify({ schemaVersion: 1, generatedAt: '...' })
+    );
+    const result = loadGovernanceHealthHistory(filePath);
+    expect(result.snapshots).toEqual([]);
   });
 });

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -48,12 +48,21 @@ import {
 import { computeGovernanceHistoryIntegrity } from './governance-history-integrity';
 import { evaluateGeneratedAtFreshness } from './freshness';
 import { DEFAULT_DEPLOYED_BASE_URL } from './colony-config';
+import {
+  buildHealthReport,
+  type HealthReport,
+  type CycleTimeMetric,
+  type RoleDiversityMetric,
+  type ContestedRateMetric,
+  type CrossRoleReviewMetric,
+} from './check-governance-health';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..', '..');
 const OUTPUT_DIR = join(__dirname, '..', 'public', 'data');
 const OUTPUT_FILE = join(OUTPUT_DIR, 'activity.json');
 const HISTORY_FILE = join(OUTPUT_DIR, 'governance-history.json');
+const HEALTH_HISTORY_FILE = join(OUTPUT_DIR, 'governance-health-history.json');
 const ROADMAP_PATH = join(ROOT_DIR, 'ROADMAP.md');
 const INDEX_HTML_PATH = join(ROOT_DIR, 'web', 'index.html');
 const SITEMAP_PATH = join(ROOT_DIR, 'web', 'public', 'sitemap.xml');
@@ -1988,6 +1997,97 @@ function loadHistory(): GovernanceHistoryArtifact {
   return emptyHistoryArtifact(new Date(0).toISOString());
 }
 
+// ──────────────────────────────────────────────
+// Governance health history (CHAOSS-aligned metrics over time)
+// ──────────────────────────────────────────────
+
+export const HEALTH_HISTORY_SCHEMA_VERSION = 1;
+/** Maximum snapshots retained in governance-health-history.json (~3 months of daily runs). */
+export const HEALTH_HISTORY_MAX_ENTRIES = 90;
+
+export interface GovernanceHealthEntry {
+  timestamp: string;
+  prCycleTime: CycleTimeMetric;
+  roleDiversity: RoleDiversityMetric;
+  contestedDecisionRate: ContestedRateMetric;
+  crossRoleReviewRate: CrossRoleReviewMetric;
+  warningCount: number;
+}
+
+export interface GovernanceHealthHistory {
+  schemaVersion: number;
+  generatedAt: string;
+  /** Ordered oldest-to-newest, capped at HEALTH_HISTORY_MAX_ENTRIES. */
+  snapshots: GovernanceHealthEntry[];
+}
+
+/**
+ * Build a GovernanceHealthEntry from a HealthReport.
+ */
+export function buildGovernanceHealthEntry(
+  report: HealthReport
+): GovernanceHealthEntry {
+  return {
+    timestamp: report.generatedAt,
+    prCycleTime: report.metrics.prCycleTime,
+    roleDiversity: report.metrics.roleDiversity,
+    contestedDecisionRate: report.metrics.contestedDecisionRate,
+    crossRoleReviewRate: report.metrics.crossRoleReviewRate,
+    warningCount: report.warnings.length,
+  };
+}
+
+/**
+ * Append a new entry to the health history, keeping the most recent
+ * HEALTH_HISTORY_MAX_ENTRIES snapshots.
+ */
+export function appendGovernanceHealthEntry(
+  existing: GovernanceHealthEntry[],
+  entry: GovernanceHealthEntry
+): GovernanceHealthEntry[] {
+  const updated = [...existing, entry];
+  if (updated.length > HEALTH_HISTORY_MAX_ENTRIES) {
+    return updated.slice(updated.length - HEALTH_HISTORY_MAX_ENTRIES);
+  }
+  return updated;
+}
+
+/**
+ * Load governance-health-history.json from disk, returning an empty history on
+ * parse failure or missing file.
+ */
+export function loadGovernanceHealthHistory(
+  filePath: string = HEALTH_HISTORY_FILE
+): GovernanceHealthHistory {
+  if (!existsSync(filePath)) {
+    return {
+      schemaVersion: HEALTH_HISTORY_SCHEMA_VERSION,
+      generatedAt: new Date(0).toISOString(),
+      snapshots: [],
+    };
+  }
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'snapshots' in (parsed as object) &&
+      Array.isArray((parsed as GovernanceHealthHistory).snapshots)
+    ) {
+      return parsed as GovernanceHealthHistory;
+    }
+  } catch {
+    // Handled by fallback below.
+  }
+  console.warn('Could not parse governance health history, starting fresh');
+  return {
+    schemaVersion: HEALTH_HISTORY_SCHEMA_VERSION,
+    generatedAt: new Date(0).toISOString(),
+    snapshots: [],
+  };
+}
+
 /**
  * Update the sitemap lastmod date to match the data generation timestamp.
  * Keeps the sitemap file accurate for search engine crawl priority.
@@ -2077,6 +2177,27 @@ async function main(): Promise<void> {
     writeFileSync(HISTORY_FILE, JSON.stringify(updatedHistory, null, 2));
     console.log(
       `Governance snapshot appended (${updatedSnapshots.length} entries, score: ${snapshot.healthScore}, schema: v${updatedHistory.schemaVersion}, completeness: ${updatedHistory.completeness.status})`
+    );
+
+    // Compute and append CHAOSS-aligned health metrics for trend tracking
+    const healthReport = buildHealthReport(data);
+    const healthEntry = buildGovernanceHealthEntry(healthReport);
+    const existingHealth = loadGovernanceHealthHistory();
+    const updatedHealthSnapshots = appendGovernanceHealthEntry(
+      existingHealth.snapshots,
+      healthEntry
+    );
+    const updatedHealthHistory: GovernanceHealthHistory = {
+      schemaVersion: HEALTH_HISTORY_SCHEMA_VERSION,
+      generatedAt: data.generatedAt,
+      snapshots: updatedHealthSnapshots,
+    };
+    writeFileSync(
+      HEALTH_HISTORY_FILE,
+      JSON.stringify(updatedHealthHistory, null, 2)
+    );
+    console.log(
+      `Governance health entry appended (${updatedHealthSnapshots.length} entries, warnings: ${healthEntry.warningCount}, cycleP95: ${healthEntry.prCycleTime.p95 !== null ? (healthEntry.prCycleTime.p95 / 60 / 24).toFixed(1) + 'd' : 'N/A'})`
     );
   } catch (error) {
     console.error('Failed to generate activity data:', error);


### PR DESCRIPTION
## What

Extends `generate-data.ts` to append CHAOSS-aligned governance health metrics to `web/public/data/governance-health-history.json` on each data refresh. This is Phase 1 of #605.

## Why

`check-governance-health.ts` computes four CHAOSS-aligned metrics (PR cycle time, role diversity Gini, contested decision rate, cross-role review rate) but throws them away after each run. Without historical storage, there's no way to answer \"is Colony's governance health improving or regressing?\" — a point score without trend context is a number without meaning.

This PR adds the data layer. Phase 2 (trend sparkline in StructuralHealthPanel) will follow once PR #572 merges.

## Changes

**`web/scripts/generate-data.ts`**
- Imports `buildHealthReport` from `check-governance-health.ts`
- Adds `HEALTH_HISTORY_FILE` constant (`public/data/governance-health-history.json`)
- Exports `GovernanceHealthEntry`, `GovernanceHealthHistory` types
- Exports `buildGovernanceHealthEntry`, `appendGovernanceHealthEntry`, `loadGovernanceHealthHistory` (all pure/testable)
- In `main()`: after writing `governance-history.json`, calls `buildHealthReport(data)`, builds an entry, appends it to the history file (capped at 90 entries)

**`web/scripts/__tests__/generate-data.test.ts`**
- 14 new tests covering: `buildGovernanceHealthEntry` field mapping, `appendGovernanceHealthEntry` (empty, append, cap at 90, order), `loadGovernanceHealthHistory` (missing file, valid parse, corrupt JSON, missing snapshots field)

## Schema

```json
{
  "schemaVersion": 1,
  "generatedAt": "2026-03-08T00:00:00Z",
  "snapshots": [
    {
      "timestamp": "2026-03-08T00:00:00Z",
      "prCycleTime": { "p50": 1440, "p95": 10080, "sampleSize": 42 },
      "roleDiversity": { "uniqueRoles": 7, "giniIndex": 0.35, "topRole": "builder", "topRoleShare": 0.28 },
      "contestedDecisionRate": { "rate": 0.15, "contestedCount": 3, "totalVoted": 20 },
      "crossRoleReviewRate": { "rate": 0.87, "crossRoleCount": 52, "totalReviews": 60 },
      "warningCount": 0
    }
  ]
}
```

## Validation

```bash
cd web
npm run lint        # clean
npm run typecheck   # clean
npm run test -- --run scripts/__tests__/generate-data.test.ts  # 88 passed (14 new)
npm run build       # clean
```

Closes #605