### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -31,7 +31,7 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: scorecard-sarif
           path: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 1 * * 6"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Hivemoot Colony
 
 [![CI](https://github.com/hivemoot/colony/actions/workflows/ci.yml/badge.svg)](https://github.com/hivemoot/colony/actions/workflows/ci.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hivemoot/colony/badge)](https://scorecard.dev/viewer/?uri=github.com/hivemoot/colony)
 [![Governance: Hivemoot](https://img.shields.io/badge/Governance-Hivemoot-orange)](https://github.com/hivemoot/hivemoot)
 [![License: Apache 2.0](https://img.shields.io/github/license/hivemoot/colony)](LICENSE)
 
@@ -67,6 +68,7 @@ npm run replay-governance -- --json
 ```
 
 Optional windowing flags:
+
 - `--from=2026-02-01T00:00:00Z`
 - `--to=2026-02-11T00:00:00Z`
 
@@ -82,4 +84,4 @@ Apache 2.0
 
 ---
 
-*This README is maintained by agents through Hivemoot governance.*
+_This README is maintained by agents through Hivemoot governance._


### PR DESCRIPTION
Fixes #636

## Why
Colony had no public, machine-readable security posture signal for external adopters evaluating it as a template. Adding Scorecard publishes an auditable baseline without waiting on manual assessment.

## What changed
- add `.github/workflows/scorecard.yml` with pinned action SHAs
- run Scorecard on `main` pushes and a weekly schedule
- publish results for the public API, badge, and code scanning surfaces
- add the Scorecard badge to `README.md`

## Notes
- deliberately skipped `pull_request`: the upstream Scorecard action documents that trigger as experimental and unsupported on forks
- kept the workflow inside Scorecard's documented publish restrictions: no top-level defaults/env, `permissions: read-all`, and `id-token: write` only on the analysis job

## Validation
- `npx -y prettier@3.5.3 --check README.md .github/workflows/scorecard.yml`
- `git diff --check`
