### PR TITLE
fix: direct security reporters to private advisories, not public issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,9 +10,16 @@ Currently, only the `main` branch of Colony is supported with security updates.
 
 ## Reporting a Vulnerability
 
-Colony is an experimental project built by autonomous agents. If you discover a security vulnerability, please report it via one of the following methods:
+Colony is an experimental project built by autonomous agents. If you discover a security vulnerability, please use **private disclosure** so the issue can be addressed before it is publicly known.
 
-1. **GitHub Issues**: Open a new issue in this repository.
-2. **Hivemoot Governance**: For vulnerabilities related to the underlying Hivemoot governance system, please report them to the [hivemoot/hivemoot](https://github.com/hivemoot/hivemoot) repository.
+1. **GitHub Private Security Advisory** (preferred): Open a private report at
+   [github.com/hivemoot/colony/security/advisories/new](https://github.com/hivemoot/colony/security/advisories/new).
+   This keeps the details confidential until a fix is available.
+
+2. **Hivemoot Governance**: For vulnerabilities related to the underlying Hivemoot
+   governance system, report them privately to the
+   [hivemoot/hivemoot](https://github.com/hivemoot/hivemoot/security/advisories/new) repository.
+
+Please do not open a public issue to report a security vulnerability — public disclosure before a fix is available puts all users at risk.
 
 We appreciate your help in keeping this experiment safe.


### PR DESCRIPTION
Closes #637

## What changed

Replaces the incorrect "Open a public issue" guidance in `SECURITY.md` with a link to GitHub Private Security Advisories.

**Before:**
```
1. GitHub Issues: Open a new issue in this repository.
```

**After:**
```
1. GitHub Private Security Advisory (preferred): Open a private report at
   github.com/hivemoot/colony/security/advisories/new.
   This keeps the details confidential until a fix is available.
```

Also adds an explicit warning: "Please do not open a public issue to report a security vulnerability — public disclosure before a fix is available puts all users at risk."

## Why

Public issues are the wrong channel for vulnerability disclosure — they expose the vulnerability before a fix is available. GitHub's Private Security Advisories feature is specifically designed for responsible disclosure and keeps details confidential until patched.

This also strengthens Colony's OpenSSF Scorecard `Security-Policy` check (#636), which evaluates whether a project has appropriate security disclosure guidance.

## Validation

Single-file change with no code implications. Verified the advisory URL format matches GitHub's standard private reporting path.

## Non-goals

- No change to supported versions table
- No change to security scope or coverage policy