### PR TITLE
fix: align visibility token precedence in check-visibility

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -7,6 +7,7 @@ import {
   resolveDeployedPageUrl,
   resolveRepositoryHomepage,
   resolveVisibilityRepository,
+  resolveVisibilityToken,
   resolveVisibilityUserAgent,
   type CheckResult,
   type VisibilityReport,
@@ -31,6 +32,46 @@ describe('resolveVisibilityUserAgent', () => {
         VISIBILITY_USER_AGENT: '   ',
       })
     ).toBe('colony-visibility-check');
+  });
+});
+
+describe('resolveVisibilityToken', () => {
+  it('returns GITHUB_TOKEN when it is the only configured token', () => {
+    expect(
+      resolveVisibilityToken({
+        GITHUB_TOKEN: 'github-token',
+      })
+    ).toBe('github-token');
+  });
+
+  it('falls back to GH_TOKEN when GITHUB_TOKEN is missing', () => {
+    expect(
+      resolveVisibilityToken({
+        GH_TOKEN: 'gh-token',
+      })
+    ).toBe('gh-token');
+  });
+
+  it('prefers GITHUB_TOKEN when both tokens are set', () => {
+    expect(
+      resolveVisibilityToken({
+        GITHUB_TOKEN: 'github-token',
+        GH_TOKEN: 'gh-token',
+      })
+    ).toBe('github-token');
+  });
+
+  it('treats blank GITHUB_TOKEN as absent and falls back to GH_TOKEN', () => {
+    expect(
+      resolveVisibilityToken({
+        GITHUB_TOKEN: '',
+        GH_TOKEN: 'gh-token',
+      })
+    ).toBe('gh-token');
+  });
+
+  it('returns undefined when neither token is configured', () => {
+    expect(resolveVisibilityToken({})).toBeUndefined();
   });
 });
 

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -49,6 +49,12 @@ export function resolveVisibilityUserAgent(
   return configured || DEFAULT_VISIBILITY_USER_AGENT;
 }
 
+export function resolveVisibilityToken(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  return env.GITHUB_TOKEN || env.GH_TOKEN || undefined;
+}
+
 export function resolveVisibilityRepository(
   env: NodeJS.ProcessEnv = process.env
 ): {
@@ -269,7 +275,7 @@ async function runChecks(): Promise<CheckResult[]> {
 
   // Repository metadata checks via GitHub API
   try {
-    const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+    const token = resolveVisibilityToken();
     const userAgent = resolveVisibilityUserAgent();
     const headers: Record<string, string> = {
       Accept: 'application/vnd.github.v3+json',


### PR DESCRIPTION
Fixes #631

## Summary
- extract `resolveVisibilityToken(env)` in `check-visibility.ts`
- prefer `GITHUB_TOKEN` over `GH_TOKEN` at the repository-metadata call site
- add focused token-resolution tests, including the blank-`GITHUB_TOKEN` fallback case

## Validation
```bash
cd web
npm run test -- --run scripts/__tests__/check-visibility.test.ts
npm run lint -- scripts/check-visibility.ts scripts/__tests__/check-visibility.test.ts
npm run build
```
