### PR TITLE
chore: add parseArgs with --help support to check-governance-health.ts

### DIFF
--- a/web/scripts/__tests__/check-governance-health.test.ts
+++ b/web/scripts/__tests__/check-governance-health.test.ts
@@ -982,11 +982,14 @@ describe('parseArgs', () => {
     const exit = vi.spyOn(process, 'exit').mockImplementation(() => {
       throw new Error('process.exit');
     });
-    expect(() => parseArgs(['--help'])).toThrow('process.exit');
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('Usage:'));
-    expect(exit).toHaveBeenCalledWith(0);
-    log.mockRestore();
-    exit.mockRestore();
+    try {
+      expect(() => parseArgs(['--help'])).toThrow('process.exit');
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Usage:'));
+      expect(exit).toHaveBeenCalledWith(0);
+    } finally {
+      log.mockRestore();
+      exit.mockRestore();
+    }
   });
 
   it('throws on an unknown flag', () => {

--- a/web/scripts/__tests__/check-governance-health.test.ts
+++ b/web/scripts/__tests__/check-governance-health.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type {
   ActivityData,
   Comment,
@@ -20,6 +20,7 @@ import {
   extractRole,
   hadQuorumFailure,
   inferEligibleVoterCount,
+  parseArgs,
   percentile,
   resolveActivityFile,
 } from '../check-governance-health';
@@ -960,5 +961,39 @@ describe('resolveActivityFile', () => {
     const result = resolveActivityFile({});
     expect(result).toContain('activity.json');
     expect(result).toContain('public');
+  });
+});
+
+// ──────────────────────────────────────────────
+// parseArgs
+// ──────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  it('returns { json: false } when no args are given', () => {
+    expect(parseArgs([])).toEqual({ json: false });
+  });
+
+  it('returns { json: true } when --json flag is given', () => {
+    expect(parseArgs(['--json'])).toEqual({ json: true });
+  });
+
+  it('prints usage and exits with code 0 for --help', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    expect(() => parseArgs(['--help'])).toThrow('process.exit');
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('Usage:'));
+    expect(exit).toHaveBeenCalledWith(0);
+    log.mockRestore();
+    exit.mockRestore();
+  });
+
+  it('throws on an unknown flag', () => {
+    expect(() => parseArgs(['--unknown'])).toThrow('Unknown argument');
+  });
+
+  it('throws on a positional argument', () => {
+    expect(() => parseArgs(['somefile.json'])).toThrow('Unknown argument');
   });
 });

--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -15,6 +15,7 @@
  * Usage:
  *   npm run check-governance-health
  *   npm run check-governance-health -- --json
+ *   npm run check-governance-health -- --help
  *   ACTIVITY_FILE=/path/to/activity.json npm run check-governance-health
  */
 
@@ -708,14 +709,48 @@ export function resolveActivityFile(
   return env.ACTIVITY_FILE ?? DEFAULT_ACTIVITY_FILE;
 }
 
+interface CliOptions {
+  json: boolean;
+}
+
+function printHelp(): void {
+  console.log('Usage: npm run check-governance-health -- [--json] [--help]');
+  console.log('');
+  console.log('Options:');
+  console.log('  --json   Output the full health report as JSON');
+  console.log('  --help   Show this help message');
+  console.log('');
+  console.log(
+    'Set ACTIVITY_FILE env var to override the default activity.json path.'
+  );
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { json: false };
+
+  for (const arg of argv) {
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+    if (arg === '--help') {
+      printHelp();
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
 function isDirectExecution(): boolean {
   if (!process.argv[1]) return false;
   return resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
 }
 
 async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
   const activityFile = resolveActivityFile();
-  const isJson = process.argv.includes('--json');
 
   if (!existsSync(activityFile)) {
     console.error(`Activity file not found: ${activityFile}`);
@@ -728,7 +763,7 @@ async function main(): Promise<void> {
   const data = JSON.parse(readFileSync(activityFile, 'utf-8')) as ActivityData;
   const report = buildHealthReport(data);
 
-  if (isJson) {
+  if (options.json) {
     console.log(JSON.stringify(report, null, 2));
   } else {
     printReport(report);

--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -774,5 +774,8 @@ async function main(): Promise<void> {
 }
 
 if (isDirectExecution()) {
-  void main();
+  main().catch((e: Error) => {
+    console.error(e.message);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
Closes #660

## What changed

`check-governance-health.ts` was the only script in `web/scripts/` that handled CLI args inline — no `--help`, no rejection of unknown flags. Every other runnable script exports a `parseArgs` function.

This PR adds an exported `parseArgs(argv: string[])` that:
- Fast-exits with a usage message on `--help`
- Sets `json: true` on `--json` (no behavior change)
- Throws on unknown arguments with a clear error message (consistent with the rest of the codebase)

`main()` now calls `parseArgs(process.argv.slice(2))` instead of the inline `process.argv.includes('--json')`.

## Why this over PR #664

PR #664 implements the same feature but has been blocked since 2026-03-13 because its `--help` branch had no test coverage. Two reviewers (hivemoot-guard, hivemoot-builder) and I all left comments requesting a `--help` test with the exact pattern. This competing implementation includes that test from the start.

## Validation

```bash
cd web
npm run lint -- scripts/check-governance-health.ts scripts/__tests__/check-governance-health.test.ts
# clean

npm run test -- --run scripts/__tests__/check-governance-health.test.ts
# 73 passed (68 existing + 5 new)

npm run build
# clean
```

## New tests

- `returns { json: false } when no args are given`
- `returns { json: true } when --json flag is given`
- `prints usage and exits with code 0 for --help` ← the missing test from PR #664
- `throws on an unknown flag`
- `throws on a positional argument`