### PR TITLE
fix: reject partial-numeric --limit in fast-track-candidates

### DIFF
--- a/web/scripts/__tests__/fast-track-candidates.test.ts
+++ b/web/scripts/__tests__/fast-track-candidates.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import {
   countDistinctApprovals,
+  DEFAULT_LIMIT,
   evaluateEligibility,
   hasAllowedPrefix,
   hasChangesRequested,
   HIGH_APPROVAL_WAIVER_THRESHOLD,
   isMergeReady,
   normalizeMergeStateStatus,
+  parseArgs,
   printHumanReport,
 } from '../fast-track-candidates';
 
@@ -363,5 +365,39 @@ describe('evaluateEligibility', () => {
 
     expect(result.eligible).toBe(true);
     expect(result.reasons).toHaveLength(0);
+  });
+});
+
+describe('parseArgs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('accepts a valid --limit value', () => {
+    const opts = parseArgs(['--limit=50']);
+    expect(opts.limit).toBe(50);
+  });
+
+  it('warns and ignores a partial-numeric --limit value (5oops)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const opts = parseArgs(['--limit=5oops']);
+    expect(opts.limit).toBe(DEFAULT_LIMIT);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('--limit="5oops"')
+    );
+  });
+
+  it('warns and ignores a non-numeric --limit value', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const opts = parseArgs(['--limit=abc']);
+    expect(opts.limit).toBe(DEFAULT_LIMIT);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('--limit="abc"'));
+  });
+
+  it('warns and ignores --limit=0 (not a positive integer)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const opts = parseArgs(['--limit=0']);
+    expect(opts.limit).toBe(DEFAULT_LIMIT);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('--limit="0"'));
   });
 });

--- a/web/scripts/fast-track-candidates.ts
+++ b/web/scripts/fast-track-candidates.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 
 const DEFAULT_REPO = 'hivemoot/colony';
-const DEFAULT_LIMIT = 200;
+export const DEFAULT_LIMIT = 200;
 
 export const FAST_TRACK_PREFIXES = [
   'fix:',
@@ -88,7 +88,7 @@ interface CliOptions {
   json: boolean;
 }
 
-function parseArgs(argv: string[]): CliOptions {
+export function parseArgs(argv: string[]): CliOptions {
   const options: CliOptions = {
     repo: DEFAULT_REPO,
     limit: DEFAULT_LIMIT,
@@ -107,9 +107,14 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg.startsWith('--limit=')) {
-      const value = Number.parseInt(arg.slice('--limit='.length), 10);
+      const raw = arg.slice('--limit='.length).trim();
+      const value = /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : NaN;
       if (Number.isFinite(value) && value > 0) {
         options.limit = value;
+      } else {
+        console.warn(
+          `Warning: --limit="${raw}" is not a valid positive integer. Ignored.`
+        );
       }
       continue;
     }


### PR DESCRIPTION
Fixes #651

## Problem

`fast-track-candidates.ts` line 110 had the same `parseInt` partial-parse gap as `external-outreach-metrics.ts` (fixed by PR #648):

```ts
const value = Number.parseInt(arg.slice('--limit='.length), 10);
```

`Number.parseInt('5oops', 10)` returns `5`. So `--limit=5oops` passes the `Number.isFinite(5) && value > 0` guard and is silently accepted as `5`. The caller gets no warning that their input was truncated.

## Fix

Same `/^\d+$/` guard used in PR #648:

```ts
const raw = arg.slice('--limit='.length).trim();
const value = /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : NaN;
if (Number.isFinite(value) && value > 0) {
  options.limit = value;
} else {
  console.warn(`Warning: --limit="${raw}" is not a valid positive integer. Ignored.`);
}
```

Also exports `parseArgs` and `DEFAULT_LIMIT` to enable direct unit testing (same pattern as PR #648's export of `parseArgs` from `external-outreach-metrics.ts`).

## Validation

```bash
cd web
npm run lint        # clean
npm run test        # 995 tests pass (4 new tests added)
```

New tests cover: valid value, partial-numeric (`5oops`), non-numeric (`abc`), and zero (not a valid positive integer).