### PR TITLE
feat: emit health-badge.json — shields.io governance health endpoint

### DIFF
--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -8,6 +8,7 @@ import {
   resolveRepositories,
   resolveRepositoryHomepage,
   updateSitemapLastmod,
+  writeHealthBadge,
   mapCommits,
   mapIssues,
   mapPullRequests,
@@ -2102,6 +2103,56 @@ describe('updateSitemapLastmod', () => {
     expect(matches).toHaveLength(2);
     expect(result).not.toContain('2026-02-10');
     expect(result).not.toContain('2026-02-09');
+  });
+});
+
+describe('writeHealthBadge', () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it.each([
+    [85, 'brightgreen'],
+    [80, 'brightgreen'],
+    [75, 'yellow'],
+    [60, 'yellow'],
+    [55, 'orange'],
+    [40, 'orange'],
+    [35, 'red'],
+    [0, 'red'],
+  ])('score %i maps to color %s', (score, expectedColor) => {
+    tempDir = mkdtempSync(join(tmpdir(), 'badge-'));
+    const badgePath = join(tempDir, 'health-badge.json');
+
+    writeHealthBadge(score, badgePath);
+
+    const badge = JSON.parse(readFileSync(badgePath, 'utf-8')) as {
+      schemaVersion: number;
+      label: string;
+      message: string;
+      color: string;
+    };
+    expect(badge.schemaVersion).toBe(1);
+    expect(badge.label).toBe('colony health');
+    expect(badge.message).toBe(String(score));
+    expect(badge.color).toBe(expectedColor);
+  });
+
+  it('writes valid JSON parseable as a shields.io endpoint badge', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'badge-'));
+    const badgePath = join(tempDir, 'health-badge.json');
+
+    writeHealthBadge(70, badgePath);
+
+    const content = readFileSync(badgePath, 'utf-8');
+    expect(() => JSON.parse(content)).not.toThrow();
+    const badge = JSON.parse(content) as Record<string, unknown>;
+    expect(typeof badge.schemaVersion).toBe('number');
+    expect(typeof badge.label).toBe('string');
+    expect(typeof badge.message).toBe('string');
+    expect(typeof badge.color).toBe('string');
   });
 });
 

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -322,12 +322,14 @@ async function runChecks(): Promise<CheckResult[]> {
     }
   };
 
-  const [rootRes, robotsRes, sitemapRes, activityRes] = await Promise.all([
-    fetchWithTimeout(baseUrl),
-    fetchWithTimeout(`${baseUrl}/robots.txt`),
-    fetchWithTimeout(`${baseUrl}/sitemap.xml`),
-    fetchWithTimeout(`${baseUrl}/data/activity.json`),
-  ]);
+  const [rootRes, robotsRes, sitemapRes, activityRes, badgeRes] =
+    await Promise.all([
+      fetchWithTimeout(baseUrl),
+      fetchWithTimeout(`${baseUrl}/robots.txt`),
+      fetchWithTimeout(`${baseUrl}/sitemap.xml`),
+      fetchWithTimeout(`${baseUrl}/data/activity.json`),
+      fetchWithTimeout(`${baseUrl}/data/health-badge.json`),
+    ]);
 
   results.push({
     label: 'Deployed site is reachable',
@@ -701,6 +703,16 @@ async function runChecks(): Promise<CheckResult[]> {
     label: 'Deployed data freshness (<= 18h)',
     ok: freshnessOk,
     details: freshnessDetails,
+  });
+
+  const badgeUrl = `${baseUrl}/data/health-badge.json`;
+  const badgeOk = badgeRes?.status === 200;
+  results.push({
+    label: 'Deployed health-badge.json is reachable',
+    ok: badgeOk,
+    details: badgeOk
+      ? `GET ${badgeUrl} returned 200`
+      : `GET ${badgeUrl} returned ${badgeRes?.status ?? 'no response'}`,
   });
 
   return results;

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -54,6 +54,7 @@ const ROOT_DIR = join(__dirname, '..', '..');
 const OUTPUT_DIR = join(__dirname, '..', 'public', 'data');
 const OUTPUT_FILE = join(OUTPUT_DIR, 'activity.json');
 const HISTORY_FILE = join(OUTPUT_DIR, 'governance-history.json');
+const BADGE_FILE = join(OUTPUT_DIR, 'health-badge.json');
 const ROADMAP_PATH = join(ROOT_DIR, 'ROADMAP.md');
 const INDEX_HTML_PATH = join(ROOT_DIR, 'web', 'index.html');
 const SITEMAP_PATH = join(ROOT_DIR, 'web', 'public', 'sitemap.xml');
@@ -2015,6 +2016,38 @@ function toRepoTag(repo: { owner: string; name: string }): string {
   return `${repo.owner}/${repo.name}`;
 }
 
+/**
+ * Return a shields.io endpoint badge color for a governance health score.
+ * Score is 0–100 (computed by computeGovernanceSnapshot, rounded to nearest 5).
+ */
+function badgeColor(score: number): string {
+  if (score >= 80) return 'brightgreen';
+  if (score >= 60) return 'yellow';
+  if (score >= 40) return 'orange';
+  return 'red';
+}
+
+/**
+ * Write a shields.io-compatible endpoint badge to `public/data/health-badge.json`.
+ * External consumers embed this as:
+ *   https://img.shields.io/endpoint?url=.../data/health-badge.json
+ */
+export function writeHealthBadge(
+  score: number,
+  badgePath: string = BADGE_FILE
+): void {
+  const badge = {
+    schemaVersion: 1,
+    label: 'colony health',
+    message: String(score),
+    color: badgeColor(score),
+  };
+  writeFileSync(badgePath, JSON.stringify(badge, null, 2));
+  console.log(
+    `Health badge written to ${badgePath} (score: ${score}, color: ${badge.color})`
+  );
+}
+
 async function main(): Promise<void> {
   try {
     const data = await generateActivityData();
@@ -2078,6 +2111,9 @@ async function main(): Promise<void> {
     console.log(
       `Governance snapshot appended (${updatedSnapshots.length} entries, score: ${snapshot.healthScore}, schema: v${updatedHistory.schemaVersion}, completeness: ${updatedHistory.completeness.status})`
     );
+
+    // Write shields.io-compatible badge for external embedding
+    writeHealthBadge(snapshot.healthScore);
   } catch (error) {
     console.error('Failed to generate activity data:', error);
     process.exit(1);


### PR DESCRIPTION
Closes #642

## What

Adds a [shields.io endpoint badge](https://shields.io/badges/endpoint-badge) artifact to Colony's data generation pipeline: `public/data/health-badge.json`.

Every Colony deployment can now embed a live governance health indicator in their README:

```md
[![Colony Health](https://img.shields.io/endpoint?url=https://hivemoot.github.io/colony/data/health-badge.json)](https://hivemoot.github.io/colony/)
```

## Why

Horizon 4 positions Colony as a Data Platform — making governance evidence consumable externally, not just visible in the dashboard. The CHAOSS metrics endpoint (PR #599) and federation stub (PR #600) are already in the queue. The health badge completes the external-consumer surface: it gives external observers a quick signal before ingesting detailed metrics, and it lets Colony deployers show credibility in their README without any dashboard setup.

## Changes

**`generate-data.ts`**
- Add `BADGE_FILE = public/data/health-badge.json` constant
- Add exported `writeHealthBadge(score, path?)` helper
- Add `badgeColor(score)` helper mapping score → shields.io color
- Call `writeHealthBadge(snapshot.healthScore)` after writing history

Color thresholds: ≥80 `brightgreen`, ≥60 `yellow`, ≥40 `orange`, <40 `red`

**`check-visibility.ts`**
- Add `data/health-badge.json` to the parallel fetch in `runChecks()`
- Add result push: `Deployed health-badge.json is reachable`

**`generate-data.test.ts`**
- 9 new tests for `writeHealthBadge` covering all 4 color thresholds and JSON structure validity (badges are parseable with all required fields)

## Validation

```bash
cd web
npm run lint
npm run test
npm run build
```

All 1000 tests pass. Lint clean.

## Output example

```json
{
  "schemaVersion": 1,
  "label": "colony health",
  "message": "80",
  "color": "brightgreen"
}
```