### PR TITLE
chore: remove duplicate computeGini from check-governance-health.ts

### DIFF
--- a/web/scripts/__tests__/check-governance-health.test.ts
+++ b/web/scripts/__tests__/check-governance-health.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { computeGini } from '../../shared/governance-snapshot';
 import type {
   ActivityData,
   Comment,
@@ -9,7 +10,6 @@ import {
   buildHealthReport,
   computeCrossRoleReviewRate,
   computeDataWindowDays,
-  computeGini,
   computeMergeBacklogDepth,
   computeMergeLatency,
   computeContestedRate,

--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -20,6 +20,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { computeGini } from '../shared/governance-snapshot';
 import type {
   ActivityData,
   Comment,
@@ -169,19 +170,6 @@ export function percentile(sorted: number[], p: number): number | null {
  * Compute the Gini coefficient for an array of non-negative values.
  * Returns 0 for arrays of length ≤ 1 or all-zero arrays.
  */
-export function computeGini(values: number[]): number {
-  if (values.length <= 1) return 0;
-  const sorted = [...values].sort((a, b) => a - b);
-  const n = sorted.length;
-  const total = sorted.reduce((a, b) => a + b, 0);
-  if (total === 0) return 0;
-  let sumOfDiffs = 0;
-  for (let i = 0; i < n; i++) {
-    sumOfDiffs += (2 * (i + 1) - n - 1) * sorted[i];
-  }
-  return sumOfDiffs / (n * total);
-}
-
 // ──────────────────────────────────────────────
 // Metric computation
 // ──────────────────────────────────────────────


### PR DESCRIPTION
Closes #654

## What changed

`web/scripts/check-governance-health.ts` had its own copy of `computeGini` (added by PR #542). The canonical implementation lives in `web/shared/governance-snapshot.ts` (PR #562) and was exported from there. PR #588 removed the `src/utils` copy but didn't touch the `scripts/` copy.

This PR:
1. Imports `computeGini` from `../shared/governance-snapshot` in `check-governance-health.ts`
2. Removes the 12-line duplicate implementation
3. Updates the test import to pull from `../../shared/governance-snapshot` (where canonical tests already live)

No behavior change — algorithms are identical.

## Validation

```bash
cd web
npm run lint        # clean
npm run test -- --run scripts/__tests__/check-governance-health.test.ts  # 68 passed
npm run typecheck   # clean
```