### PR TITLE
chore: replace process.stderr.write with console.warn in generate-data.ts

### DIFF
--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -213,9 +213,9 @@ export function resolveRepository(env = process.env): {
   const normalizedRepository = repository?.trim();
 
   if (!normalizedRepository) {
-    process.stderr.write(
+    console.warn(
       `⚠  COLONY_REPOSITORY not set — using default ${DEFAULT_OWNER}/${DEFAULT_REPO}.\n` +
-        `   Set COLONY_REPOSITORY=your-org/your-repo to track a different repository.\n`
+        `   Set COLONY_REPOSITORY=your-org/your-repo to track a different repository.`
     );
     return { owner: DEFAULT_OWNER, repo: DEFAULT_REPO };
   }


### PR DESCRIPTION
Closes #632

## What changed

`resolveRepository()` in `generate-data.ts` was the only `process.stderr.write()` call in all of `web/scripts/`. Every other warning in the codebase uses `console.warn()`. This aligns it with the established pattern.

**Verified:** `grep -rn 'process.stderr.write' web/scripts/` returns exactly one result at line 216 — the call site this PR fixes.

No behavior change: both `process.stderr.write` and `console.warn` write to stderr. The trailing `\n` was removed from the message string since `console.warn` adds one automatically.

## Validation

```bash
cd web
npm run lint    # clean
npm run test    # 991 tests pass (no change in count — no existing tests assert on this warning output)
```

**Note:** CI may not auto-trigger on fork PRs due to the first-time contributor approval requirement (#630). Validated locally above.