### PR TITLE
feat: add StructuralHealthTrend panel — CHAOSS metric sparklines over time

### DIFF
--- a/web/shared/governance-health-history.ts
+++ b/web/shared/governance-health-history.ts
@@ -2,47 +2,42 @@
  * Schema for governance-health-history.json — CHAOSS-aligned governance health
  * metrics accumulated over time by generate-data.ts.
  *
- * This schema is a frontend mirror of the types defined in generate-data.ts
- * (see GovernanceHealthEntry and GovernanceHealthHistory there). Keep in sync.
+ * This schema is a frontend mirror of GovernanceHealthEntry in generate-data.ts
+ * (introduced in PR #673). Keep in sync.
+ *
+ * The flat `metrics.*` structure matches the shape written by
+ * buildGovernanceHealthEntry in generate-data.ts. Do not re-nest — the
+ * history file would be unreadable by this schema.
  */
 
 export const GOVERNANCE_HEALTH_HISTORY_SCHEMA_VERSION = 1;
 
-export interface CycleTimeMetric {
-  p50: number | null;
-  p95: number | null;
-  sampleSize: number;
-}
-
-export interface RoleDiversityMetric {
-  uniqueRoles: number;
-  giniIndex: number;
-  topRole: string;
-  topRoleShare: number;
-}
-
-export interface ContestedRateMetric {
-  contestedCount: number;
-  totalVoted: number;
-  rate: number;
-}
-
-export interface CrossRoleReviewMetric {
-  crossRoleCount: number;
-  totalReviews: number;
-  rate: number;
-}
-
 /**
  * One periodic snapshot of CHAOSS-aligned governance health metrics.
  * Appended each time generate-data runs; history is capped at 90 entries.
+ *
+ * All time values are in hours. Rate values are 0–1. Null means insufficient
+ * data in the measurement window (e.g. no PRs merged → no cycle time).
  */
 export interface GovernanceHealthEntry {
   timestamp: string;
-  prCycleTime: CycleTimeMetric;
-  roleDiversity: RoleDiversityMetric;
-  contestedDecisionRate: ContestedRateMetric;
-  crossRoleReviewRate: CrossRoleReviewMetric;
+  metrics: {
+    prCycleTimeP50Hours: number | null;
+    prCycleTimeP95Hours: number | null;
+    prCycleTimeSampleSize: number;
+    reviewLatencyP50Hours: number | null;
+    reviewLatencyP95Hours: number | null;
+    reviewLatencySampleSize: number;
+    mergeLatencyP50Hours: number | null;
+    mergeLatencyP95Hours: number | null;
+    mergeLatencySampleSize: number;
+    mergeBacklogDepth: number;
+    roleDiversityGini: number;
+    roleDiversityUniqueRoles: number;
+    contestedDecisionRate: number | null;
+    crossRoleReviewRate: number | null;
+    voterParticipationRate: number | null;
+  };
   warningCount: number;
 }
 

--- a/web/shared/governance-health-history.ts
+++ b/web/shared/governance-health-history.ts
@@ -1,0 +1,70 @@
+/**
+ * Schema for governance-health-history.json — CHAOSS-aligned governance health
+ * metrics accumulated over time by generate-data.ts.
+ *
+ * This schema is a frontend mirror of the types defined in generate-data.ts
+ * (see GovernanceHealthEntry and GovernanceHealthHistory there). Keep in sync.
+ */
+
+export const GOVERNANCE_HEALTH_HISTORY_SCHEMA_VERSION = 1;
+
+export interface CycleTimeMetric {
+  p50: number | null;
+  p95: number | null;
+  sampleSize: number;
+}
+
+export interface RoleDiversityMetric {
+  uniqueRoles: number;
+  giniIndex: number;
+  topRole: string;
+  topRoleShare: number;
+}
+
+export interface ContestedRateMetric {
+  contestedCount: number;
+  totalVoted: number;
+  rate: number;
+}
+
+export interface CrossRoleReviewMetric {
+  crossRoleCount: number;
+  totalReviews: number;
+  rate: number;
+}
+
+/**
+ * One periodic snapshot of CHAOSS-aligned governance health metrics.
+ * Appended each time generate-data runs; history is capped at 90 entries.
+ */
+export interface GovernanceHealthEntry {
+  timestamp: string;
+  prCycleTime: CycleTimeMetric;
+  roleDiversity: RoleDiversityMetric;
+  contestedDecisionRate: ContestedRateMetric;
+  crossRoleReviewRate: CrossRoleReviewMetric;
+  warningCount: number;
+}
+
+/**
+ * governance-health-history.json top-level artifact.
+ */
+export interface GovernanceHealthHistory {
+  schemaVersion: number;
+  generatedAt: string;
+  /** Ordered oldest-to-newest, capped at ~90 entries (3 months of daily runs). */
+  snapshots: GovernanceHealthEntry[];
+}
+
+/**
+ * Parse and validate a raw JSON value as a GovernanceHealthHistory.
+ * Returns null if the input is not a valid history artifact.
+ */
+export function parseGovernanceHealthHistory(
+  raw: unknown
+): GovernanceHealthHistory | null {
+  if (raw === null || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  if (!Array.isArray(obj['snapshots'])) return null;
+  return raw as GovernanceHealthHistory;
+}

--- a/web/src/components/ActivityFeed.tsx
+++ b/web/src/components/ActivityFeed.tsx
@@ -25,7 +25,9 @@ import { CommentList } from './CommentList';
 import { ColonyStory } from './ColonyStory';
 import { ColonyIntelligence } from './ColonyIntelligence';
 import { ColonyLiveMode } from './ColonyLiveMode';
+import { StructuralHealthTrend } from './StructuralHealthTrend';
 import { useGovernanceHistory } from '../hooks/useGovernanceHistory';
+import { useGovernanceHealthHistory } from '../hooks/useGovernanceHealthHistory';
 import { formatTimeAgo } from '../utils/time';
 
 interface ActivityFeedProps {
@@ -52,6 +54,7 @@ export function ActivityFeed({
   onSelectAgent,
 }: ActivityFeedProps): React.ReactElement {
   const { history: governanceHistory } = useGovernanceHistory();
+  const { snapshots: healthSnapshots } = useGovernanceHealthHistory();
   const timeAgo = lastUpdated ? formatTimeAgo(lastUpdated) : 'unknown';
   const statusLabel = getStatusLabel(mode);
   const statusStyles = getStatusStyles(mode);
@@ -321,6 +324,7 @@ export function ActivityFeed({
               </h2>
               <GovernanceHealth data={data} />
               <GovernanceTrend history={governanceHistory} />
+              <StructuralHealthTrend snapshots={healthSnapshots} />
             </section>
           )}
 

--- a/web/src/components/StructuralHealthTrend.test.tsx
+++ b/web/src/components/StructuralHealthTrend.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StructuralHealthTrend } from './StructuralHealthTrend';
+import type { GovernanceHealthEntry } from '../../shared/governance-health-history';
+
+function makeEntry(
+  timestamp: string,
+  overrides: Partial<GovernanceHealthEntry> = {}
+): GovernanceHealthEntry {
+  return {
+    timestamp,
+    prCycleTime: { p50: 1440, p95: 10080, sampleSize: 10 },
+    roleDiversity: {
+      uniqueRoles: 5,
+      giniIndex: 0.3,
+      topRole: 'builder',
+      topRoleShare: 0.4,
+    },
+    contestedDecisionRate: { contestedCount: 2, totalVoted: 10, rate: 0.2 },
+    crossRoleReviewRate: { crossRoleCount: 8, totalReviews: 10, rate: 0.8 },
+    warningCount: 0,
+    ...overrides,
+  };
+}
+
+describe('StructuralHealthTrend', () => {
+  it('returns null with empty snapshots', () => {
+    const { container } = render(<StructuralHealthTrend snapshots={[]} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('returns null with a single snapshot (insufficient for trend)', () => {
+    const { container } = render(
+      <StructuralHealthTrend snapshots={[makeEntry('2026-03-01T00:00:00Z')]} />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders structural health trends with 2+ snapshots', () => {
+    const snapshots = [
+      makeEntry('2026-03-01T00:00:00Z'),
+      makeEntry('2026-03-08T00:00:00Z'),
+    ];
+
+    render(<StructuralHealthTrend snapshots={snapshots} />);
+
+    expect(screen.getByText('Structural Health Trends')).toBeInTheDocument();
+    expect(screen.getByText('PR Cycle Time (p95)')).toBeInTheDocument();
+    expect(screen.getByText('Role Diversity (Gini)')).toBeInTheDocument();
+    expect(screen.getByText('Contested Decision Rate')).toBeInTheDocument();
+    expect(screen.getByText('Cross-Role Review Rate')).toBeInTheDocument();
+  });
+
+  it('shows snapshot count', () => {
+    const snapshots = [
+      makeEntry('2026-03-01T00:00:00Z'),
+      makeEntry('2026-03-08T00:00:00Z'),
+    ];
+
+    render(<StructuralHealthTrend snapshots={snapshots} />);
+
+    expect(screen.getByText(/2 snapshots/)).toBeInTheDocument();
+  });
+
+  it('shows sparklines via SVG elements', () => {
+    const snapshots = [
+      makeEntry('2026-03-01T00:00:00Z', {
+        prCycleTime: { p50: 720, p95: 7200, sampleSize: 5 },
+      }),
+      makeEntry('2026-03-08T00:00:00Z', {
+        prCycleTime: { p50: 1440, p95: 10080, sampleSize: 10 },
+      }),
+    ];
+
+    const { container } = render(
+      <StructuralHealthTrend snapshots={snapshots} />
+    );
+
+    const svgs = container.querySelectorAll('svg');
+    // One sparkline per metric that has 2+ data points (all 4)
+    expect(svgs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders aria-label on sparklines', () => {
+    const snapshots = [
+      makeEntry('2026-03-01T00:00:00Z'),
+      makeEntry('2026-03-08T00:00:00Z'),
+    ];
+
+    render(<StructuralHealthTrend snapshots={snapshots} />);
+
+    expect(
+      screen.getByRole('img', { name: /PR Cycle Time .p95. trend/i })
+    ).toBeInTheDocument();
+  });
+
+  it('skips metrics with null values gracefully', () => {
+    const snapshots = [
+      makeEntry('2026-03-01T00:00:00Z', {
+        prCycleTime: { p50: null, p95: null, sampleSize: 0 },
+      }),
+      makeEntry('2026-03-08T00:00:00Z', {
+        prCycleTime: { p50: null, p95: null, sampleSize: 0 },
+      }),
+    ];
+
+    render(<StructuralHealthTrend snapshots={snapshots} />);
+
+    // Component renders (other metrics still have data)
+    expect(screen.getByText('Structural Health Trends')).toBeInTheDocument();
+    // PR Cycle Time card shows "Insufficient data" since all values are null
+    expect(screen.getByText(/Insufficient data/)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/StructuralHealthTrend.test.tsx
+++ b/web/src/components/StructuralHealthTrend.test.tsx
@@ -5,21 +5,29 @@ import type { GovernanceHealthEntry } from '../../shared/governance-health-histo
 
 function makeEntry(
   timestamp: string,
-  overrides: Partial<GovernanceHealthEntry> = {}
+  metricsOverrides: Partial<GovernanceHealthEntry['metrics']> = {}
 ): GovernanceHealthEntry {
   return {
     timestamp,
-    prCycleTime: { p50: 1440, p95: 10080, sampleSize: 10 },
-    roleDiversity: {
-      uniqueRoles: 5,
-      giniIndex: 0.3,
-      topRole: 'builder',
-      topRoleShare: 0.4,
+    metrics: {
+      prCycleTimeP50Hours: 24,
+      prCycleTimeP95Hours: 168,
+      prCycleTimeSampleSize: 10,
+      reviewLatencyP50Hours: 6,
+      reviewLatencyP95Hours: 24,
+      reviewLatencySampleSize: 10,
+      mergeLatencyP50Hours: 2,
+      mergeLatencyP95Hours: 8,
+      mergeLatencySampleSize: 10,
+      mergeBacklogDepth: 3,
+      roleDiversityGini: 0.3,
+      roleDiversityUniqueRoles: 5,
+      contestedDecisionRate: 0.2,
+      crossRoleReviewRate: 0.8,
+      voterParticipationRate: 0.75,
+      ...metricsOverrides,
     },
-    contestedDecisionRate: { contestedCount: 2, totalVoted: 10, rate: 0.2 },
-    crossRoleReviewRate: { crossRoleCount: 8, totalReviews: 10, rate: 0.8 },
     warningCount: 0,
-    ...overrides,
   };
 }
 
@@ -65,10 +73,14 @@ describe('StructuralHealthTrend', () => {
   it('shows sparklines via SVG elements', () => {
     const snapshots = [
       makeEntry('2026-03-01T00:00:00Z', {
-        prCycleTime: { p50: 720, p95: 7200, sampleSize: 5 },
+        prCycleTimeP50Hours: 12,
+        prCycleTimeP95Hours: 120,
+        prCycleTimeSampleSize: 5,
       }),
       makeEntry('2026-03-08T00:00:00Z', {
-        prCycleTime: { p50: 1440, p95: 10080, sampleSize: 10 },
+        prCycleTimeP50Hours: 24,
+        prCycleTimeP95Hours: 168,
+        prCycleTimeSampleSize: 10,
       }),
     ];
 
@@ -97,10 +109,14 @@ describe('StructuralHealthTrend', () => {
   it('skips metrics with null values gracefully', () => {
     const snapshots = [
       makeEntry('2026-03-01T00:00:00Z', {
-        prCycleTime: { p50: null, p95: null, sampleSize: 0 },
+        prCycleTimeP50Hours: null,
+        prCycleTimeP95Hours: null,
+        prCycleTimeSampleSize: 0,
       }),
       makeEntry('2026-03-08T00:00:00Z', {
-        prCycleTime: { p50: null, p95: null, sampleSize: 0 },
+        prCycleTimeP50Hours: null,
+        prCycleTimeP95Hours: null,
+        prCycleTimeSampleSize: 0,
       }),
     ];
 

--- a/web/src/components/StructuralHealthTrend.tsx
+++ b/web/src/components/StructuralHealthTrend.tsx
@@ -29,8 +29,7 @@ const METRICS: MetricDef[] = [
   {
     key: 'cycleTimeP95',
     label: 'PR Cycle Time (p95)',
-    extract: (s) =>
-      s.prCycleTime.p95 !== null ? s.prCycleTime.p95 / 60 : null,
+    extract: (s) => s.metrics.prCycleTimeP95Hours,
     direction: 'lower-is-better',
     formatValue: (v) => `${v.toFixed(0)}h`,
     strokeClass: 'text-sky-500 dark:text-sky-400',
@@ -40,7 +39,7 @@ const METRICS: MetricDef[] = [
   {
     key: 'giniIndex',
     label: 'Role Diversity (Gini)',
-    extract: (s) => s.roleDiversity.giniIndex,
+    extract: (s) => s.metrics.roleDiversityGini,
     direction: 'lower-is-better',
     formatValue: (v) => v.toFixed(2),
     strokeClass: 'text-violet-500 dark:text-violet-400',
@@ -51,8 +50,8 @@ const METRICS: MetricDef[] = [
     key: 'contestedRate',
     label: 'Contested Decision Rate',
     extract: (s) =>
-      s.contestedDecisionRate.totalVoted > 0
-        ? s.contestedDecisionRate.rate * 100
+      s.metrics.contestedDecisionRate !== null
+        ? s.metrics.contestedDecisionRate * 100
         : null,
     direction: 'higher-is-better',
     formatValue: (v) => `${v.toFixed(0)}%`,
@@ -64,8 +63,8 @@ const METRICS: MetricDef[] = [
     key: 'crossRoleRate',
     label: 'Cross-Role Review Rate',
     extract: (s) =>
-      s.crossRoleReviewRate.totalReviews > 0
-        ? s.crossRoleReviewRate.rate * 100
+      s.metrics.crossRoleReviewRate !== null
+        ? s.metrics.crossRoleReviewRate * 100
         : null,
     direction: 'higher-is-better',
     formatValue: (v) => `${v.toFixed(0)}%`,

--- a/web/src/components/StructuralHealthTrend.tsx
+++ b/web/src/components/StructuralHealthTrend.tsx
@@ -1,0 +1,306 @@
+import { useMemo } from 'react';
+import type { GovernanceHealthEntry } from '../../shared/governance-health-history.ts';
+
+interface StructuralHealthTrendProps {
+  snapshots: GovernanceHealthEntry[];
+}
+
+interface DataPoint {
+  date: string;
+  value: number;
+}
+
+interface MetricDef {
+  key: string;
+  label: string;
+  extract: (s: GovernanceHealthEntry) => number | null;
+  /**
+   * "higher-is-better" or "lower-is-better" controls whether an upward
+   * trend indicator is rendered green (improving) or red (worsening).
+   */
+  direction: 'higher-is-better' | 'lower-is-better';
+  formatValue: (v: number) => string;
+  strokeClass: string;
+  fillClass: string;
+  dotClass: string;
+}
+
+const METRICS: MetricDef[] = [
+  {
+    key: 'cycleTimeP95',
+    label: 'PR Cycle Time (p95)',
+    extract: (s) =>
+      s.prCycleTime.p95 !== null ? s.prCycleTime.p95 / 60 : null,
+    direction: 'lower-is-better',
+    formatValue: (v) => `${v.toFixed(0)}h`,
+    strokeClass: 'text-sky-500 dark:text-sky-400',
+    fillClass: 'text-sky-200/40 dark:text-sky-800/30',
+    dotClass: 'text-sky-600 dark:text-sky-300',
+  },
+  {
+    key: 'giniIndex',
+    label: 'Role Diversity (Gini)',
+    extract: (s) => s.roleDiversity.giniIndex,
+    direction: 'lower-is-better',
+    formatValue: (v) => v.toFixed(2),
+    strokeClass: 'text-violet-500 dark:text-violet-400',
+    fillClass: 'text-violet-200/40 dark:text-violet-800/30',
+    dotClass: 'text-violet-600 dark:text-violet-300',
+  },
+  {
+    key: 'contestedRate',
+    label: 'Contested Decision Rate',
+    extract: (s) =>
+      s.contestedDecisionRate.totalVoted > 0
+        ? s.contestedDecisionRate.rate * 100
+        : null,
+    direction: 'higher-is-better',
+    formatValue: (v) => `${v.toFixed(0)}%`,
+    strokeClass: 'text-amber-500 dark:text-amber-400',
+    fillClass: 'text-amber-200/40 dark:text-amber-800/30',
+    dotClass: 'text-amber-600 dark:text-amber-300',
+  },
+  {
+    key: 'crossRoleRate',
+    label: 'Cross-Role Review Rate',
+    extract: (s) =>
+      s.crossRoleReviewRate.totalReviews > 0
+        ? s.crossRoleReviewRate.rate * 100
+        : null,
+    direction: 'higher-is-better',
+    formatValue: (v) => `${v.toFixed(0)}%`,
+    strokeClass: 'text-emerald-500 dark:text-emerald-400',
+    fillClass: 'text-emerald-200/40 dark:text-emerald-800/30',
+    dotClass: 'text-emerald-600 dark:text-emerald-300',
+  },
+];
+
+/**
+ * Renders trend sparklines for the four CHAOSS-aligned governance health
+ * metrics stored in governance-health-history.json (written by generate-data.ts
+ * after PR #612 merges).
+ *
+ * Designed to complement GovernanceTrend (which shows the high-level health
+ * score from governance-history.json) — this panel shows the underlying
+ * structural metrics over time.
+ *
+ * Returns null when fewer than 2 snapshots are available.
+ */
+export function StructuralHealthTrend({
+  snapshots,
+}: StructuralHealthTrendProps): React.ReactElement | null {
+  const metricData = useMemo(
+    () =>
+      METRICS.map((metric) => ({
+        metric,
+        points: toDataPoints(snapshots, metric.extract),
+      })),
+    [snapshots]
+  );
+
+  // Need at least 2 points to show a meaningful trend
+  const hasData = metricData.some((d) => d.points.length >= 2);
+  if (!hasData) return null;
+
+  return (
+    <div
+      className="pt-3 mt-3 border-t border-amber-200/50 dark:border-neutral-600/50"
+      aria-label="CHAOSS governance health metric trends"
+    >
+      <p className="text-xs font-semibold text-amber-700 dark:text-amber-300 mb-2">
+        Structural Health Trends
+      </p>
+      <div
+        className="grid grid-cols-1 gap-3 sm:grid-cols-2"
+        role="group"
+        aria-label="CHAOSS-aligned metric sparklines"
+      >
+        {metricData.map(({ metric, points }) => (
+          <MetricCard key={metric.key} metric={metric} points={points} />
+        ))}
+      </div>
+      <p className="text-xs text-amber-500 dark:text-amber-500 mt-2">
+        {snapshots.length} snapshot{snapshots.length !== 1 ? 's' : ''} ·
+        CHAOSS-aligned metrics
+      </p>
+    </div>
+  );
+}
+
+function MetricCard({
+  metric,
+  points,
+}: {
+  metric: MetricDef;
+  points: DataPoint[];
+}): React.ReactElement {
+  const current = points.length > 0 ? points[points.length - 1].value : null;
+  const trendDir =
+    points.length >= 2 ? getTrendDirection(points, metric.direction) : null;
+
+  const trendArrow: Record<'up' | 'down' | 'flat', string> = {
+    up: '\u2191',
+    down: '\u2193',
+    flat: '\u2192',
+  };
+  const trendColor: Record<'improving' | 'stable' | 'worsening', string> = {
+    improving: 'text-green-600 dark:text-green-400',
+    stable: 'text-blue-600 dark:text-blue-400',
+    worsening: 'text-red-600 dark:text-red-400',
+  };
+
+  return (
+    <div
+      className="space-y-1"
+      aria-label={`${metric.label} structural health trend`}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-neutral-700 dark:text-neutral-300">
+          {metric.label}
+        </span>
+        <span className="flex items-center gap-1">
+          {current !== null && (
+            <span className="text-xs font-mono text-neutral-500 dark:text-neutral-400">
+              {metric.formatValue(current)}
+            </span>
+          )}
+          {trendDir && (
+            <span
+              className={`text-xs ${trendColor[trendDir.sentiment]}`}
+              aria-label={`${metric.label} trend: ${trendDir.sentiment}`}
+            >
+              {trendArrow[trendDir.arrow]}
+            </span>
+          )}
+        </span>
+      </div>
+      {points.length >= 2 ? (
+        <Sparkline
+          data={points}
+          ariaLabel={`${metric.label} trend over ${points.length} data points`}
+          strokeClass={metric.strokeClass}
+          fillClass={metric.fillClass}
+          dotClass={metric.dotClass}
+        />
+      ) : (
+        <p className="text-xs text-neutral-400 dark:text-neutral-500 italic">
+          Insufficient data
+        </p>
+      )}
+    </div>
+  );
+}
+
+function getTrendDirection(
+  points: DataPoint[],
+  direction: MetricDef['direction']
+): {
+  arrow: 'up' | 'down' | 'flat';
+  sentiment: 'improving' | 'stable' | 'worsening';
+} {
+  const first = points[0].value;
+  const last = points[points.length - 1].value;
+  const relativeChange = first !== 0 ? (last - first) / Math.abs(first) : 0;
+
+  // Threshold: 5% relative change to avoid noise
+  const THRESHOLD = 0.05;
+
+  if (relativeChange > THRESHOLD) {
+    return {
+      arrow: 'up',
+      sentiment: direction === 'higher-is-better' ? 'improving' : 'worsening',
+    };
+  }
+  if (relativeChange < -THRESHOLD) {
+    return {
+      arrow: 'down',
+      sentiment: direction === 'lower-is-better' ? 'improving' : 'worsening',
+    };
+  }
+  return { arrow: 'flat', sentiment: 'stable' };
+}
+
+function toDataPoints(
+  snapshots: GovernanceHealthEntry[],
+  extract: (s: GovernanceHealthEntry) => number | null
+): DataPoint[] {
+  const points: DataPoint[] = [];
+  for (const s of snapshots) {
+    const value = extract(s);
+    if (value !== null) {
+      points.push({ date: s.timestamp.slice(0, 10), value });
+    }
+  }
+  return points;
+}
+
+/** Compact SVG sparkline — no charting library needed. */
+function Sparkline({
+  data,
+  ariaLabel,
+  strokeClass,
+  fillClass,
+  dotClass,
+}: {
+  data: DataPoint[];
+  ariaLabel: string;
+  strokeClass: string;
+  fillClass: string;
+  dotClass: string;
+}): React.ReactElement {
+  const width = 120;
+  const height = 24;
+  const padding = 2;
+
+  const values = data.map((d) => d.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+
+  const points = values.map((v, i) => {
+    const x =
+      padding + (i / Math.max(values.length - 1, 1)) * (width - 2 * padding);
+    const y = height - padding - ((v - min) / range) * (height - 2 * padding);
+    return `${x},${y}`;
+  });
+
+  const pathD = `M ${points.join(' L ')}`;
+  const fillD = `${pathD} L ${width - padding},${height - padding} L ${padding},${height - padding} Z`;
+  const lastX =
+    padding +
+    ((values.length - 1) / Math.max(values.length - 1, 1)) *
+      (width - 2 * padding);
+  const lastY =
+    height -
+    padding -
+    ((values[values.length - 1] - min) / range) * (height - 2 * padding);
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label={ariaLabel}
+      className="w-full max-w-[120px]"
+    >
+      <path d={fillD} fill="currentColor" className={fillClass} />
+      <path
+        d={pathD}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={strokeClass}
+      />
+      <circle
+        cx={lastX}
+        cy={lastY}
+        r={1.5}
+        fill="currentColor"
+        className={dotClass}
+      />
+    </svg>
+  );
+}

--- a/web/src/hooks/useGovernanceHealthHistory.test.ts
+++ b/web/src/hooks/useGovernanceHealthHistory.test.ts
@@ -9,15 +9,23 @@ import type {
 function makeEntry(timestamp: string): GovernanceHealthEntry {
   return {
     timestamp,
-    prCycleTime: { p50: 1440, p95: 10080, sampleSize: 10 },
-    roleDiversity: {
-      uniqueRoles: 5,
-      giniIndex: 0.3,
-      topRole: 'builder',
-      topRoleShare: 0.4,
+    metrics: {
+      prCycleTimeP50Hours: 24,
+      prCycleTimeP95Hours: 168,
+      prCycleTimeSampleSize: 10,
+      reviewLatencyP50Hours: 6,
+      reviewLatencyP95Hours: 24,
+      reviewLatencySampleSize: 10,
+      mergeLatencyP50Hours: 2,
+      mergeLatencyP95Hours: 8,
+      mergeLatencySampleSize: 10,
+      mergeBacklogDepth: 3,
+      roleDiversityGini: 0.3,
+      roleDiversityUniqueRoles: 5,
+      contestedDecisionRate: 0.2,
+      crossRoleReviewRate: 0.8,
+      voterParticipationRate: 0.75,
     },
-    contestedDecisionRate: { contestedCount: 2, totalVoted: 10, rate: 0.2 },
-    crossRoleReviewRate: { crossRoleCount: 8, totalReviews: 10, rate: 0.8 },
     warningCount: 0,
   };
 }
@@ -52,8 +60,8 @@ describe('useGovernanceHealthHistory', () => {
 
     expect(result.current.snapshots).toHaveLength(2);
     expect(result.current.snapshots[0].timestamp).toBe('2026-03-07T00:00:00Z');
-    expect(result.current.snapshots[0].prCycleTime.p95).toBe(10080);
-    expect(result.current.snapshots[0].roleDiversity.giniIndex).toBe(0.3);
+    expect(result.current.snapshots[0].metrics.prCycleTimeP95Hours).toBe(168);
+    expect(result.current.snapshots[0].metrics.roleDiversityGini).toBe(0.3);
   });
 
   it('returns empty array when file does not exist (404)', async () => {

--- a/web/src/hooks/useGovernanceHealthHistory.test.ts
+++ b/web/src/hooks/useGovernanceHealthHistory.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useGovernanceHealthHistory } from './useGovernanceHealthHistory';
+import type {
+  GovernanceHealthHistory,
+  GovernanceHealthEntry,
+} from '../../shared/governance-health-history';
+
+function makeEntry(timestamp: string): GovernanceHealthEntry {
+  return {
+    timestamp,
+    prCycleTime: { p50: 1440, p95: 10080, sampleSize: 10 },
+    roleDiversity: {
+      uniqueRoles: 5,
+      giniIndex: 0.3,
+      topRole: 'builder',
+      topRoleShare: 0.4,
+    },
+    contestedDecisionRate: { contestedCount: 2, totalVoted: 10, rate: 0.2 },
+    crossRoleReviewRate: { crossRoleCount: 8, totalReviews: 10, rate: 0.8 },
+    warningCount: 0,
+  };
+}
+
+const mockHistory: GovernanceHealthHistory = {
+  schemaVersion: 1,
+  generatedAt: '2026-03-08T00:00:00Z',
+  snapshots: [
+    makeEntry('2026-03-07T00:00:00Z'),
+    makeEntry('2026-03-08T00:00:00Z'),
+  ],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useGovernanceHealthHistory', () => {
+  it('loads snapshots from governance-health-history.json', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockHistory,
+    } as Response);
+
+    const { result } = renderHook(() => useGovernanceHealthHistory());
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.snapshots).toHaveLength(2);
+    expect(result.current.snapshots[0].timestamp).toBe('2026-03-07T00:00:00Z');
+    expect(result.current.snapshots[0].prCycleTime.p95).toBe(10080);
+    expect(result.current.snapshots[0].roleDiversity.giniIndex).toBe(0.3);
+  });
+
+  it('returns empty array when file does not exist (404)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as Response);
+
+    const { result } = renderHook(() => useGovernanceHealthHistory());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.snapshots).toEqual([]);
+  });
+
+  it('returns empty array on network error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(
+      new Error('Network error')
+    );
+
+    const { result } = renderHook(() => useGovernanceHealthHistory());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.snapshots).toEqual([]);
+  });
+
+  it('returns empty array when response has no snapshots field', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ schemaVersion: 1, generatedAt: '...' }),
+    } as Response);
+
+    const { result } = renderHook(() => useGovernanceHealthHistory());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.snapshots).toEqual([]);
+  });
+});

--- a/web/src/hooks/useGovernanceHealthHistory.ts
+++ b/web/src/hooks/useGovernanceHealthHistory.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+import {
+  parseGovernanceHealthHistory,
+  type GovernanceHealthEntry,
+} from '../../shared/governance-health-history.ts';
+
+const BASE_URL = import.meta.env.BASE_URL ?? '/';
+
+export interface UseGovernanceHealthHistoryResult {
+  snapshots: GovernanceHealthEntry[];
+  loading: boolean;
+}
+
+/**
+ * Load CHAOSS-aligned governance health history from the static data directory.
+ * Returns an empty array if the file doesn't exist yet (first deploy before
+ * any data runs with PR #612's history-appending logic).
+ */
+export function useGovernanceHealthHistory(): UseGovernanceHealthHistoryResult {
+  const [snapshots, setSnapshots] = useState<GovernanceHealthEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load(): Promise<void> {
+      try {
+        const res = await fetch(
+          `${BASE_URL}data/governance-health-history.json`
+        );
+        if (!res.ok) {
+          // File doesn't exist yet — expected on first deploy
+          if (!cancelled) setSnapshots([]);
+          return;
+        }
+        const data: unknown = await res.json();
+        const history = parseGovernanceHealthHistory(data);
+        if (!cancelled) {
+          setSnapshots(history?.snapshots ?? []);
+        }
+      } catch {
+        if (!cancelled) setSnapshots([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return (): void => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { snapshots, loading };
+}


### PR DESCRIPTION
## Summary

Implements Phase 2 (dashboard trend line) of #605.

Phase 1 (PR #612 — periodic CHAOSS health metrics written to `governance-health-history.json`) is approved and awaiting merge. This PR adds the frontend visualization layer so the trend panel is ready the moment that data starts accumulating.

## What changed

**`web/shared/governance-health-history.ts`** — frontend schema mirror of the types PR #612 exports from `generate-data.ts`. Defines `GovernanceHealthEntry`, `GovernanceHealthHistory`, and a `parseGovernanceHealthHistory` validator.

**`web/src/hooks/useGovernanceHealthHistory.ts`** — fetch hook that loads `governance-health-history.json`. Returns empty array if the file doesn't exist yet (first deploy before any history), matching the `useGovernanceHistory` graceful-fallback pattern.

**`web/src/components/StructuralHealthTrend.tsx`** — 2×2 grid of compact SVG sparklines for the four CHAOSS-aligned metrics:
- PR Cycle Time (p95) — lower is better
- Role Diversity (Gini index) — lower is better (more equal)
- Contested Decision Rate — higher is better (vigorous debate)
- Cross-Role Review Rate — higher is better (diverse reviews)

Each card shows the current value, a directional trend arrow that accounts for whether higher or lower is better, and an accessible sparkline. Returns `null` when fewer than 2 snapshots are available.

**`web/src/components/ActivityFeed.tsx`** — adds `StructuralHealthTrend` below `GovernanceTrend` in the Governance Health section.

## Why this complements GovernanceTrend

`GovernanceTrend` (existing) shows the composite health score trend from `governance-history.json`. `StructuralHealthTrend` (new) shows the underlying CHAOSS structural metrics from `governance-health-history.json`. They answer different questions:

- "Is Colony getting healthier overall?" → GovernanceTrend
- "Is our PR cycle time improving? Is role diversity balanced?" → StructuralHealthTrend

## Validation

```bash
cd web
npm run lint        # clean
npm run typecheck   # clean
npm run test -- --run  # 1002/1002 passed (11 new tests)
npm run build       # clean
```

Closes #605 (Phase 2; Phase 1 is PR #612)