### PR TITLE
feat: append governance health snapshot to governance-health-history.json on each run

### DIFF
--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -21,6 +21,13 @@ import {
   extractPhaseTransitions,
   filterAndMapProposals,
   enrichPullRequestsWithApprovalTimes,
+  buildGovernanceHealthEntry,
+  appendGovernanceHealthEntry,
+  loadGovernanceHealthHistory,
+  HEALTH_HISTORY_SCHEMA_VERSION,
+  HEALTH_HISTORY_MAX_ENTRIES,
+  type GovernanceHealthEntry,
+  type GovernanceHealthHistory,
   type GitHubCommit,
   type GitHubEvent,
   type GitHubTimelineEvent,
@@ -2328,5 +2335,189 @@ describe('extractPhaseTransitions with hivemoot:* labels', () => {
       { phase: 'voting', enteredAt: '2026-01-02T00:00:00Z' },
       { phase: 'implemented', enteredAt: '2026-01-03T00:00:00Z' },
     ]);
+  });
+});
+
+// ──────────────────────────────────────────────
+// Governance health history
+// ──────────────────────────────────────────────
+
+function makeHealthReport(overrides: Record<string, unknown> = {}) {
+  return {
+    generatedAt: '2026-03-14T00:00:00.000Z',
+    dataWindowDays: 30,
+    metrics: {
+      prCycleTime: { p50: 12, p95: 48, sampleSize: 10 },
+      reviewLatency: { p50: 6, p95: 24, sampleSize: 10 },
+      mergeLatency: { p50: 2, p95: 8, sampleSize: 10 },
+      mergeBacklogDepth: { depth: 3, eldestApprovedHours: 72 },
+      roleDiversity: {
+        uniqueRoles: 4,
+        giniIndex: 0.25,
+        topRole: 'forager',
+        topRoleShare: 0.4,
+      },
+      contestedDecisionRate: { contestedCount: 1, totalVoted: 5, rate: 0.2 },
+      crossRoleReviewRate: { crossRoleCount: 7, totalReviews: 10, rate: 0.7 },
+      voterParticipationRate: {
+        votingCyclesAnalyzed: 5,
+        averageParticipationRate: 0.8,
+        quorumFailureRate: 0.1,
+        eligibleVoterCount: 6,
+      },
+    },
+    warnings: ['one warning'],
+    recommendations: ['one recommendation'],
+    ...overrides,
+  };
+}
+
+describe('buildGovernanceHealthEntry', () => {
+  it('maps all HealthReport fields to a GovernanceHealthEntry', () => {
+    const report = makeHealthReport();
+    const entry = buildGovernanceHealthEntry(report as never);
+    expect(entry.timestamp).toBe('2026-03-14T00:00:00.000Z');
+    expect(entry.warningCount).toBe(1);
+    expect(entry.metrics.prCycleTimeP50Hours).toBe(12);
+    expect(entry.metrics.prCycleTimeP95Hours).toBe(48);
+    expect(entry.metrics.prCycleTimeSampleSize).toBe(10);
+    expect(entry.metrics.reviewLatencyP50Hours).toBe(6);
+    expect(entry.metrics.reviewLatencyP95Hours).toBe(24);
+    expect(entry.metrics.reviewLatencySampleSize).toBe(10);
+    expect(entry.metrics.mergeLatencyP50Hours).toBe(2);
+    expect(entry.metrics.mergeLatencyP95Hours).toBe(8);
+    expect(entry.metrics.mergeLatencySampleSize).toBe(10);
+    expect(entry.metrics.mergeBacklogDepth).toBe(3);
+    expect(entry.metrics.roleDiversityGini).toBe(0.25);
+    expect(entry.metrics.roleDiversityUniqueRoles).toBe(4);
+    expect(entry.metrics.contestedDecisionRate).toBe(0.2);
+    expect(entry.metrics.crossRoleReviewRate).toBe(0.7);
+    expect(entry.metrics.voterParticipationRate).toBe(0.8);
+  });
+
+  it('handles null metrics correctly', () => {
+    const report = makeHealthReport();
+    report.metrics.prCycleTime.p50 = null as never;
+    report.metrics.prCycleTime.p95 = null as never;
+    report.metrics.voterParticipationRate.averageParticipationRate =
+      null as never;
+    const entry = buildGovernanceHealthEntry(report as never);
+    expect(entry.metrics.prCycleTimeP50Hours).toBeNull();
+    expect(entry.metrics.prCycleTimeP95Hours).toBeNull();
+    expect(entry.metrics.voterParticipationRate).toBeNull();
+  });
+
+  it('sets warningCount to zero when no warnings', () => {
+    const report = makeHealthReport();
+    report.warnings = [];
+    const entry = buildGovernanceHealthEntry(report as never);
+    expect(entry.warningCount).toBe(0);
+  });
+});
+
+describe('appendGovernanceHealthEntry', () => {
+  it('appends an entry to an empty list', () => {
+    const report = makeHealthReport();
+    const entry = buildGovernanceHealthEntry(report as never);
+    const result = appendGovernanceHealthEntry([], entry);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(entry);
+  });
+
+  it('preserves order — new entry is last', () => {
+    const e1 = buildGovernanceHealthEntry(
+      makeHealthReport({ generatedAt: '2026-01-01T00:00:00.000Z' }) as never
+    );
+    const e2 = buildGovernanceHealthEntry(
+      makeHealthReport({ generatedAt: '2026-01-02T00:00:00.000Z' }) as never
+    );
+    const result = appendGovernanceHealthEntry([e1], e2);
+    expect(result[0].timestamp).toBe('2026-01-01T00:00:00.000Z');
+    expect(result[1].timestamp).toBe('2026-01-02T00:00:00.000Z');
+  });
+
+  it('caps at HEALTH_HISTORY_MAX_ENTRIES (90)', () => {
+    const base = buildGovernanceHealthEntry(makeHealthReport() as never);
+    const existing: GovernanceHealthEntry[] = Array.from(
+      { length: HEALTH_HISTORY_MAX_ENTRIES },
+      (_, i) => ({
+        ...base,
+        timestamp: `2025-01-${String(i + 1).padStart(2, '0')}T00:00:00.000Z`,
+      })
+    );
+    const newEntry = { ...base, timestamp: '2026-03-14T00:00:00.000Z' };
+    const result = appendGovernanceHealthEntry(existing, newEntry);
+    expect(result).toHaveLength(HEALTH_HISTORY_MAX_ENTRIES);
+    expect(result[result.length - 1].timestamp).toBe(
+      '2026-03-14T00:00:00.000Z'
+    );
+    // oldest entry should have been dropped
+    expect(result[0].timestamp).toBe('2025-01-02T00:00:00.000Z');
+  });
+
+  it('does not mutate the existing array', () => {
+    const e1 = buildGovernanceHealthEntry(makeHealthReport() as never);
+    const e2 = buildGovernanceHealthEntry(makeHealthReport() as never);
+    const original = [e1];
+    appendGovernanceHealthEntry(original, e2);
+    expect(original).toHaveLength(1);
+  });
+});
+
+describe('loadGovernanceHealthHistory', () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns empty history when file does not exist', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'health-history-'));
+    const result = loadGovernanceHealthHistory(
+      join(tmpDir, 'nonexistent.json')
+    );
+    expect(result.schemaVersion).toBe(HEALTH_HISTORY_SCHEMA_VERSION);
+    expect(result.snapshots).toEqual([]);
+  });
+
+  it('parses a valid history file', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'health-history-'));
+    const filePath = join(tmpDir, 'governance-health-history.json');
+    const entry = buildGovernanceHealthEntry(makeHealthReport() as never);
+    const history: GovernanceHealthHistory = {
+      schemaVersion: HEALTH_HISTORY_SCHEMA_VERSION,
+      generatedAt: '2026-03-14T00:00:00.000Z',
+      snapshots: [entry],
+    };
+    writeFileSync(filePath, JSON.stringify(history, null, 2));
+    const result = loadGovernanceHealthHistory(filePath);
+    expect(result.schemaVersion).toBe(HEALTH_HISTORY_SCHEMA_VERSION);
+    expect(result.snapshots).toHaveLength(1);
+    expect(result.snapshots[0].timestamp).toBe('2026-03-14T00:00:00.000Z');
+  });
+
+  it('returns empty history on invalid JSON', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'health-history-'));
+    const filePath = join(tmpDir, 'governance-health-history.json');
+    writeFileSync(filePath, 'not valid json{{{');
+    const result = loadGovernanceHealthHistory(filePath);
+    expect(result.schemaVersion).toBe(HEALTH_HISTORY_SCHEMA_VERSION);
+    expect(result.snapshots).toEqual([]);
+  });
+
+  it('returns empty history when schemaVersion is mismatched', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'health-history-'));
+    const filePath = join(tmpDir, 'governance-health-history.json');
+    const badHistory = {
+      schemaVersion: 999,
+      generatedAt: '2026-03-14T00:00:00.000Z',
+      snapshots: [],
+    };
+    writeFileSync(filePath, JSON.stringify(badHistory));
+    const result = loadGovernanceHealthHistory(filePath);
+    expect(result.schemaVersion).toBe(HEALTH_HISTORY_SCHEMA_VERSION);
+    expect(result.snapshots).toEqual([]);
   });
 });

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -49,6 +49,10 @@ import { computeGovernanceHistoryIntegrity } from './governance-history-integrit
 import { evaluateGeneratedAtFreshness } from './freshness';
 import { DEFAULT_DEPLOYED_BASE_URL } from './colony-config';
 import { buildChaossSnapshot } from './chaoss-snapshot';
+import {
+  buildHealthReport,
+  type HealthReport,
+} from './check-governance-health';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '..', '..');
@@ -56,6 +60,7 @@ const OUTPUT_DIR = join(__dirname, '..', 'public', 'data');
 const OUTPUT_FILE = join(OUTPUT_DIR, 'activity.json');
 const HISTORY_FILE = join(OUTPUT_DIR, 'governance-history.json');
 const METRICS_SNAPSHOT_FILE = join(OUTPUT_DIR, 'metrics', 'snapshot.json');
+const HEALTH_HISTORY_FILE = join(OUTPUT_DIR, 'governance-health-history.json');
 const ROADMAP_PATH = join(ROOT_DIR, 'ROADMAP.md');
 const INDEX_HTML_PATH = join(ROOT_DIR, 'web', 'index.html');
 const SITEMAP_PATH = join(ROOT_DIR, 'web', 'public', 'sitemap.xml');
@@ -1974,6 +1979,103 @@ function emptyHistoryArtifact(generatedAt: string): GovernanceHistoryArtifact {
   };
 }
 
+// ──────────────────────────────────────────────
+// Governance health history
+// ──────────────────────────────────────────────
+
+export const HEALTH_HISTORY_SCHEMA_VERSION = 1;
+export const HEALTH_HISTORY_MAX_ENTRIES = 90;
+
+export interface GovernanceHealthEntry {
+  timestamp: string;
+  metrics: {
+    prCycleTimeP50Hours: number | null;
+    prCycleTimeP95Hours: number | null;
+    prCycleTimeSampleSize: number;
+    reviewLatencyP50Hours: number | null;
+    reviewLatencyP95Hours: number | null;
+    reviewLatencySampleSize: number;
+    mergeLatencyP50Hours: number | null;
+    mergeLatencyP95Hours: number | null;
+    mergeLatencySampleSize: number;
+    mergeBacklogDepth: number;
+    roleDiversityGini: number;
+    roleDiversityUniqueRoles: number;
+    contestedDecisionRate: number | null;
+    crossRoleReviewRate: number | null;
+    voterParticipationRate: number | null;
+  };
+  warningCount: number;
+}
+
+export interface GovernanceHealthHistory {
+  schemaVersion: number;
+  generatedAt: string;
+  snapshots: GovernanceHealthEntry[];
+}
+
+export function buildGovernanceHealthEntry(
+  report: HealthReport
+): GovernanceHealthEntry {
+  const m = report.metrics;
+  return {
+    timestamp: report.generatedAt,
+    metrics: {
+      prCycleTimeP50Hours: m.prCycleTime.p50,
+      prCycleTimeP95Hours: m.prCycleTime.p95,
+      prCycleTimeSampleSize: m.prCycleTime.sampleSize,
+      reviewLatencyP50Hours: m.reviewLatency.p50,
+      reviewLatencyP95Hours: m.reviewLatency.p95,
+      reviewLatencySampleSize: m.reviewLatency.sampleSize,
+      mergeLatencyP50Hours: m.mergeLatency.p50,
+      mergeLatencyP95Hours: m.mergeLatency.p95,
+      mergeLatencySampleSize: m.mergeLatency.sampleSize,
+      mergeBacklogDepth: m.mergeBacklogDepth.depth,
+      roleDiversityGini: m.roleDiversity.giniIndex,
+      roleDiversityUniqueRoles: m.roleDiversity.uniqueRoles,
+      contestedDecisionRate: m.contestedDecisionRate.rate,
+      crossRoleReviewRate: m.crossRoleReviewRate.rate,
+      voterParticipationRate: m.voterParticipationRate.averageParticipationRate,
+    },
+    warningCount: report.warnings.length,
+  };
+}
+
+export function appendGovernanceHealthEntry(
+  existing: GovernanceHealthEntry[],
+  entry: GovernanceHealthEntry
+): GovernanceHealthEntry[] {
+  const updated = [...existing, entry];
+  if (updated.length > HEALTH_HISTORY_MAX_ENTRIES) {
+    return updated.slice(updated.length - HEALTH_HISTORY_MAX_ENTRIES);
+  }
+  return updated;
+}
+
+export function loadGovernanceHealthHistory(
+  filePath: string = HEALTH_HISTORY_FILE
+): GovernanceHealthHistory {
+  try {
+    if (existsSync(filePath)) {
+      const raw = readFileSync(filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as GovernanceHealthHistory;
+      if (
+        parsed.schemaVersion === HEALTH_HISTORY_SCHEMA_VERSION &&
+        Array.isArray(parsed.snapshots)
+      ) {
+        return parsed;
+      }
+    }
+  } catch {
+    // fall through to empty history
+  }
+  return {
+    schemaVersion: HEALTH_HISTORY_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    snapshots: [],
+  };
+}
+
 /**
  * Load existing governance history from disk, normalizing legacy array format.
  */
@@ -2043,6 +2145,27 @@ async function main(): Promise<void> {
       JSON.stringify(chaossSnapshot, null, 2)
     );
     console.log(`CHAOSS metrics snapshot written to ${METRICS_SNAPSHOT_FILE}`);
+
+    // Append governance health snapshot
+    const healthReport = buildHealthReport(data);
+    const healthEntry = buildGovernanceHealthEntry(healthReport);
+    const healthHistory = loadGovernanceHealthHistory();
+    const updatedHealthSnapshots = appendGovernanceHealthEntry(
+      healthHistory.snapshots,
+      healthEntry
+    );
+    const updatedHealthHistory: GovernanceHealthHistory = {
+      schemaVersion: HEALTH_HISTORY_SCHEMA_VERSION,
+      generatedAt: data.generatedAt,
+      snapshots: updatedHealthSnapshots,
+    };
+    writeFileSync(
+      HEALTH_HISTORY_FILE,
+      JSON.stringify(updatedHealthHistory, null, 2)
+    );
+    console.log(
+      `Governance health snapshot appended to ${HEALTH_HISTORY_FILE} (${updatedHealthSnapshots.length} entries)`
+    );
 
     // Keep sitemap lastmod in sync with the generation timestamp
     updateSitemapLastmod(data.generatedAt);


### PR DESCRIPTION
## Summary

Fixes #605 (Phase 1 only)

- Adds `HEALTH_HISTORY_FILE` constant pointing to `web/public/data/governance-health-history.json`
- Imports `buildHealthReport` from `./check-governance-health` (no modifications to that file)
- Exports `buildGovernanceHealthEntry`, `appendGovernanceHealthEntry`, `loadGovernanceHealthHistory`, plus the `GovernanceHealthEntry` / `GovernanceHealthHistory` interfaces and the `HEALTH_HISTORY_SCHEMA_VERSION` / `HEALTH_HISTORY_MAX_ENTRIES` constants
- In `main()`, after writing the CHAOSS snapshot, calls `buildHealthReport(data)`, maps the result to a `GovernanceHealthEntry`, loads the existing history, appends the entry (ring-buffer capped at 90), and writes the updated file
- Only `generate-data.ts` and its test file are modified

## Test plan

- [ ] `cd web && npm run test -- --run scripts/__tests__/generate-data.test.ts` — 91 tests pass
- [ ] `npm run lint -- scripts/generate-data.ts` — exits 0
- [ ] `npm run build` — exits 0
- [ ] New `describe` blocks cover `buildGovernanceHealthEntry` (field mapping, null propagation, zero warnings), `appendGovernanceHealthEntry` (append, ordering, 90-entry cap, no mutation), and `loadGovernanceHealthHistory` (missing file, valid file, invalid JSON, schema mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)