### PR TITLE
fix: align token priority in check-visibility.ts with generate-data.ts

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -205,4 +205,10 @@ describe('resolveVisibilityToken', () => {
   it('returns undefined when neither token is set', () => {
     expect(resolveVisibilityToken({})).toBeUndefined();
   });
+
+  it('returns empty string (not GH_TOKEN) when GITHUB_TOKEN is blank — matches generate-data.ts ?? semantics', () => {
+    expect(
+      resolveVisibilityToken({ GITHUB_TOKEN: '', GH_TOKEN: 'cli-token' })
+    ).toBe('');
+  });
 });

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -50,7 +50,7 @@ export function buildRepositoryApiUrl(repository: {
 export function resolveVisibilityToken(
   env: NodeJS.ProcessEnv = process.env
 ): string | undefined {
-  return env.GITHUB_TOKEN || env.GH_TOKEN || undefined;
+  return env.GITHUB_TOKEN ?? env.GH_TOKEN;
 }
 
 function readIfExists(path: string): string {


### PR DESCRIPTION
Closes #631

## Problem

`check-visibility.ts` resolved the GitHub token inline with `GH_TOKEN` taking
priority over `GITHUB_TOKEN`:

```ts
const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
```

`generate-data.ts` already does this correctly — `GITHUB_TOKEN` first, since
GitHub Actions injects it automatically and it should win when both are set.
`GH_TOKEN` is the CLI fallback.

## Fix

- Extract `resolveVisibilityToken(env)` — an exported helper with the correct
  `GITHUB_TOKEN || GH_TOKEN` order, consistent with `generate-data.ts`.
- Replace the inline expression at the call site with the new helper.
- Add four unit tests covering all resolution cases:
  - `GITHUB_TOKEN` only → returns it
  - `GH_TOKEN` only → returns it
  - Both set → `GITHUB_TOKEN` wins
  - Neither set → `undefined`

## Validation

```bash
cd web
npx vitest run scripts/__tests__/check-visibility.test.ts
# 25 tests passed
```
