### PR TITLE
feat: add actionable recommendations to governance health CLI output

### DIFF
--- a/web/scripts/__tests__/check-governance-health.test.ts
+++ b/web/scripts/__tests__/check-governance-health.test.ts
@@ -438,6 +438,19 @@ describe('buildHealthReport', () => {
     expect(report.metrics.contestedDecisionRate).toBeDefined();
     expect(report.metrics.crossRoleReviewRate).toBeDefined();
     expect(report.warnings).toBeInstanceOf(Array);
+    expect(report.recommendations).toBeInstanceOf(Array);
+  });
+
+  it('recommendations and warnings have the same length', () => {
+    const longPrs = Array.from({ length: 5 }, (_, i) =>
+      makePr({
+        number: i + 1,
+        createdAt: '2026-02-01T00:00:00Z',
+        mergedAt: '2026-02-15T00:00:00Z',
+      })
+    );
+    const report = buildHealthReport(minimalData({ pullRequests: longPrs }));
+    expect(report.recommendations).toHaveLength(report.warnings.length);
   });
 
   it('emits no warnings for healthy data', () => {
@@ -486,6 +499,7 @@ describe('buildHealthReport', () => {
       minimalData({ pullRequests: prs, proposals, comments })
     );
     expect(report.warnings).toHaveLength(0);
+    expect(report.recommendations).toHaveLength(0);
   });
 
   it('emits PR cycle time warning when p95 exceeds 7 days', () => {
@@ -498,6 +512,9 @@ describe('buildHealthReport', () => {
     );
     const report = buildHealthReport(minimalData({ pullRequests: longPrs }));
     expect(report.warnings.some((w) => w.includes('PR cycle time'))).toBe(true);
+    expect(
+      report.recommendations.some((r) => r.includes('hivemoot:merge-ready'))
+    ).toBe(true);
   });
 
   it('emits role concentration warning when top role > 60%', () => {
@@ -506,6 +523,12 @@ describe('buildHealthReport', () => {
     );
     const report = buildHealthReport(minimalData({ proposals }));
     expect(report.warnings.some((w) => w.includes('Role concentration'))).toBe(
+      true
+    );
+    expect(
+      report.recommendations.some((r) => r.includes('hivemoot:discussion'))
+    ).toBe(true);
+    expect(report.recommendations.some((r) => r.includes('builder'))).toBe(
       true
     );
   });
@@ -520,6 +543,9 @@ describe('buildHealthReport', () => {
     const report = buildHealthReport(minimalData({ proposals }));
     expect(
       report.warnings.some((w) => w.includes('Contested decision rate'))
+    ).toBe(true);
+    expect(
+      report.recommendations.some((r) => r.includes('rubber-stamping'))
     ).toBe(true);
   });
 
@@ -542,6 +568,9 @@ describe('buildHealthReport', () => {
     );
     expect(
       report.warnings.some((w) => w.includes('Cross-role review rate'))
+    ).toBe(true);
+    expect(
+      report.recommendations.some((r) => r.includes('hivemoot:candidate'))
     ).toBe(true);
   });
 

--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -94,6 +94,8 @@ export interface HealthReport {
   };
   /** Human-readable warnings for metrics outside healthy thresholds */
   warnings: string[];
+  /** Actionable recommendations paired to each warning, in the same order */
+  recommendations: string[];
 }
 
 // ──────────────────────────────────────────────
@@ -276,6 +278,7 @@ export function buildHealthReport(data: ActivityData): HealthReport {
   );
 
   const warnings: string[] = [];
+  const recommendations: string[] = [];
 
   if (
     prCycleTime.p95 !== null &&
@@ -285,12 +288,18 @@ export function buildHealthReport(data: ActivityData): HealthReport {
     warnings.push(
       `PR cycle time p95 (${days}d) exceeds ${PR_CYCLE_P95_WARN_DAYS}d threshold`
     );
+    recommendations.push(
+      `Run 'gh pr list --label hivemoot:merge-ready' to identify approved PRs waiting for merge. High p95 often means a small number of PRs have been stuck for weeks.`
+    );
   }
 
   if (roleDiversity.topRoleShare > ROLE_CONCENTRATION_WARN) {
     const pct = Math.round(roleDiversity.topRoleShare * 100);
     warnings.push(
       `Role concentration: ${roleDiversity.topRole} accounts for ${pct}% of proposals (threshold: ${Math.round(ROLE_CONCENTRATION_WARN * 100)}%)`
+    );
+    recommendations.push(
+      `Encourage agents from underrepresented roles to submit proposals. Check 'gh issue list --label hivemoot:discussion' to see if roles other than ${roleDiversity.topRole} are participating.`
     );
   }
 
@@ -302,6 +311,9 @@ export function buildHealthReport(data: ActivityData): HealthReport {
     warnings.push(
       `Contested decision rate (${pct}%) below ${Math.round(CONTESTED_MIN_WARN * 100)}% — may indicate rubber-stamping`
     );
+    recommendations.push(
+      `Low contested rate may indicate rubber-stamping. Review recent voting comment threads to see if concerns are being raised in comments but not registered as votes.`
+    );
   }
 
   if (
@@ -311,6 +323,9 @@ export function buildHealthReport(data: ActivityData): HealthReport {
     const pct = Math.round(crossRoleReviewRate.rate * 100);
     warnings.push(
       `Cross-role review rate (${pct}%) below ${Math.round(CROSS_ROLE_MIN_WARN * 100)}% — reviews mostly within same role`
+    );
+    recommendations.push(
+      `Assign cross-role reviewers to active PRs: 'gh pr list --label hivemoot:candidate' shows candidates accepting new reviews. Cross-role review strengthens governance legitimacy.`
     );
   }
 
@@ -324,6 +339,7 @@ export function buildHealthReport(data: ActivityData): HealthReport {
       crossRoleReviewRate,
     },
     warnings,
+    recommendations,
   };
 }
 
@@ -388,6 +404,11 @@ function printReport(report: HealthReport): void {
     console.log('Warnings:');
     for (const w of report.warnings) {
       console.log(`  WARN ${w}`);
+    }
+    console.log('');
+    console.log('Recommendations:');
+    for (const r of report.recommendations) {
+      console.log(`  → ${r}`);
     }
   } else {
     console.log('No health warnings detected.');


### PR DESCRIPTION
Closes #621

## What changed

Adds `recommendations: string[]` to `HealthReport` and populates it alongside `warnings` in `buildHealthReport`. Each warning condition now produces a paired recommendation in the same `if` block.

**`check-governance-health.ts`:**
- `HealthReport` interface gains `recommendations: string[]` (additive field)
- `buildHealthReport` pushes a recommendation string for each warning fired, co-located with the warning push
- `printReport` adds a `Recommendations:` section after `Warnings:`

**`check-governance-health.test.ts`:**
- New test: `recommendations` is an empty array when there are no warnings
- New test: `recommendations` and `warnings` always have the same length
- 4 new assertions: each warning condition test now also asserts the paired recommendation contains the expected key phrase

## Recommendation strings

| Warning | Recommendation |
|---------|---------------|
| PR cycle time p95 exceeds threshold | `Run 'gh pr list --label hivemoot:merge-ready' to identify approved PRs waiting for merge...` |
| Role concentration above threshold | `Encourage agents from underrepresented roles to submit proposals. Check 'gh issue list --label hivemoot:discussion'...` (interpolates `topRole`) |
| Contested decision rate below threshold | `Low contested rate may indicate rubber-stamping. Review recent voting comment threads...` |
| Cross-role review rate below threshold | `Assign cross-role reviewers to active PRs: 'gh pr list --label hivemoot:candidate'...` |

## Validation

```bash
cd web
npm run lint        # clean
npm run typecheck   # clean
npm run test -- --run  # 992/992 passed (8 new assertions, 44 tests in governance health file)
```

## Non-goals (per issue spec)

- No changes to metric computation or warning thresholds
- No new metrics
- No CI exit-code behavior change
- No governance history schema change