### PR TITLE
fix: escape & in avatar img src on agent profile page

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -127,6 +127,9 @@ describe('generateStaticPages', () => {
     expect(html).toContain('50'); // commits
     expect(html).toContain('20'); // PRs merged
     expect(html).toContain('30'); // reviews
+    // avatar URL ampersand must be HTML-escaped on the agent profile page
+    expect(html).toContain('src="https://avatars.example.com/1&amp;s=64"');
+    expect(html).not.toContain('src="https://avatars.example.com/1&s=64"');
   });
 
   it('generates agents index page', () => {

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -420,7 +420,7 @@ function agentPage(agent: AgentStats): string {
     </nav>
 
     <h1 style="display: flex; align-items: center; gap: 0.75rem;">
-      ${agent.avatarUrl ? `<img src="${escapeHtml(agent.avatarUrl)}&s=64" alt="" width="48" height="48" style="border-radius: 50%;" />` : ''}
+      ${agent.avatarUrl ? `<img src="${escapeHtml(agent.avatarUrl + '&s=64')}" alt="" width="48" height="48" style="border-radius: 50%;" />` : ''}
       ${escapeHtml(agent.login)}
     </h1>
     <div class="meta">


### PR DESCRIPTION
Fixes #554

## What

The `&s=64` size parameter appended to the avatar URL on agent profile pages was a raw ampersand in an HTML attribute value — a violation of the HTML spec. Browsers handled it silently, but validators flagged it.

The same bug was already fixed on line 484–485 for the `s=32` variant on the agents index page. This PR brings the profile page in line.

**Before:**
```html
<img src="https://avatars.github.com/u/1234?v=4&s=64" ...>
```

**After:**
```html
<img src="https://avatars.github.com/u/1234?v=4&amp;s=64" ...>
```

Browsers decode `&amp;` back to `&` when resolving the `src`, so image loading is unchanged.

## Also added

A regression test asserting `&amp;s=64` on the agent profile page. The agents index already had a test for `&amp;s=32`, but the profile page had no equivalent assertion.

## Validation

```bash
cd web
npm run lint        # clean
npm run test        # 991/991 passing (38 in static-pages.test.ts)
```