### PR TITLE
feat: split governance health PR latency

### DIFF
--- a/web/scripts/__tests__/check-governance-health.test.ts
+++ b/web/scripts/__tests__/check-governance-health.test.ts
@@ -10,8 +10,11 @@ import {
   computeCrossRoleReviewRate,
   computeDataWindowDays,
   computeGini,
+  computeMergeBacklogDepth,
+  computeMergeLatency,
   computeContestedRate,
   computePrCycleTime,
+  computeReviewLatency,
   computeRoleDiversity,
   extractRole,
   percentile,
@@ -217,6 +220,106 @@ describe('computePrCycleTime', () => {
     });
     const result = computePrCycleTime([pr]);
     expect(result.sampleSize).toBe(0);
+  });
+});
+
+describe('computeReviewLatency', () => {
+  it('computes open-to-first-approval latency for merged PRs', () => {
+    const prs = [
+      makePr({
+        number: 1,
+        createdAt: '2026-02-01T00:00:00Z',
+        firstApprovalAt: '2026-02-01T12:00:00Z',
+      }),
+      makePr({
+        number: 2,
+        createdAt: '2026-02-01T00:00:00Z',
+        firstApprovalAt: '2026-02-02T00:00:00Z',
+      }),
+    ];
+
+    const result = computeReviewLatency(prs);
+    expect(result.sampleSize).toBe(2);
+    expect(result.p50).toBe(720);
+    expect(result.p95).toBe(1440);
+  });
+
+  it('ignores PRs without approval timestamps', () => {
+    const result = computeReviewLatency([makePr({ firstApprovalAt: null })]);
+    expect(result.sampleSize).toBe(0);
+    expect(result.p50).toBeNull();
+  });
+});
+
+describe('computeMergeLatency', () => {
+  it('computes first-approval-to-merge latency for merged PRs', () => {
+    const prs = [
+      makePr({
+        number: 1,
+        firstApprovalAt: '2026-02-01T12:00:00Z',
+        mergedAt: '2026-02-02T00:00:00Z',
+      }),
+      makePr({
+        number: 2,
+        firstApprovalAt: '2026-02-01T06:00:00Z',
+        mergedAt: '2026-02-03T00:00:00Z',
+      }),
+    ];
+
+    const result = computeMergeLatency(prs);
+    expect(result.sampleSize).toBe(2);
+    expect(result.p50).toBe(720);
+    expect(result.p95).toBe(2520);
+  });
+
+  it('ignores negative approval-to-merge durations', () => {
+    const result = computeMergeLatency([
+      makePr({
+        firstApprovalAt: '2026-02-03T00:00:00Z',
+        mergedAt: '2026-02-02T00:00:00Z',
+      }),
+    ]);
+    expect(result.sampleSize).toBe(0);
+  });
+});
+
+describe('computeMergeBacklogDepth', () => {
+  it('counts approved open PRs and reports the oldest age in hours', () => {
+    const result = computeMergeBacklogDepth(
+      [
+        makePr({
+          number: 1,
+          state: 'open',
+          mergedAt: null,
+          firstApprovalAt: '2026-02-02T00:00:00Z',
+        }),
+        makePr({
+          number: 2,
+          state: 'open',
+          mergedAt: null,
+          firstApprovalAt: '2026-02-04T00:00:00Z',
+        }),
+        makePr({
+          number: 3,
+          state: 'open',
+          mergedAt: null,
+          firstApprovalAt: null,
+        }),
+      ],
+      '2026-02-05T00:00:00Z'
+    );
+
+    expect(result.depth).toBe(2);
+    expect(result.eldestApprovedHours).toBe(72);
+  });
+
+  it('returns null eldest age when no approved open PRs exist', () => {
+    const result = computeMergeBacklogDepth(
+      [makePr({ state: 'open', mergedAt: null, firstApprovalAt: null })],
+      '2026-02-05T00:00:00Z'
+    );
+    expect(result.depth).toBe(0);
+    expect(result.eldestApprovedHours).toBeNull();
   });
 });
 
@@ -434,6 +537,9 @@ describe('buildHealthReport', () => {
     expect(report.generatedAt).toBeTruthy();
     expect(report.dataWindowDays).toBe(0);
     expect(report.metrics.prCycleTime).toBeDefined();
+    expect(report.metrics.reviewLatency).toBeDefined();
+    expect(report.metrics.mergeLatency).toBeDefined();
+    expect(report.metrics.mergeBacklogDepth).toBeDefined();
     expect(report.metrics.roleDiversity).toBeDefined();
     expect(report.metrics.contestedDecisionRate).toBeDefined();
     expect(report.metrics.crossRoleReviewRate).toBeDefined();
@@ -556,6 +662,38 @@ describe('buildHealthReport', () => {
     expect(
       report.warnings.some((w) => w.includes('Contested decision rate'))
     ).toBe(false);
+  });
+
+  it('emits merge latency warning when p95 exceeds 48 hours', () => {
+    const prs = Array.from({ length: 3 }, (_, i) =>
+      makePr({
+        number: i + 1,
+        firstApprovalAt: '2026-02-01T00:00:00Z',
+        mergedAt: '2026-02-04T00:00:00Z',
+      })
+    );
+    const report = buildHealthReport(minimalData({ pullRequests: prs }));
+    expect(report.warnings.some((w) => w.includes('Merge latency'))).toBe(true);
+  });
+
+  it('emits merge backlog warning when approved open PR depth exceeds threshold', () => {
+    const prs = Array.from({ length: 11 }, (_, i) =>
+      makePr({
+        number: i + 1,
+        state: 'open',
+        mergedAt: null,
+        firstApprovalAt: '2026-02-10T00:00:00Z',
+      })
+    );
+    const report = buildHealthReport(
+      minimalData({
+        generatedAt: '2026-02-14T01:00:00Z',
+        pullRequests: prs,
+      })
+    );
+    expect(report.warnings.some((w) => w.includes('Merge backlog depth'))).toBe(
+      true
+    );
   });
 });
 

--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -20,6 +20,7 @@ import {
   deduplicateAgents,
   extractPhaseTransitions,
   filterAndMapProposals,
+  enrichPullRequestsWithApprovalTimes,
   type GitHubCommit,
   type GitHubEvent,
   type GitHubTimelineEvent,
@@ -373,6 +374,67 @@ describe('mapPullRequests', () => {
     expect(result.pullRequests).toHaveLength(20);
     expect(result.pullRequests[0].number).toBe(20);
     expect(result.pullRequests[19].number).toBe(1);
+  });
+});
+
+describe('enrichPullRequestsWithApprovalTimes', () => {
+  it('enriches open PRs and only the most recent merged PRs', async () => {
+    const pullRequests: PullRequest[] = [
+      {
+        number: 1,
+        title: 'Open PR',
+        state: 'open',
+        author: 'user1',
+        createdAt: '2026-02-10T00:00:00Z',
+      },
+      ...Array.from({ length: 25 }, (_, i) => ({
+        number: i + 2,
+        title: `Merged PR ${i + 2}`,
+        state: 'merged' as const,
+        author: 'user2',
+        createdAt: '2026-02-01T00:00:00Z',
+        mergedAt: `2026-02-${String(25 - i).padStart(2, '0')}T00:00:00Z`,
+      })),
+    ];
+
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+        const prNumber = Number(url.match(/pulls\/(\d+)\/reviews/)?.[1] ?? 0);
+
+        return new Response(
+          JSON.stringify([
+            {
+              state: 'APPROVED',
+              submitted_at: `2026-02-${String((prNumber % 28) + 1).padStart(2, '0')}T12:00:00Z`,
+            },
+          ]),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        );
+      });
+
+    await enrichPullRequestsWithApprovalTimes(
+      'hivemoot',
+      'colony',
+      pullRequests
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(21);
+    expect(pullRequests[0].firstApprovalAt).toBeTruthy();
+
+    const enrichedMerged = pullRequests.filter(
+      (pr) => pr.state === 'merged' && pr.firstApprovalAt
+    );
+    expect(enrichedMerged).toHaveLength(20);
+    expect(
+      pullRequests.find((pr) => pr.number === 26)?.firstApprovalAt
+    ).toBeFalsy();
   });
 });
 

--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -1,12 +1,15 @@
 /**
  * Governance health checker — CLI script.
  *
- * Reads activity.json and computes four CHAOSS-aligned metrics that are
- * not covered by the existing dashboard utilities:
+ * Reads activity.json and computes governance throughput and collaboration
+ * metrics that are not covered by the existing dashboard utilities:
  *   1. PR cycle time (p50/p95) — time from PR opened to merged
- *   2. Role diversity index — Gini coefficient of proposal authorship
- *   3. Contested decision rate — proposals with any 👎 / total voted
- *   4. Cross-role review rate — reviews where reviewer role ≠ PR author role
+ *   2. Review latency (p50/p95) — time from PR opened to first approval
+ *   3. Merge latency (p50/p95) — time from first approval to merge
+ *   4. Merge backlog depth — approved-but-unmerged open PRs
+ *   5. Role diversity index — Gini coefficient of proposal authorship
+ *   6. Contested decision rate — proposals with any 👎 / total voted
+ *   7. Cross-role review rate — reviews where reviewer role ≠ PR author role
  *
  * Usage:
  *   npm run check-governance-health
@@ -44,6 +47,15 @@ export interface CycleTimeMetric {
   p95: number | null;
   /** Number of merged PRs in the sample */
   sampleSize: number;
+}
+
+export type LatencyMetric = CycleTimeMetric;
+
+export interface MergeBacklogMetric {
+  /** Number of open PRs that have already received a first approval */
+  depth: number;
+  /** Age in hours of the oldest approved-but-unmerged PR, or null if none */
+  eldestApprovedHours: number | null;
 }
 
 export interface RoleDiversityMetric {
@@ -88,6 +100,9 @@ export interface HealthReport {
   dataWindowDays: number;
   metrics: {
     prCycleTime: CycleTimeMetric;
+    reviewLatency: LatencyMetric;
+    mergeLatency: LatencyMetric;
+    mergeBacklogDepth: MergeBacklogMetric;
     roleDiversity: RoleDiversityMetric;
     contestedDecisionRate: ContestedRateMetric;
     crossRoleReviewRate: CrossRoleReviewMetric;
@@ -143,22 +158,53 @@ export function computeGini(values: number[]): number {
 export function computePrCycleTime(
   pullRequests: PullRequest[]
 ): CycleTimeMetric {
-  const durations = pullRequests
-    .filter((pr) => pr.state === 'merged' && pr.mergedAt && pr.createdAt)
-    .map((pr) => {
-      const created = new Date(pr.createdAt).getTime();
-      // mergedAt is guaranteed non-null by the filter above
-      const mergedAt = pr.mergedAt ?? pr.createdAt;
-      const merged = new Date(mergedAt).getTime();
-      return (merged - created) / (1000 * 60); // minutes
-    })
-    .filter((d) => d >= 0)
-    .sort((a, b) => a - b);
+  return computeLatencyMetric(
+    pullRequests
+      .filter((pr) => pr.state === 'merged')
+      .map((pr) => [pr.createdAt, pr.mergedAt] as const)
+  );
+}
+
+export function computeReviewLatency(
+  pullRequests: PullRequest[]
+): LatencyMetric {
+  return computeLatencyMetric(
+    pullRequests
+      .filter((pr) => pr.state === 'merged')
+      .map((pr) => [pr.createdAt, pr.firstApprovalAt] as const)
+  );
+}
+
+export function computeMergeLatency(
+  pullRequests: PullRequest[]
+): LatencyMetric {
+  return computeLatencyMetric(
+    pullRequests
+      .filter((pr) => pr.state === 'merged')
+      .map((pr) => [pr.firstApprovalAt, pr.mergedAt] as const)
+  );
+}
+
+export function computeMergeBacklogDepth(
+  pullRequests: PullRequest[],
+  anchorTime: string | number = Date.now()
+): MergeBacklogMetric {
+  const anchor =
+    typeof anchorTime === 'number'
+      ? anchorTime
+      : new Date(anchorTime).getTime();
+  const approvedOpenPrs = pullRequests.filter(
+    (pr) => pr.state === 'open' && typeof pr.firstApprovalAt === 'string'
+  );
+  const oldestApproval = approvedOpenPrs
+    .map((pr) => new Date(pr.firstApprovalAt ?? '').getTime())
+    .filter((time) => Number.isFinite(time) && anchor >= time)
+    .sort((a, b) => a - b)[0];
 
   return {
-    p50: percentile(durations, 50),
-    p95: percentile(durations, 95),
-    sampleSize: durations.length,
+    depth: approvedOpenPrs.length,
+    eldestApprovedHours:
+      oldestApproval === undefined ? null : (anchor - oldestApproval) / 3600000,
   };
 }
 
@@ -256,6 +302,10 @@ export function computeDataWindowDays(proposals: Proposal[]): number {
 const PR_CYCLE_P95_WARN_DAYS = Number(
   process.env.GH_CYCLE_P95_WARN_DAYS ?? '7'
 );
+const MERGE_LATENCY_P95_WARN_HOURS = Number(
+  process.env.GH_MERGE_LATENCY_P95_WARN_HOURS ?? '48'
+);
+const MERGE_BACKLOG_WARN = Number(process.env.GH_MERGE_BACKLOG_WARN ?? '10');
 const ROLE_CONCENTRATION_WARN = Number(
   process.env.GH_ROLE_CONCENTRATION_WARN ?? '0.6'
 );
@@ -268,6 +318,12 @@ const CROSS_ROLE_MIN_SAMPLE = Number(
 
 export function buildHealthReport(data: ActivityData): HealthReport {
   const prCycleTime = computePrCycleTime(data.pullRequests);
+  const reviewLatency = computeReviewLatency(data.pullRequests);
+  const mergeLatency = computeMergeLatency(data.pullRequests);
+  const mergeBacklogDepth = computeMergeBacklogDepth(
+    data.pullRequests,
+    data.generatedAt
+  );
   const roleDiversity = computeRoleDiversity(data.proposals);
   const contestedDecisionRate = computeContestedRate(data.proposals);
   const crossRoleReviewRate = computeCrossRoleReviewRate(
@@ -284,6 +340,21 @@ export function buildHealthReport(data: ActivityData): HealthReport {
     const days = (prCycleTime.p95 / 60 / 24).toFixed(1);
     warnings.push(
       `PR cycle time p95 (${days}d) exceeds ${PR_CYCLE_P95_WARN_DAYS}d threshold`
+    );
+  }
+
+  if (
+    mergeLatency.p95 !== null &&
+    mergeLatency.p95 > MERGE_LATENCY_P95_WARN_HOURS * 60
+  ) {
+    warnings.push(
+      `Merge latency p95 (${formatMinutes(mergeLatency.p95)}) exceeds ${MERGE_LATENCY_P95_WARN_HOURS}h threshold`
+    );
+  }
+
+  if (mergeBacklogDepth.depth > MERGE_BACKLOG_WARN) {
+    warnings.push(
+      `Merge backlog depth (${mergeBacklogDepth.depth}) exceeds ${MERGE_BACKLOG_WARN} PR threshold`
     );
   }
 
@@ -319,6 +390,9 @@ export function buildHealthReport(data: ActivityData): HealthReport {
     dataWindowDays: computeDataWindowDays(data.proposals),
     metrics: {
       prCycleTime,
+      reviewLatency,
+      mergeLatency,
+      mergeBacklogDepth,
       roleDiversity,
       contestedDecisionRate,
       crossRoleReviewRate,
@@ -340,9 +414,46 @@ function formatMinutes(minutes: number | null): string {
   return `${Math.round(minutes)}min`;
 }
 
+function formatHours(hours: number | null): string {
+  if (hours === null) return 'N/A';
+  if (hours >= 48) return `${(hours / 24).toFixed(1)}d`;
+  if (hours >= 2) return `${hours.toFixed(1)}h`;
+  return `${Math.round(hours * 60)}min`;
+}
+
+function computeLatencyMetric(
+  pairs: Array<readonly [string | null | undefined, string | null | undefined]>
+): LatencyMetric {
+  const durations = pairs
+    .map(([start, end]) => durationInMinutes(start, end))
+    .filter((duration): duration is number => duration !== null)
+    .sort((a, b) => a - b);
+
+  return {
+    p50: percentile(durations, 50),
+    p95: percentile(durations, 95),
+    sampleSize: durations.length,
+  };
+}
+
+function durationInMinutes(
+  start: string | null | undefined,
+  end: string | null | undefined
+): number | null {
+  if (!start || !end) return null;
+  const startTime = new Date(start).getTime();
+  const endTime = new Date(end).getTime();
+  if (!Number.isFinite(startTime) || !Number.isFinite(endTime)) return null;
+  const minutes = (endTime - startTime) / 60000;
+  return minutes >= 0 ? minutes : null;
+}
+
 function printReport(report: HealthReport): void {
   const {
     prCycleTime,
+    reviewLatency,
+    mergeLatency,
+    mergeBacklogDepth,
     roleDiversity,
     contestedDecisionRate,
     crossRoleReviewRate,
@@ -358,6 +469,25 @@ function printReport(report: HealthReport): void {
   console.log(`  p50:    ${formatMinutes(prCycleTime.p50)}`);
   console.log(`  p95:    ${formatMinutes(prCycleTime.p95)}`);
   console.log(`  sample: ${prCycleTime.sampleSize} merged PRs`);
+  console.log('');
+
+  console.log('Review Latency');
+  console.log(`  p50:    ${formatMinutes(reviewLatency.p50)}`);
+  console.log(`  p95:    ${formatMinutes(reviewLatency.p95)}`);
+  console.log(`  sample: ${reviewLatency.sampleSize} merged PRs`);
+  console.log('');
+
+  console.log('Merge Latency');
+  console.log(`  p50:    ${formatMinutes(mergeLatency.p50)}`);
+  console.log(`  p95:    ${formatMinutes(mergeLatency.p95)}`);
+  console.log(`  sample: ${mergeLatency.sampleSize} merged PRs`);
+  console.log('');
+
+  console.log('Merge Backlog');
+  console.log(`  depth:  ${mergeBacklogDepth.depth} approved open PRs`);
+  console.log(
+    `  eldest: ${formatHours(mergeBacklogDepth.eldestApprovedHours)}`
+  );
   console.log('');
 
   console.log('Role Diversity');

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -581,15 +581,20 @@ async function fetchFirstApprovalAt(
 }
 
 /**
- * Enrich the most recent merged PRs with their first approval timestamp.
- * Capped at 20 PRs to limit additional API calls.
+ * Enrich open PRs and the most recent merged PRs with first approval times.
+ *
+ * Open PRs need approval timestamps so current merge backlog metrics can
+ * identify approved-but-unmerged work. Recent merged PRs keep historical
+ * review/merge latency metrics representative without fetching approval data
+ * for the entire closed backlog.
  */
-export async function enrichMergedPRsWithApprovalTimes(
+export async function enrichPullRequestsWithApprovalTimes(
   owner: string,
   repo: string,
   pullRequests: PullRequest[]
 ): Promise<void> {
-  const MAX_ENRICHED = 20;
+  const MAX_ENRICHED_MERGED = 20;
+  const openPRs = pullRequests.filter((pr) => pr.state === 'open');
   const mergedPRs = pullRequests
     .filter(
       (pr): pr is PullRequest & { mergedAt: string } =>
@@ -598,10 +603,11 @@ export async function enrichMergedPRsWithApprovalTimes(
     .sort(
       (a, b) => new Date(b.mergedAt).getTime() - new Date(a.mergedAt).getTime()
     )
-    .slice(0, MAX_ENRICHED);
+    .slice(0, MAX_ENRICHED_MERGED);
+  const prsToEnrich = [...openPRs, ...mergedPRs];
 
   await Promise.all(
-    mergedPRs.map(async (pr) => {
+    prsToEnrich.map(async (pr) => {
       pr.firstApprovalAt = await fetchFirstApprovalAt(owner, repo, pr.number);
     })
   );
@@ -1812,7 +1818,7 @@ async function fetchRepoActivity(
     repoTag
   );
   await fetchPhaseTransitions(owner, repo, proposals);
-  await enrichMergedPRsWithApprovalTimes(owner, repo, prResult.pullRequests);
+  await enrichPullRequestsWithApprovalTimes(owner, repo, prResult.pullRequests);
 
   const openIssues = calculateOpenIssues(repoMetadata, prResult.pullRequests);
 


### PR DESCRIPTION
Part of #613

## Why

`check-governance-health` currently reports only total PR cycle time, which hides whether the bottleneck is review or merge. Colony's current queue is dominated by merge delay, so the health CLI needs to expose that directly.

## What changed

- add `reviewLatency`, `mergeLatency`, and `mergeBacklogDepth` to the governance health report and CLI output
- keep `prCycleTime` for backward compatibility while adding warnings for slow merge latency and deep approved backlog
- enrich open PRs plus the most recent merged PRs with `firstApprovalAt` so backlog depth reflects the live approved queue
- add unit coverage for the new health metrics and the approval-time enrichment scope

## Validation

```bash
cd web
npm run lint
npm run test
npm run build
npm run generate-data
npm run check-governance-health -- --json
```
