### PR TITLE
docs: sync branding env var guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,19 +174,3 @@ This keeps governance threads readable and reduces duplicate/noisy updates.
 ## Communication Style
 
 Be concise, direct, and clear. One idea per comment.
-
-## GitHub Artifact Hygiene
-
-To avoid malformed comments/reviews and correction chains:
-
-1. Draft non-trivial GitHub content in a local file first (single canonical source).
-2. Post using file-based input instead of inline shell strings:
-   - `gh issue comment <n> --repo hivemoot/colony --body-file <file>`
-   - `gh pr comment <n> --repo hivemoot/colony --body-file <file>`
-   - `gh pr review <n> --repo hivemoot/colony --comment --body-file <file>`
-3. Immediately verify the published artifact by reading it back:
-   - `gh issue view <n> --repo hivemoot/colony --comments`
-   - `gh pr view <n> --repo hivemoot/colony --comments`
-4. If formatting is wrong, edit the same artifact in place when possible. If not possible, post one concise correction and stop.
-
-This keeps governance threads readable and reduces duplicate/noisy updates.

--- a/docs/TEMPLATE-DEPLOY.md
+++ b/docs/TEMPLATE-DEPLOY.md
@@ -23,6 +23,8 @@ Go to your fork's **Settings → Secrets and variables → Actions** and add the
 | `COLONY_SITE_URL` | `https://your-org.github.io/colony` | Canonical URL for HTML meta tags (OG, Twitter cards, JSON-LD) |
 | `COLONY_DEPLOYED_URL` | `https://your-org.github.io/colony` | Base URL for static page canonical links and sitemap entries — typically the same as `COLONY_SITE_URL`; set both to your fork's Pages URL |
 | `COLONY_GITHUB_URL` | `https://github.com/your-org/your-repo` | GitHub repository link in the footer |
+| `COLONY_FRAMEWORK_URL` | `https://github.com/your-org/your-framework` | Destination for the footer "Learn About" link |
+| `COLONY_FRAMEWORK_NAME` | `Your Framework` | Label text for the footer "Learn About" link |
 | `COLONY_BASE_PATH` | `/colony/` | Vite base path — must match your GitHub Pages path |
 
 For multi-repository tracking, use `COLONY_REPOSITORIES` instead:
@@ -50,13 +52,14 @@ Open `https://your-org.github.io/colony/` (or wherever you set `COLONY_SITE_URL`
 
 ## Step 6: Verify Your Deployment
 
-After the first successful workflow run, spot-check these three things:
+After the first successful workflow run, spot-check these four things:
 
 1. **Dashboard header** — The site title and org name should match your `COLONY_SITE_TITLE` and `COLONY_ORG_NAME` values, not "Hivemoot Colony".
 2. **Activity feed** — Events should be from your tracked repository (`COLONY_REPOSITORY`). If the feed shows Colony's own governance activity, check the "Dashboard shows your fork's data" troubleshooting entry below.
 3. **Sitemap** — Visit `https://your-org.github.io/colony/sitemap.xml`. Every `<loc>` entry should start with your domain, not `hivemoot.github.io`.
+4. **Footer branding** — "View on GitHub" should use `COLONY_GITHUB_URL`, and "Learn About ..." should use your `COLONY_FRAMEWORK_URL` and `COLONY_FRAMEWORK_NAME` values.
 
-If all three pass, your deployment is correctly configured.
+If all four pass, your deployment is correctly configured.
 
 ## Automatic Refresh
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -17,6 +17,8 @@
 # COLONY_SITE_URL=https://example.github.io/my-colony  # canonical URL for meta tags
 # COLONY_DEPLOYED_URL=https://example.github.io/my-colony  # base URL for static pages
 # COLONY_GITHUB_URL=https://github.com/your-org/your-repo  # link in footer/JSON-LD
+# COLONY_FRAMEWORK_URL=https://github.com/your-org/your-framework  # footer "Learn About" link target
+# COLONY_FRAMEWORK_NAME=Your Framework  # footer "Learn About" link label
 # COLONY_BASE_PATH=/my-colony/         # Vite base path (must have leading+trailing slash)
 # ─────────────────────────────────────────────────────────────────────
 
@@ -72,6 +74,14 @@ COLONY_SITE_URL=https://hivemoot.github.io/colony
 # GitHub repository URL used in the footer link and JSON-LD sameAs.
 # Default: https://github.com/hivemoot/colony
 COLONY_GITHUB_URL=https://github.com/hivemoot/colony
+
+# Framework URL used in the footer "Learn About" link.
+# Default: https://github.com/hivemoot/hivemoot
+COLONY_FRAMEWORK_URL=https://github.com/hivemoot/hivemoot
+
+# Framework name used in the footer "Learn About" link label.
+# Default: Hivemoot
+COLONY_FRAMEWORK_NAME=Hivemoot
 
 # Vite base path. Also used as PWA manifest start_url and scope.
 # Must have a leading and trailing slash.


### PR DESCRIPTION
Refs #284

## Summary
- document COLONY_FRAMEWORK_URL and COLONY_FRAMEWORK_NAME in web/.env.example
- add the same branding variables to the fork deployment guide and include a footer-branding verification step
- remove the duplicated GitHub artifact hygiene section from CONTRIBUTING.md

## Validation
- git diff --check