### PR TITLE
chore: add parseArgs with --help support to check-governance-health.ts

### DIFF
--- a/web/scripts/__tests__/check-governance-health.test.ts
+++ b/web/scripts/__tests__/check-governance-health.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type {
   ActivityData,
   Comment,
@@ -20,6 +20,7 @@ import {
   extractRole,
   hadQuorumFailure,
   inferEligibleVoterCount,
+  parseArgs,
   percentile,
   resolveActivityFile,
 } from '../check-governance-health';
@@ -931,6 +932,47 @@ describe('buildHealthReport', () => {
     expect(report.warnings.some((w) => w.includes('Merge backlog depth'))).toBe(
       true
     );
+  });
+});
+
+// ──────────────────────────────────────────────
+// parseArgs
+// ──────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  it('returns json=false with no args', () => {
+    expect(parseArgs([])).toEqual({ json: false });
+  });
+
+  it('sets json=true for --json flag', () => {
+    expect(parseArgs(['--json'])).toEqual({ json: true });
+  });
+
+  it('throws on unknown flags', () => {
+    expect(() => parseArgs(['--unknown'])).toThrow(
+      'Unknown argument: --unknown'
+    );
+  });
+
+  it('throws on positional args', () => {
+    expect(() => parseArgs(['somefile.json'])).toThrow(
+      'Unknown argument: somefile.json'
+    );
+  });
+
+  it('prints usage and exits with code 0 for --help', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    try {
+      expect(() => parseArgs(['--help'])).toThrow('process.exit');
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Usage:'));
+      expect(exit).toHaveBeenCalledWith(0);
+    } finally {
+      log.mockRestore();
+      exit.mockRestore();
+    }
   });
 });
 

--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -704,6 +704,47 @@ export function resolveActivityFile(
   return env.ACTIVITY_FILE ?? DEFAULT_ACTIVITY_FILE;
 }
 
+// ──────────────────────────────────────────────
+// CLI argument parsing
+// ──────────────────────────────────────────────
+
+interface CliOptions {
+  json: boolean;
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { json: false };
+
+  for (const arg of argv) {
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+
+    if (arg === '--help') {
+      console.log(
+        'Usage: npm run check-governance-health [-- [--json]] [ACTIVITY_FILE=path]'
+      );
+      console.log('');
+      console.log('Options:');
+      console.log(
+        '  --json   Output report as JSON instead of human-readable text'
+      );
+      console.log('  --help   Print this help message and exit');
+      console.log('');
+      console.log('Environment:');
+      console.log(
+        '  ACTIVITY_FILE   Path to activity.json (default: web/public/data/activity.json)'
+      );
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
 function isDirectExecution(): boolean {
   if (!process.argv[1]) return false;
   return resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
@@ -711,7 +752,7 @@ function isDirectExecution(): boolean {
 
 async function main(): Promise<void> {
   const activityFile = resolveActivityFile();
-  const isJson = process.argv.includes('--json');
+  const { json: isJson } = parseArgs(process.argv.slice(2));
 
   if (!existsSync(activityFile)) {
     console.error(`Activity file not found: ${activityFile}`);


### PR DESCRIPTION
Closes #660

## What changed

`check-governance-health.ts` was the only script in `web/scripts/` that handled CLI args inline — no `--help`, no rejection of unknown flags. Every other script exports a `parseArgs` function.

This PR adds an exported `parseArgs(argv: string[])` that:
- Fast-exits with a usage message on `--help`
- Preserves `--json` (no behavior change)
- Throws on unknown arguments (consistent with the rest of the codebase)

`main()` now calls `parseArgs(process.argv.slice(2))` instead of the inline `process.argv.includes('--json')`.

## Validation

```bash
cd web
npm run lint
npm run test -- --run scripts/__tests__/check-governance-health.test.ts
npm run build
```

All pass. Tests: 47 (43 existing + 4 new covering `--json`, `--help`, and unknown flag/arg rejection).