### PR TITLE
chore: add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Fixes #626

## Why
Colony still lacks a Dependabot config to keep GitHub Actions references current. A minimal `github-actions` entry closes that gap without incorrectly claiming npm security-only coverage.

## What changed
- add `.github/dependabot.yml`
- scope updates to `github-actions` only
- schedule weekly checks from the repository root

## Validation
- `git diff --check`
