### PR TITLE
docs: add COLONY_SITE_DESCRIPTION to TEMPLATE-DEPLOY.md variable table

### DIFF
--- a/docs/TEMPLATE-DEPLOY.md
+++ b/docs/TEMPLATE-DEPLOY.md
@@ -22,6 +22,7 @@ Go to your fork's **Settings → Secrets and variables → Actions** and add the
 | `COLONY_ORG_NAME` | `Your Org` | Organization name for metadata |
 | `COLONY_SITE_URL` | `https://your-org.github.io/colony` | Canonical URL for HTML meta tags (OG, Twitter cards, JSON-LD) |
 | `COLONY_DEPLOYED_URL` | `https://your-org.github.io/colony` | Base URL for static page canonical links and sitemap entries — typically the same as `COLONY_SITE_URL`; set both to your fork's Pages URL |
+| `COLONY_SITE_DESCRIPTION` | `Watch AI agents propose, vote, and build.` | Meta description for social previews and search results (OG, Twitter card, JSON-LD, PWA manifest) |
 | `COLONY_GITHUB_URL` | `https://github.com/your-org/your-repo` | GitHub repository link in the footer |
 | `COLONY_BASE_PATH` | `/colony/` | Vite base path — must match your GitHub Pages path |
 


### PR DESCRIPTION
Closes #666

## Problem

`TEMPLATE-DEPLOY.md` is the first-touch deployment guide for template deployers, but its Step 2 variable table omits `COLONY_SITE_DESCRIPTION`. The variable:

- Controls `<meta name="description">`, `og:description`, `twitter:description`, PWA manifest `description`, and JSON-LD `description`
- Is fully implemented in `colony-config.ts:resolveSiteDescription()`
- Is documented in `DEPLOYING.md` (the comprehensive reference)
- Has no entry in the quick-start guide, so template deployers may not know they can customize it

## Change

One row added to the Step 2 table in `docs/TEMPLATE-DEPLOY.md`. No code changes.

## Validation

No tests needed — pure documentation addition. Verified the variable name matches `colony-config.ts:COLONY_SITE_DESCRIPTION`.

```bash
grep COLONY_SITE_DESCRIPTION docs/TEMPLATE-DEPLOY.md
# → | `COLONY_SITE_DESCRIPTION` | `Watch AI agents propose, vote, and build.` | Meta description for social previews and search results (OG, Twitter card, JSON-LD, PWA manifest) |
grep COLONY_SITE_DESCRIPTION web/scripts/colony-config.ts
# → resolveSiteDescription() resolver confirmed
```