### PR TITLE
feat: add proposal lifecycle timing health metric

### DIFF
--- a/web/scripts/__tests__/check-governance-health.test.ts
+++ b/web/scripts/__tests__/check-governance-health.test.ts
@@ -12,6 +12,7 @@ import {
   computeGini,
   computeContestedRate,
   computePrCycleTime,
+  computeProposalLifecycleTiming,
   computeRoleDiversity,
   extractRole,
   percentile,
@@ -44,6 +45,19 @@ function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
     commentCount: 3,
     ...overrides,
   };
+}
+
+function makePhaseTransitions(
+  discussionAt: string,
+  votingAt: string,
+  terminalAt?: string,
+  terminalPhase: Proposal['phase'] = 'implemented'
+): NonNullable<Proposal['phaseTransitions']> {
+  return [
+    { phase: 'discussion', enteredAt: discussionAt },
+    { phase: 'voting', enteredAt: votingAt },
+    ...(terminalAt ? [{ phase: terminalPhase, enteredAt: terminalAt }] : []),
+  ];
 }
 
 function makeComment(overrides: Partial<Comment> = {}): Comment {
@@ -403,6 +417,106 @@ describe('computeCrossRoleReviewRate', () => {
 });
 
 // ──────────────────────────────────────────────
+// computeProposalLifecycleTiming
+// ──────────────────────────────────────────────
+
+describe('computeProposalLifecycleTiming', () => {
+  it('returns null medians and zero samples for proposals without transitions', () => {
+    const result = computeProposalLifecycleTiming([makeProposal()]);
+    expect(result.medianDiscussionHours).toBeNull();
+    expect(result.medianVotingHours).toBeNull();
+    expect(result.medianCycleHours).toBeNull();
+    expect(result.sampleSize).toBe(0);
+    expect(result.resolvedSampleSize).toBe(0);
+  });
+
+  it('computes median discussion, voting, and cycle hours from transitions', () => {
+    const proposals = [
+      makeProposal({
+        number: 1,
+        createdAt: '2026-02-01T00:00:00Z',
+        phaseTransitions: makePhaseTransitions(
+          '2026-02-01T00:00:00Z',
+          '2026-02-02T00:00:00Z',
+          '2026-02-03T00:00:00Z'
+        ),
+      }),
+      makeProposal({
+        number: 2,
+        createdAt: '2026-02-01T00:00:00Z',
+        phaseTransitions: makePhaseTransitions(
+          '2026-02-01T00:00:00Z',
+          '2026-02-03T00:00:00Z',
+          '2026-02-05T00:00:00Z'
+        ),
+      }),
+      makeProposal({
+        number: 3,
+        createdAt: '2026-02-01T00:00:00Z',
+        phaseTransitions: makePhaseTransitions(
+          '2026-02-01T00:00:00Z',
+          '2026-02-04T00:00:00Z',
+          '2026-02-07T00:00:00Z'
+        ),
+      }),
+    ];
+
+    const result = computeProposalLifecycleTiming(proposals);
+    expect(result.medianDiscussionHours).toBe(48);
+    expect(result.medianVotingHours).toBe(48);
+    expect(result.medianCycleHours).toBe(96);
+    expect(result.sampleSize).toBe(3);
+    expect(result.resolvedSampleSize).toBe(3);
+  });
+
+  it('counts active proposals in sampleSize without adding terminal-cycle data', () => {
+    const proposals = [
+      makeProposal({
+        number: 1,
+        phase: 'voting',
+        phaseTransitions: makePhaseTransitions(
+          '2026-02-01T00:00:00Z',
+          '2026-02-02T00:00:00Z'
+        ),
+      }),
+      makeProposal({
+        number: 2,
+        createdAt: '2026-02-01T00:00:00Z',
+        phaseTransitions: makePhaseTransitions(
+          '2026-02-01T00:00:00Z',
+          '2026-02-03T00:00:00Z',
+          '2026-02-05T00:00:00Z'
+        ),
+      }),
+    ];
+
+    const result = computeProposalLifecycleTiming(proposals);
+    expect(result.sampleSize).toBe(2);
+    expect(result.resolvedSampleSize).toBe(1);
+    expect(result.medianDiscussionHours).toBe(36);
+    expect(result.medianVotingHours).toBe(48);
+    expect(result.medianCycleHours).toBe(96);
+  });
+
+  it('uses extended-voting as the voting start when standard voting is absent', () => {
+    const result = computeProposalLifecycleTiming([
+      makeProposal({
+        createdAt: '2026-02-01T00:00:00Z',
+        phaseTransitions: [
+          { phase: 'discussion', enteredAt: '2026-02-01T00:00:00Z' },
+          { phase: 'extended-voting', enteredAt: '2026-02-03T00:00:00Z' },
+          { phase: 'implemented', enteredAt: '2026-02-05T00:00:00Z' },
+        ],
+      }),
+    ]);
+
+    expect(result.medianDiscussionHours).toBe(48);
+    expect(result.medianVotingHours).toBe(48);
+    expect(result.medianCycleHours).toBe(96);
+  });
+});
+
+// ──────────────────────────────────────────────
 // computeDataWindowDays
 // ──────────────────────────────────────────────
 
@@ -437,6 +551,7 @@ describe('buildHealthReport', () => {
     expect(report.metrics.roleDiversity).toBeDefined();
     expect(report.metrics.contestedDecisionRate).toBeDefined();
     expect(report.metrics.crossRoleReviewRate).toBeDefined();
+    expect(report.metrics.proposalLifecycleTiming).toBeDefined();
     expect(report.warnings).toBeInstanceOf(Array);
   });
 
@@ -545,6 +660,44 @@ describe('buildHealthReport', () => {
     ).toBe(true);
   });
 
+  it('emits proposal discussion warning when median discussion time exceeds 72 hours', () => {
+    const proposals = Array.from({ length: 5 }, (_, i) =>
+      makeProposal({
+        number: i + 1,
+        createdAt: '2026-02-01T00:00:00Z',
+        phaseTransitions: makePhaseTransitions(
+          '2026-02-01T00:00:00Z',
+          '2026-02-05T00:00:00Z',
+          '2026-02-06T00:00:00Z'
+        ),
+      })
+    );
+
+    const report = buildHealthReport(minimalData({ proposals }));
+    expect(
+      report.warnings.some((w) => w.includes('Proposal discussion median'))
+    ).toBe(true);
+  });
+
+  it('emits proposal lifecycle warning when median cycle time exceeds 14 days', () => {
+    const proposals = Array.from({ length: 5 }, (_, i) =>
+      makeProposal({
+        number: i + 1,
+        createdAt: '2026-02-01T00:00:00Z',
+        phaseTransitions: makePhaseTransitions(
+          '2026-02-01T00:00:00Z',
+          '2026-02-03T00:00:00Z',
+          '2026-02-18T00:00:00Z'
+        ),
+      })
+    );
+
+    const report = buildHealthReport(minimalData({ proposals }));
+    expect(
+      report.warnings.some((w) => w.includes('Proposal lifecycle median'))
+    ).toBe(true);
+  });
+
   it('does not emit contested warning with fewer than 5 voted proposals', () => {
     const proposals = Array.from({ length: 4 }, (_, i) =>
       makeProposal({
@@ -555,6 +708,28 @@ describe('buildHealthReport', () => {
     const report = buildHealthReport(minimalData({ proposals }));
     expect(
       report.warnings.some((w) => w.includes('Contested decision rate'))
+    ).toBe(false);
+  });
+
+  it('does not emit lifecycle warnings with fewer than 5 resolved proposals', () => {
+    const proposals = Array.from({ length: 4 }, (_, i) =>
+      makeProposal({
+        number: i + 1,
+        createdAt: '2026-02-01T00:00:00Z',
+        phaseTransitions: makePhaseTransitions(
+          '2026-02-01T00:00:00Z',
+          '2026-02-10T00:00:00Z',
+          '2026-02-20T00:00:00Z'
+        ),
+      })
+    );
+
+    const report = buildHealthReport(minimalData({ proposals }));
+    expect(
+      report.warnings.some((w) => w.includes('Proposal discussion median'))
+    ).toBe(false);
+    expect(
+      report.warnings.some((w) => w.includes('Proposal lifecycle median'))
     ).toBe(false);
   });
 });

--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -1,12 +1,12 @@
 /**
  * Governance health checker — CLI script.
  *
- * Reads activity.json and computes four CHAOSS-aligned metrics that are
- * not covered by the existing dashboard utilities:
+ * Reads activity.json and computes five governance health metrics:
  *   1. PR cycle time (p50/p95) — time from PR opened to merged
  *   2. Role diversity index — Gini coefficient of proposal authorship
  *   3. Contested decision rate — proposals with any 👎 / total voted
  *   4. Cross-role review rate — reviews where reviewer role ≠ PR author role
+ *   5. Proposal lifecycle timing — median discussion, voting, and full-cycle duration
  *
  * Usage:
  *   npm run check-governance-health
@@ -82,6 +82,19 @@ export interface CrossRoleReviewMetric {
   rate: number;
 }
 
+export interface ProposalLifecycleTimingMetric {
+  /** Median hours from proposal creation to entering voting, or null if no data */
+  medianDiscussionHours: number | null;
+  /** Median hours from entering voting to terminal phase, or null if no data */
+  medianVotingHours: number | null;
+  /** Median hours from proposal creation to terminal phase, or null if no data */
+  medianCycleHours: number | null;
+  /** Number of proposals that include at least one phase transition */
+  sampleSize: number;
+  /** Number of proposals that reached a terminal phase */
+  resolvedSampleSize: number;
+}
+
 export interface HealthReport {
   generatedAt: string;
   /** Days spanned by the earliest to latest proposal */
@@ -91,6 +104,7 @@ export interface HealthReport {
     roleDiversity: RoleDiversityMetric;
     contestedDecisionRate: ContestedRateMetric;
     crossRoleReviewRate: CrossRoleReviewMetric;
+    proposalLifecycleTiming: ProposalLifecycleTimingMetric;
   };
   /** Human-readable warnings for metrics outside healthy thresholds */
   warnings: string[];
@@ -135,6 +149,22 @@ export function computeGini(values: number[]): number {
   }
   return sumOfDiffs / (n * total);
 }
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
+const TERMINAL_PHASES = new Set([
+  'ready-to-implement',
+  'implemented',
+  'rejected',
+  'inconclusive',
+]);
 
 // ──────────────────────────────────────────────
 // Metric computation
@@ -241,6 +271,78 @@ export function computeCrossRoleReviewRate(
   };
 }
 
+export function computeProposalLifecycleTiming(
+  proposals: Proposal[]
+): ProposalLifecycleTimingMetric {
+  const discussionDurations: number[] = [];
+  const votingDurations: number[] = [];
+  const cycleDurations: number[] = [];
+
+  let sampleSize = 0;
+  let resolvedSampleSize = 0;
+
+  for (const proposal of proposals) {
+    const transitions = proposal.phaseTransitions;
+    if (!transitions || transitions.length === 0) continue;
+
+    sampleSize++;
+
+    const phaseTimestamps = new Map<string, number>();
+    for (const transition of transitions) {
+      if (!phaseTimestamps.has(transition.phase)) {
+        phaseTimestamps.set(
+          transition.phase,
+          new Date(transition.enteredAt).getTime()
+        );
+      }
+    }
+
+    const discussionStart = phaseTimestamps.get('discussion');
+    const votingStart =
+      phaseTimestamps.get('voting') ?? phaseTimestamps.get('extended-voting');
+
+    let terminalTime: number | undefined;
+    for (const transition of transitions) {
+      if (TERMINAL_PHASES.has(transition.phase)) {
+        terminalTime = new Date(transition.enteredAt).getTime();
+        break;
+      }
+    }
+
+    if (discussionStart !== undefined && votingStart !== undefined) {
+      const discussionHours =
+        (votingStart - discussionStart) / (1000 * 60 * 60);
+      if (discussionHours >= 0) {
+        discussionDurations.push(discussionHours);
+      }
+    }
+
+    if (votingStart !== undefined && terminalTime !== undefined) {
+      const votingHours = (terminalTime - votingStart) / (1000 * 60 * 60);
+      if (votingHours >= 0) {
+        votingDurations.push(votingHours);
+      }
+    }
+
+    if (terminalTime !== undefined) {
+      const createdTime = new Date(proposal.createdAt).getTime();
+      const cycleHours = (terminalTime - createdTime) / (1000 * 60 * 60);
+      if (cycleHours >= 0) {
+        cycleDurations.push(cycleHours);
+      }
+      resolvedSampleSize++;
+    }
+  }
+
+  return {
+    medianDiscussionHours: median(discussionDurations),
+    medianVotingHours: median(votingDurations),
+    medianCycleHours: median(cycleDurations),
+    sampleSize,
+    resolvedSampleSize,
+  };
+}
+
 export function computeDataWindowDays(proposals: Proposal[]): number {
   if (proposals.length === 0) return 0;
   const times = proposals.map((p) => new Date(p.createdAt).getTime());
@@ -265,6 +367,13 @@ const CROSS_ROLE_MIN_WARN = Number(process.env.GH_CROSS_ROLE_MIN_WARN ?? '0.3');
 const CROSS_ROLE_MIN_SAMPLE = Number(
   process.env.GH_CROSS_ROLE_MIN_SAMPLE ?? '10'
 );
+const DISCUSSION_HOURS_WARN = Number(
+  process.env.GH_DISCUSSION_HOURS_WARN ?? '72'
+);
+const LIFECYCLE_HOURS_WARN = Number(
+  process.env.GH_LIFECYCLE_HOURS_WARN ?? '336'
+);
+const LIFECYCLE_MIN_SAMPLE = Number(process.env.GH_LIFECYCLE_MIN_SAMPLE ?? '5');
 
 export function buildHealthReport(data: ActivityData): HealthReport {
   const prCycleTime = computePrCycleTime(data.pullRequests);
@@ -273,6 +382,9 @@ export function buildHealthReport(data: ActivityData): HealthReport {
   const crossRoleReviewRate = computeCrossRoleReviewRate(
     data.pullRequests,
     data.comments
+  );
+  const proposalLifecycleTiming = computeProposalLifecycleTiming(
+    data.proposals
   );
 
   const warnings: string[] = [];
@@ -314,6 +426,27 @@ export function buildHealthReport(data: ActivityData): HealthReport {
     );
   }
 
+  if (
+    proposalLifecycleTiming.resolvedSampleSize >= LIFECYCLE_MIN_SAMPLE &&
+    proposalLifecycleTiming.medianDiscussionHours !== null &&
+    proposalLifecycleTiming.medianDiscussionHours > DISCUSSION_HOURS_WARN
+  ) {
+    warnings.push(
+      `Proposal discussion median (${proposalLifecycleTiming.medianDiscussionHours.toFixed(1)}h) exceeds ${DISCUSSION_HOURS_WARN}h threshold — proposals may be stalling before voting`
+    );
+  }
+
+  if (
+    proposalLifecycleTiming.resolvedSampleSize >= LIFECYCLE_MIN_SAMPLE &&
+    proposalLifecycleTiming.medianCycleHours !== null &&
+    proposalLifecycleTiming.medianCycleHours > LIFECYCLE_HOURS_WARN
+  ) {
+    const days = (proposalLifecycleTiming.medianCycleHours / 24).toFixed(1);
+    warnings.push(
+      `Proposal lifecycle median (${days}d) exceeds ${(LIFECYCLE_HOURS_WARN / 24).toFixed(0)}d threshold`
+    );
+  }
+
   return {
     generatedAt: new Date().toISOString(),
     dataWindowDays: computeDataWindowDays(data.proposals),
@@ -322,6 +455,7 @@ export function buildHealthReport(data: ActivityData): HealthReport {
       roleDiversity,
       contestedDecisionRate,
       crossRoleReviewRate,
+      proposalLifecycleTiming,
     },
     warnings,
   };
@@ -346,6 +480,7 @@ function printReport(report: HealthReport): void {
     roleDiversity,
     contestedDecisionRate,
     crossRoleReviewRate,
+    proposalLifecycleTiming,
   } = report.metrics;
 
   console.log(`Governance Health Report`);
@@ -382,6 +517,21 @@ function printReport(report: HealthReport): void {
     `  ${crossRoleReviewRate.crossRoleCount}/${crossRoleReviewRate.totalReviews} reviews are cross-role`
   );
   console.log(`  rate: ${Math.round(crossRoleReviewRate.rate * 100)}%`);
+  console.log('');
+
+  console.log('Proposal Lifecycle Timing');
+  console.log(
+    `  discussion p50: ${proposalLifecycleTiming.medianDiscussionHours === null ? 'N/A' : `${proposalLifecycleTiming.medianDiscussionHours.toFixed(1)}h`}`
+  );
+  console.log(
+    `  voting p50:     ${proposalLifecycleTiming.medianVotingHours === null ? 'N/A' : `${proposalLifecycleTiming.medianVotingHours.toFixed(1)}h`}`
+  );
+  console.log(
+    `  cycle p50:      ${proposalLifecycleTiming.medianCycleHours === null ? 'N/A' : `${proposalLifecycleTiming.medianCycleHours.toFixed(1)}h`}`
+  );
+  console.log(
+    `  sample:         ${proposalLifecycleTiming.sampleSize} proposals with transitions (${proposalLifecycleTiming.resolvedSampleSize} resolved)`
+  );
   console.log('');
 
   if (report.warnings.length > 0) {


### PR DESCRIPTION
Fixes #659

## Summary
- add `proposalLifecycleTiming` to the governance health CLI report and JSON output
- compute median discussion, voting, and full-cycle proposal durations from `phaseTransitions`
- warn when median discussion or full lifecycle timing shows sustained governance slowdown
- add focused coverage for the new metric and warning thresholds

## Validation
```bash
cd web
npm install
npm run test -- --run scripts/__tests__/check-governance-health.test.ts
npm run lint -- scripts/check-governance-health.ts scripts/__tests__/check-governance-health.test.ts
npm run build
```
