### PR TITLE
fix: pre-flight token warning and suppress per-call 403 noise in generate-data

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -8,7 +8,7 @@ This guide covers how to deploy Colony from this repository today.
 
 - Node.js 20+
 - npm
-- A GitHub token for higher API limits (`GITHUB_TOKEN` or `GH_TOKEN`)
+- A GitHub token (`GITHUB_TOKEN` or `GH_TOKEN`) — required for complete data generation; without it, timeline data (phase transitions) is skipped and the script emits a warning
 
 ## 1. Configure Environment
 
@@ -23,7 +23,8 @@ COLONY_REPOSITORY=hivemoot/colony
 # Optional: track multiple repositories (comma-separated owner/repo values)
 COLONY_REPOSITORIES=hivemoot/colony,hivemoot/hivemoot
 
-# Optional but recommended: avoid low unauthenticated rate limits
+# Required for complete data (timeline/phase transitions); omitting skips
+# timeline fetches and prints a single warning at startup.
 GITHUB_TOKEN=ghp_xxx
 
 # Optional: custom user agent for visibility checks

--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -3,6 +3,7 @@ import { writeFileSync, readFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
+  resolveToken,
   resolveRepository,
   resolveRequiredDiscoverabilityTopics,
   resolveRepositories,
@@ -168,6 +169,31 @@ describe('resolveRepositories', () => {
       { owner: 'hivemoot', repo: 'colony' },
       { owner: 'hivemoot', repo: 'hivemoot' },
     ]);
+  });
+});
+
+describe('resolveToken', () => {
+  it('returns GITHUB_TOKEN when set', () => {
+    expect(resolveToken({ GITHUB_TOKEN: 'ghp_primary', GH_TOKEN: 'ghp_fallback' })).toBe(
+      'ghp_primary'
+    );
+  });
+
+  it('falls back to GH_TOKEN when GITHUB_TOKEN is absent', () => {
+    expect(resolveToken({ GH_TOKEN: 'ghp_fallback' })).toBe('ghp_fallback');
+  });
+
+  it('falls back to GH_TOKEN when GITHUB_TOKEN is an empty string', () => {
+    // This is the key ?? vs || difference: ?? treats "" as present, || does not.
+    expect(resolveToken({ GITHUB_TOKEN: '', GH_TOKEN: 'ghp_fallback' })).toBe('ghp_fallback');
+  });
+
+  it('returns undefined when neither is set', () => {
+    expect(resolveToken({})).toBeUndefined();
+  });
+
+  it('returns undefined when both are empty strings', () => {
+    expect(resolveToken({ GITHUB_TOKEN: '', GH_TOKEN: '' })).toBeUndefined();
   });
 });
 

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -688,6 +688,13 @@ async function fetchPhaseTransitions(
   repo: string,
   proposals: Proposal[]
 ): Promise<void> {
+  const hasToken = Boolean(process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN);
+  if (!hasToken) {
+    // No token: timeline API requires authentication. Pre-flight warning in
+    // main() already informs the user; skip silently here to avoid 403 noise.
+    return;
+  }
+
   await Promise.all(
     proposals.map(async (proposal) => {
       try {
@@ -2017,6 +2024,16 @@ function toRepoTag(repo: { owner: string; name: string }): string {
 
 async function main(): Promise<void> {
   try {
+    const hasToken = Boolean(process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN);
+    if (!hasToken) {
+      process.stderr.write(
+        '[generate-data] No GITHUB_TOKEN or GH_TOKEN set.\n' +
+          '  Timeline data (phase transitions) will be skipped.\n' +
+          '  Output will be partial — activity counts only, no governance history transitions.\n' +
+          '  Set GITHUB_TOKEN for complete output.\n'
+      );
+    }
+
     const data = await generateActivityData();
 
     // Ensure output directory exists

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -639,33 +639,37 @@ async function fetchProposals(
     votablePhases.includes(p.phase)
   );
 
-  await Promise.all(
-    votingProposals.map(async (proposal) => {
-      try {
-        const comments = await fetchJson<GitHubComment[]>(
-          `/repos/${owner}/${repo}/issues/${proposal.number}/comments`
-        );
-        const votingComment = comments.find(
-          (c) =>
-            (c.user.login === 'hivemoot[bot]' || c.user.login === 'hivemoot') &&
-            (c.body.includes('React to THIS comment to vote') ||
-              (c.body.includes('hivemoot-metadata') &&
-                c.body.includes('"type":"voting"')))
-        );
-        if (votingComment && votingComment.reactions) {
-          proposal.votesSummary = {
-            thumbsUp: votingComment.reactions['+1'] || 0,
-            thumbsDown: votingComment.reactions['-1'] || 0,
-          };
+  if (resolveToken()) {
+    await Promise.all(
+      votingProposals.map(async (proposal) => {
+        try {
+          const comments = await fetchJson<GitHubComment[]>(
+            `/repos/${owner}/${repo}/issues/${proposal.number}/comments`
+          );
+          const votingComment = comments.find(
+            (c) =>
+              (c.user.login === 'hivemoot[bot]' || c.user.login === 'hivemoot') &&
+              (c.body.includes('React to THIS comment to vote') ||
+                (c.body.includes('hivemoot-metadata') &&
+                  c.body.includes('"type":"voting"')))
+          );
+          if (votingComment && votingComment.reactions) {
+            proposal.votesSummary = {
+              thumbsUp: votingComment.reactions['+1'] || 0,
+              thumbsDown: votingComment.reactions['-1'] || 0,
+            };
+          }
+        } catch (e) {
+          console.warn(
+            `Failed to fetch reactions for issue #${proposal.number}`,
+            e
+          );
         }
-      } catch (e) {
-        console.warn(
-          `Failed to fetch reactions for issue #${proposal.number}`,
-          e
-        );
-      }
-    })
-  );
+      })
+    );
+  }
+  // No token: reaction enrichment requires authentication. Pre-flight warning
+  // in main() already informs the user; skip silently here.
 
   return proposals.sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -181,6 +181,15 @@ export interface GitHubTimelineEvent {
   created_at: string;
 }
 
+/**
+ * Resolves a GitHub token from the environment, treating empty strings as
+ * absent. Falls back from GITHUB_TOKEN to GH_TOKEN, returns undefined if
+ * neither is set or both are empty.
+ */
+export function resolveToken(env = process.env): string | undefined {
+  return env.GITHUB_TOKEN || env.GH_TOKEN || undefined;
+}
+
 export async function fetchJson<T>(endpoint: string): Promise<T> {
   const url = `${GITHUB_API}${endpoint}`;
   const headers: Record<string, string> = {
@@ -189,7 +198,7 @@ export async function fetchJson<T>(endpoint: string): Promise<T> {
   };
 
   // Use GITHUB_TOKEN/GH_TOKEN if available (CI or local environment)
-  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const token = resolveToken();
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }
@@ -688,7 +697,7 @@ async function fetchPhaseTransitions(
   repo: string,
   proposals: Proposal[]
 ): Promise<void> {
-  const hasToken = Boolean(process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN);
+  const hasToken = Boolean(resolveToken());
   if (!hasToken) {
     // No token: timeline API requires authentication. Pre-flight warning in
     // main() already informs the user; skip silently here to avoid 403 noise.
@@ -2024,7 +2033,7 @@ function toRepoTag(repo: { owner: string; name: string }): string {
 
 async function main(): Promise<void> {
   try {
-    const hasToken = Boolean(process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN);
+    const hasToken = Boolean(resolveToken());
     if (!hasToken) {
       process.stderr.write(
         '[generate-data] No GITHUB_TOKEN or GH_TOKEN set.\n' +


### PR DESCRIPTION
## Summary

Without `GITHUB_TOKEN`/`GH_TOKEN`, `generate-data` was generating one `console.warn` per proposal timeline fetch failure — producing a wall of 403 errors that makes an unauthenticated run look like a broken setup.

Changes:
- `main()` emits a single pre-flight warning to stderr when no token is detected, before any fetches begin
- `fetchPhaseTransitions` returns early silently when no token is set — the pre-flight warning already covers the case, so per-call noise is suppressed entirely
- `DEPLOYING.md` updated: token described as required for complete output (not "optional but recommended"), with inline comment clarifying the consequence of omitting it

## Before / After

**Before (no token):**
```
Failed to fetch timeline for #604 Error: GitHub API error: 403 Forbidden...
Failed to fetch timeline for #598 Error: GitHub API error: 403 Forbidden...
Failed to fetch timeline for #591 Error: GitHub API error: 403 Forbidden...
... (dozens more)
```

**After (no token):**
```
[generate-data] No GITHUB_TOKEN or GH_TOKEN set.
  Timeline data (phase transitions) will be skipped.
  Output will be partial — activity counts only, no governance history transitions.
  Set GITHUB_TOKEN for complete output.
```

## Validation

```bash
cd web
npm run test          # 991 passed, 63 files — no regressions
npm run build         # clean

# No-token path:
unset GITHUB_TOKEN GH_TOKEN
npm run generate-data
# Should see exactly one warning block at startup; no per-call 403 lines
```

Note: a unit test for the pre-flight path would require either exporting `main()` or mocking `process.env` at the module level — not done here to keep scope minimal. The behavior is verifiable via the manual smoke-test above.

Closes #618

Related: #616