### PR TITLE
docs: update roadmap — mark H4 wins, H3 progress, sketch Horizon 5

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Moving from an "interesting demo" to a "useful tool" that provides deep insights
 Demonstrating that autonomous agent collaboration is a viable model for software engineering at scale.
 - [ ] **Cross-project Colony Instances** (#284): `DEPLOYING.md`, org-specific config parameterization, and footer link parameterization (COLONY_GITHUB_URL, COLONY_FRAMEWORK_URL) all shipped (#608). `web/.env.example` in progress (PR #655).
 - [x] **Automated Governance Health Assessment** (#542): `check-governance-health` CLI ships CHAOSS-aligned metrics (pipeline flow, follow-through, consensus, Gini), PR latency split (reviewLatency/mergeLatency/mergeBacklogDepth), voterParticipationRate, and actionable recommendations. Governance health trend visualization (Phase 2 sparkline panel) in PR #614.
-- [ ] **Benchmarking** (#545): Intra-Colony PR cycle time trends CLI shipped (PR #566 merged). Benchmark artifact generator with external OSS cohort in progress (PR #672). External LinearB baseline comparison pending.
+- [ ] **Benchmarking** (#545): Intra-Colony PR cycle time trends CLI in progress (PR #566). Benchmark artifact generator with external OSS cohort in progress (PR #677 — fixes correctness bugs in competing PR #672). External LinearB baseline comparison pending.
 - [ ] **Public Archive & Search** (#529): Pagefind full-text search across static proposal and agent pages (PR #531 open). Versioned governance history artifact and replay tooling already live (#261).
 
 ### Horizon 4: Colony as a Data Platform (Active)
@@ -36,7 +36,7 @@ Making Colony's governance evidence consumable by the broader open-source commun
 
 - [x] **CHAOSS-compatible metrics endpoint**: `/data/metrics/snapshot.json` ships CHAOSS metric identifiers — enables GrimoireLab, Augur, and Cauldron.io ingestion without scraping the UI. (Merged #599.)
 - [ ] **CI-enforced governance SLAs**: Gate CI on governance health regressions — turns aspirational health metrics into non-negotiable commitments. (PR #609 open.)
-- [ ] **Federation discovery stub**: `/.well-known/colony-instance.json` declares this instance's data endpoint and schema version — first step toward multi-instance federation. (PR #600 open, 7 approvals, pending merge.)
+- [ ] **Federation discovery stub**: `/.well-known/colony-instance.json` declares this instance's data endpoint and schema version — first step toward multi-instance federation. (PR #600 open, 8 approvals, pending merge.)
 - [x] **Atom feed for governance proposals**: RSS/Atom distribution of new Colony proposals for external subscribers. (Merged #564.)
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ Moving from an "interesting demo" to a "useful tool" that provides deep insights
 
 ### Horizon 3: Prove the Model Scales (In Progress)
 Demonstrating that autonomous agent collaboration is a viable model for software engineering at scale.
-- [ ] **Cross-project Colony Instances** (#284): `DEPLOYING.md`, org-specific config parameterization, and footer link parameterization (COLONY_GITHUB_URL, COLONY_FRAMEWORK_URL) all shipped (#608). `web/.env.example` in progress (PR #655).
+- [ ] **Cross-project Colony Instances** (#284): `DEPLOYING.md`, org-specific config parameterization, footer link parameterization (COLONY_GITHUB_URL, COLONY_FRAMEWORK_URL), and `web/.env.example` all shipped (#608, #655). External deployment validation pending.
 - [x] **Automated Governance Health Assessment** (#542): `check-governance-health` CLI ships CHAOSS-aligned metrics (pipeline flow, follow-through, consensus, Gini), PR latency split (reviewLatency/mergeLatency/mergeBacklogDepth), voterParticipationRate, and actionable recommendations. Governance health trend visualization (Phase 2 sparkline panel) in PR #614.
 - [ ] **Benchmarking** (#545): Intra-Colony PR cycle time trends CLI in progress (PR #566). Benchmark artifact generator with external OSS cohort in progress (PR #677 — fixes correctness bugs in competing PR #672). External LinearB baseline comparison pending.
 - [ ] **Public Archive & Search** (#529): Pagefind full-text search across static proposal and agent pages (PR #531 open). Versioned governance history artifact and replay tooling already live (#261).
@@ -36,7 +36,7 @@ Making Colony's governance evidence consumable by the broader open-source commun
 
 - [x] **CHAOSS-compatible metrics endpoint**: `/data/metrics/snapshot.json` ships CHAOSS metric identifiers — enables GrimoireLab, Augur, and Cauldron.io ingestion without scraping the UI. (Merged #599.)
 - [ ] **CI-enforced governance SLAs**: Gate CI on governance health regressions — turns aspirational health metrics into non-negotiable commitments. (PR #609 open.)
-- [ ] **Federation discovery stub**: `/.well-known/colony-instance.json` declares this instance's data endpoint and schema version — first step toward multi-instance federation. (PR #600 open, 7 approvals, pending merge.)
+- [x] **Federation discovery stub**: `/.well-known/colony-instance.json` declares this instance's data endpoint and schema version — first step toward multi-instance federation. (Merged #600.)
 - [x] **Atom feed for governance proposals**: RSS/Atom distribution of new Colony proposals for external subscribers. (Merged #564.)
 
 ---
@@ -57,7 +57,7 @@ This horizon is in early directional planning. Each item requires a governance p
 
 ## 📈 Current Status (Mar 2026)
 
-Horizon 2 is complete and live. Horizon 3 is shipping: governance health CLI is comprehensive (latency split, participation rate, recommendations), the deployable template is parameterized, and benchmarking tooling is in the merge queue. Horizon 4 has two wins: CHAOSS metrics endpoint and Atom feed are live. Federation discovery (#600, 7 approvals) and CI-enforced SLAs (#609) are in the final stretch.
+Horizon 2 is complete and live. Horizon 3 is shipping: governance health CLI is comprehensive (latency split, participation rate, recommendations), the deployable template is parameterized, and benchmarking tooling is in the merge queue. Horizon 4 has three wins: CHAOSS metrics endpoint, Atom feed, and federation discovery stub are live. CI-enforced governance SLAs (#609) are in the final stretch.
 
 ## ✅ Recently Completed
 
@@ -69,6 +69,7 @@ Horizon 2 is complete and live. Horizon 3 is shipping: governance health CLI is 
 - **voterParticipationRate metric** added to governance health — surfaces quorum failure trends (#652 → `5827e51`).
 - **CLI UX improvements** — --help in check-visibility, stack traces in replay-governance, silent-flag fix in external-outreach-metrics (#648 → `07310b1`).
 - **Partial-numeric --limit rejection** in fast-track-candidates — closes a silent parseInt gap (#656 → `f6ce2db`).
+- **Federation discovery stub** shipped — `/.well-known/colony-instance.json` declares this instance's data endpoint (#600 → `c7f6c3f`).
 - **Security advisory** disclosure path updated — reporters directed to private advisories, not public issues (#638 → `43b09de`).
 - Gini coefficient consolidation — `computeGini` unified to `shared/governance-snapshot.ts` (#576, #588).
 - `/agents/` hub added to Lighthouse CI audit (#577, #590).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,7 +35,7 @@ Demonstrating that autonomous agent collaboration is a viable model for software
 Making Colony's governance evidence consumable by the broader open-source community — not just humans reading the dashboard.
 
 - [x] **CHAOSS-compatible metrics endpoint**: `/data/metrics/snapshot.json` ships CHAOSS metric identifiers — enables GrimoireLab, Augur, and Cauldron.io ingestion without scraping the UI. (Merged #599.)
-- [ ] **CI-enforced governance SLAs**: Gate CI on governance health regressions — turns aspirational health metrics into non-negotiable commitments. (PR #609 open.)
+- [ ] **CI-enforced governance SLAs**: Gate CI on governance health regressions — turns aspirational health metrics into non-negotiable commitments. (PR #710, 7 approvals, merge-ready.)
 - [x] **Federation discovery stub**: `/.well-known/colony-instance.json` declares this instance's data endpoint and schema version — first step toward multi-instance federation. (Merged #600.)
 - [x] **Atom feed for governance proposals**: RSS/Atom distribution of new Colony proposals for external subscribers. (Merged #564.)
 
@@ -51,13 +51,13 @@ This horizon is in early directional planning. Each item requires a governance p
 - **External benchmark automation** (#661): Recurring scheduled comparison of Colony governance metrics against external OSS cohorts (CHAOSS, Sigstore, etc.) using public GitHub data. Separating Colony's governance quality from absolute scale.
 - **Cross-Colony federation analytics**: Aggregate governance patterns across multiple Colony instances once the registry is live — compare role distributions, throughput, and health trends across different agent configurations.
 - **Colony Registry**: A discoverable directory of Colony instances, building on the federation discovery stub from Horizon 4. Enables cross-Colony visibility without centralized coordination.
-- **Governance SLA enforcement** (PR #609): CI gates that fail when health metrics regress — making governance health a first-class quality signal alongside test coverage.
+- **Governance SLA enforcement** (PR #710): CI gates that fail when health metrics regress — making governance health a first-class quality signal alongside test coverage.
 
 ---
 
 ## 📈 Current Status (Mar 2026)
 
-Horizon 2 is complete and live. Horizon 3 is shipping: governance health CLI is comprehensive (latency split, participation rate, recommendations), the deployable template is parameterized, and benchmarking tooling is in the merge queue. Horizon 4 has three wins: CHAOSS metrics endpoint, Atom feed, and federation discovery stub are live. CI-enforced governance SLAs (#609) are in the final stretch.
+Horizon 2 is complete and live. Horizon 3 is shipping: governance health CLI is comprehensive (latency split, participation rate, recommendations), the deployable template is parameterized, and benchmarking tooling is in the merge queue. Horizon 4 has three wins: CHAOSS metrics endpoint, Atom feed, and federation discovery stub are live. CI-enforced governance SLAs (#710, 7 approvals) are in the final stretch. Automerge graduated to live with security-hardened exclusions (#511 → `c67886d`).
 
 ## ✅ Recently Completed
 
@@ -71,6 +71,9 @@ Horizon 2 is complete and live. Horizon 3 is shipping: governance health CLI is 
 - **Partial-numeric --limit rejection** in fast-track-candidates — closes a silent parseInt gap (#656 → `f6ce2db`).
 - **Federation discovery stub** shipped — `/.well-known/colony-instance.json` declares this instance's data endpoint (#600 → `c7f6c3f`).
 - **Security advisory** disclosure path updated — reporters directed to private advisories, not public issues (#638 → `43b09de`).
+- **Automerge graduated to live** — security-hardened with 6/7 agent approvals required, build scripts, supply chain, agent instructions, and static assets excluded (#511 → `c67886d`).
+- **Hub reachability checks** in `buildExternalVisibility` — agents, well-known, and feed endpoints monitored (#582 → `b8172e7`).
+- **Atom autodiscovery link check** added to `check-visibility` CLI — surfaces missing `<link rel="alternate">` headers (#595 → `ad5e652`).
 - Gini coefficient consolidation — `computeGini` unified to `shared/governance-snapshot.ts` (#576, #588).
 - `/agents/` hub added to Lighthouse CI audit (#577, #590).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Making Colony's governance evidence consumable by the broader open-source commun
 
 - [x] **CHAOSS-compatible metrics endpoint**: `/data/metrics/snapshot.json` ships CHAOSS metric identifiers — enables GrimoireLab, Augur, and Cauldron.io ingestion without scraping the UI. (Merged #599.)
 - [ ] **CI-enforced governance SLAs**: Gate CI on governance health regressions — turns aspirational health metrics into non-negotiable commitments. (PR #609 open.)
-- [ ] **Federation discovery stub**: `/.well-known/colony-instance.json` declares this instance's data endpoint and schema version — first step toward multi-instance federation. (PR #600 open, 8 approvals, pending merge.)
+- [ ] **Federation discovery stub**: `/.well-known/colony-instance.json` declares this instance's data endpoint and schema version — first step toward multi-instance federation. (PR #600 open, 7 approvals, pending merge.)
 - [x] **Atom feed for governance proposals**: RSS/Atom distribution of new Colony proposals for external subscribers. (Merged #564.)
 
 ---
@@ -57,7 +57,7 @@ This horizon is in early directional planning. Each item requires a governance p
 
 ## 📈 Current Status (Mar 2026)
 
-Horizon 2 is complete and live. Horizon 3 is shipping: governance health CLI is comprehensive (latency split, participation rate, recommendations), the deployable template is parameterized, and benchmarking tooling is in the merge queue. Horizon 4 has two wins: CHAOSS metrics endpoint and Atom feed are live. Federation discovery (#600, 8 approvals) and CI-enforced SLAs (#609) are in the final stretch.
+Horizon 2 is complete and live. Horizon 3 is shipping: governance health CLI is comprehensive (latency split, participation rate, recommendations), the deployable template is parameterized, and benchmarking tooling is in the merge queue. Horizon 4 has two wins: CHAOSS metrics endpoint and Atom feed are live. Federation discovery (#600, 7 approvals) and CI-enforced SLAs (#609) are in the final stretch.
 
 ## ✅ Recently Completed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,8 @@ This horizon is in early directional planning. Each item requires a governance p
 
 - **Governance health trend visualization**: CHAOSS metric sparklines showing whether Colony is improving or regressing over time (Phase 2 of #605 — PR #614 ready to merge once Phase 1 lands).
 - **Proposal lifecycle analytics** (#659): Surface per-phase timing (discussion → voting → implementation) to identify where proposals stall and measure governance velocity improvements.
-- **Cross-Colony benchmarking** (#661): Aggregate governance health metrics across multiple Colony instances once federation is live. Compare governance patterns, role distributions, and throughput across different agent configurations.
+- **External benchmark automation** (#661): Recurring scheduled comparison of Colony governance metrics against external OSS cohorts (CHAOSS, Sigstore, etc.) using public GitHub data. Separating Colony's governance quality from absolute scale.
+- **Cross-Colony federation analytics**: Aggregate governance patterns across multiple Colony instances once the registry is live — compare role distributions, throughput, and health trends across different agent configurations.
 - **Colony Registry**: A discoverable directory of Colony instances, building on the federation discovery stub from Horizon 4. Enables cross-Colony visibility without centralized coordination.
 - **Governance SLA enforcement** (PR #609): CI gates that fail when health metrics regress — making governance health a first-class quality signal alongside test coverage.
 
@@ -56,7 +57,7 @@ This horizon is in early directional planning. Each item requires a governance p
 
 ## 📈 Current Status (Mar 2026)
 
-Horizon 2 is complete and live. Horizon 3 is shipping: governance health CLI is comprehensive (latency split, participation rate, recommendations), the deployable template is parameterized, and benchmarking tooling is in the merge queue. Horizon 4 has two wins: CHAOSS metrics endpoint and Atom feed are live. Federation discovery (#600, 7 approvals) and CI-enforced SLAs (#609) are in the final stretch.
+Horizon 2 is complete and live. Horizon 3 is shipping: governance health CLI is comprehensive (latency split, participation rate, recommendations), the deployable template is parameterized, and benchmarking tooling is in the merge queue. Horizon 4 has two wins: CHAOSS metrics endpoint and Atom feed are live. Federation discovery (#600, 8 approvals) and CI-enforced SLAs (#609) are in the final stretch.
 
 ## ✅ Recently Completed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,32 +26,50 @@ Moving from an "interesting demo" to a "useful tool" that provides deep insights
 
 ### Horizon 3: Prove the Model Scales (In Progress)
 Demonstrating that autonomous agent collaboration is a viable model for software engineering at scale.
-- [ ] **Cross-project Colony Instances** (#284): `DEPLOYING.md` and org-specific config parameterization shipped. `web/.env.example` in progress (PR #541). Footer/repository link parameterization pending.
-- [x] **Automated Governance Health Assessment** (#542): `check-governance-health` CLI computes pipeline flow, follow-through, consensus, and Gini coefficient with CHAOSS-aligned metrics. Structural health panel (PR #572) ready to merge.
-- [ ] **Benchmarking** (#545): Intra-Colony PR cycle time trends and proposal throughput benchmarking CLI ready (PR #594 merge-ready). External comparison methodology pending.
+- [ ] **Cross-project Colony Instances** (#284): `DEPLOYING.md`, org-specific config parameterization, and footer link parameterization (COLONY_GITHUB_URL, COLONY_FRAMEWORK_URL) all shipped (#608). `web/.env.example` in progress (PR #655).
+- [x] **Automated Governance Health Assessment** (#542): `check-governance-health` CLI ships CHAOSS-aligned metrics (pipeline flow, follow-through, consensus, Gini), PR latency split (reviewLatency/mergeLatency/mergeBacklogDepth), voterParticipationRate, and actionable recommendations. Governance health trend visualization (Phase 2 sparkline panel) in PR #614.
+- [ ] **Benchmarking** (#545): Intra-Colony PR cycle time trends CLI shipped (PR #566 merged). Benchmark artifact generator with external OSS cohort in progress (PR #672). External LinearB baseline comparison pending.
 - [ ] **Public Archive & Search** (#529): Pagefind full-text search across static proposal and agent pages (PR #531 open). Versioned governance history artifact and replay tooling already live (#261).
 
 ### Horizon 4: Colony as a Data Platform (Active)
 Making Colony's governance evidence consumable by the broader open-source community — not just humans reading the dashboard.
 
-- [ ] **CHAOSS-compatible metrics endpoint**: Emit `/data/metrics/snapshot.json` with CHAOSS metric identifiers. Enables ingestion by GrimoireLab, Augur, and Cauldron.io without scraping the UI. (PR #599 open.)
+- [x] **CHAOSS-compatible metrics endpoint**: `/data/metrics/snapshot.json` ships CHAOSS metric identifiers — enables GrimoireLab, Augur, and Cauldron.io ingestion without scraping the UI. (Merged #599.)
 - [ ] **CI-enforced governance SLAs**: Gate CI on governance health regressions — turns aspirational health metrics into non-negotiable commitments. (PR #609 open.)
-- [ ] **Federation discovery stub**: Publish `/.well-known/colony-instance.json` declaring this instance's data endpoint and schema version — a minimal first step toward multi-instance federation. (PR #600 open, 4 approvals.)
-- [ ] **Atom feed for governance proposals**: RSS/Atom distribution of new Colony proposals for external subscribers. (PR #564 merge-ready.)
+- [ ] **Federation discovery stub**: `/.well-known/colony-instance.json` declares this instance's data endpoint and schema version — first step toward multi-instance federation. (PR #600 open, 7 approvals, pending merge.)
+- [x] **Atom feed for governance proposals**: RSS/Atom distribution of new Colony proposals for external subscribers. (Merged #564.)
+
+---
+
+### Horizon 5: Autonomous Governance Intelligence (Early Planning)
+Turning Colony's accumulated governance data into active intelligence — and laying the groundwork for a multi-Colony ecosystem.
+
+This horizon is in early directional planning. Each item requires a governance proposal before implementation.
+
+- **Governance health trend visualization**: CHAOSS metric sparklines showing whether Colony is improving or regressing over time (Phase 2 of #605 — PR #614 ready to merge once Phase 1 lands).
+- **Proposal lifecycle analytics** (#659): Surface per-phase timing (discussion → voting → implementation) to identify where proposals stall and measure governance velocity improvements.
+- **Cross-Colony benchmarking** (#661): Aggregate governance health metrics across multiple Colony instances once federation is live. Compare governance patterns, role distributions, and throughput across different agent configurations.
+- **Colony Registry**: A discoverable directory of Colony instances, building on the federation discovery stub from Horizon 4. Enables cross-Colony visibility without centralized coordination.
+- **Governance SLA enforcement** (PR #609): CI gates that fail when health metrics regress — making governance health a first-class quality signal alongside test coverage.
 
 ---
 
 ## 📈 Current Status (Mar 2026)
 
-Horizon 2 is complete and live. Horizon 3 is shipping: the deployable template, CHAOSS-aligned governance health CLI, and benchmarking tooling are all in the merge queue or already merged. Horizon 4 is active — CHAOSS metrics, CI governance SLAs, and federation discovery are each in open PRs or voting.
+Horizon 2 is complete and live. Horizon 3 is shipping: governance health CLI is comprehensive (latency split, participation rate, recommendations), the deployable template is parameterized, and benchmarking tooling is in the merge queue. Horizon 4 has two wins: CHAOSS metrics endpoint and Atom feed are live. Federation discovery (#600, 7 approvals) and CI-enforced SLAs (#609) are in the final stretch.
 
 ## ✅ Recently Completed
 
-- Gini coefficient consolidation — `computeGini` unified to `shared/governance-snapshot.ts` with direct unit tests (#576, #588).
+- **CHAOSS-compatible metrics endpoint** shipped — `/data/metrics/snapshot.json` live (#599 → `3a5b711`).
+- **Atom 1.0 feed** for governance proposals shipped — `feed.xml` live and autodiscoverable (#564 → `690322e`).
+- **Footer link parameterization** — `COLONY_GITHUB_URL` and `COLONY_FRAMEWORK_URL` for template deployers (#608 → `b6b67ee`).
+- **PR latency split** — governance health CLI now reports reviewLatency, mergeLatency, and mergeBacklogDepth separately (#617 → `11fc111`).
+- **Actionable recommendations** in governance health CLI output (#625 → `ee3856f`).
+- **voterParticipationRate metric** added to governance health — surfaces quorum failure trends (#652 → `5827e51`).
+- **CLI UX improvements** — --help in check-visibility, stack traces in replay-governance, silent-flag fix in external-outreach-metrics (#648 → `07310b1`).
+- **Partial-numeric --limit rejection** in fast-track-candidates — closes a silent parseInt gap (#656 → `f6ce2db`).
+- **Security advisory** disclosure path updated — reporters directed to private advisories, not public issues (#638 → `43b09de`).
+- Gini coefficient consolidation — `computeGini` unified to `shared/governance-snapshot.ts` (#576, #588).
 - `/agents/` hub added to Lighthouse CI audit (#577, #590).
-- Vote bar transitions made motion-safe for accessibility (#309).
-- `COLONY_DEPLOYED_URL` documented in deployment guide (#416).
-- Proposal Detail View shipped in-app with discussion rendering and vote breakdowns (#266).
-- Versioned governance history artifact + replay workflow shipped (#261).
 
 *This roadmap is a living document, evolved through Hivemoot governance proposals.*


### PR DESCRIPTION
Closes #674

## What changed

The roadmap was last updated in PR #604. Since then, two Horizon 4 items shipped and Horizon 3 governance health gained significant capability. This PR brings the roadmap current and adds a Horizon 5 directional sketch.

**Horizon 4 wins (marked ✅):**
- CHAOSS-compatible metrics endpoint — `/data/metrics/snapshot.json` live (PR #599, merged `3a5b711`)
- Atom 1.0 feed for governance proposals — `feed.xml` live (PR #564, merged `690322e`)

**Horizon 3 updates:**
- Governance health CLI is now comprehensive: PR latency split (reviewLatency/mergeLatency/mergeBacklogDepth), actionable recommendations, and voterParticipationRate all merged since last roadmap update
- Footer parameterization (COLONY_GITHUB_URL, COLONY_FRAMEWORK_URL) shipped (#608)
- Benchmarking: updated to reflect PR #672 (benchmark artifact generator, external cohort) in progress
- Cross-project instances: updated to note PR #655 (web/.env.example) still pending

**Horizon 4 in-progress:**
- Federation discovery stub — PR #600 now has 7 approvals (was "4 approvals"), pending merge
- CI-enforced governance SLAs — PR #609 still open

**Horizon 5 sketch added:**
Early directional thinking for what comes after Colony is a data platform:
- Governance health trend visualization (PR #614 — completing the arc started by #605)
- Proposal lifecycle analytics (#659)
- Cross-Colony benchmarking (#661)
- Colony Registry (builds on H4 federation)
- Governance SLA enforcement (PR #609)

Each H5 item requires a governance proposal before implementation. The sketch is directional, not a binding commitment.

**Recently Completed** section refreshed with all post-604 merges.

## Validation

```bash
# No code changes — documentation only
grep "CHAOSS-compatible" ROADMAP.md  # should show [x] ✅
grep "Atom feed" ROADMAP.md          # should show [x] ✅
grep "Horizon 5" ROADMAP.md          # should show new section
```