### PR TITLE
fix: HTML-escape full avatar URL including size param on agent detail page

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -127,6 +127,9 @@ describe('generateStaticPages', () => {
     expect(html).toContain('50'); // commits
     expect(html).toContain('20'); // PRs merged
     expect(html).toContain('30'); // reviews
+    // avatar URL ampersand must be HTML-escaped on the detail page
+    expect(html).toContain('src="https://avatars.example.com/1&amp;s=64"');
+    expect(html).not.toContain('src="https://avatars.example.com/1&s=64"');
   });
 
   it('generates agents index page', () => {

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -422,7 +422,7 @@ function agentPage(agent: AgentStats): string {
     </nav>
 
     <h1 style="display: flex; align-items: center; gap: 0.75rem;">
-      ${agent.avatarUrl ? `<img src="${escapeHtml(agent.avatarUrl)}&s=64" alt="" width="48" height="48" style="border-radius: 50%;" />` : ''}
+      ${agent.avatarUrl ? `<img src="${escapeHtml(agent.avatarUrl + '&s=64')}" alt="" width="48" height="48" style="border-radius: 50%;" />` : ''}
       ${escapeHtml(agent.login)}
     </h1>
     <div class="meta">


### PR DESCRIPTION
Fixes #554

## Problem

`agentPage()` in `static-pages.ts` built the avatar `src` with a raw `&` before the size parameter:

```ts
src="${escapeHtml(agent.avatarUrl)}&s=64"
```

This produces invalid HTML — `&s=64` should be `&amp;s=64`. HTML validators flag it, and browsers technically have to treat `&s` as an unknown character reference.

The agent _list_ page (line 487) already used the correct pattern:
```ts
src="${escapeHtml(agent.avatarUrl + '&s=32')}"
```

## Fix

Apply the same pattern to the agent _detail_ page: pass the full URL including the size parameter to `escapeHtml`.

```ts
// before
src="${escapeHtml(agent.avatarUrl)}&s=64"

// after
src="${escapeHtml(agent.avatarUrl + '&s=64')}"
```

Browser behavior is unchanged — `&amp;` is decoded back to `&` when resolving the image src.

## Test coverage

Added two assertions to the existing `'generates agent pages'` test:
- Verifies `&amp;s=64` is present
- Verifies raw `&s=64` is absent

## Validation

```bash
cd web
npm run lint -- scripts/static-pages.ts scripts/__tests__/static-pages.test.ts
npx vitest run scripts/__tests__/static-pages.test.ts
# 49 tests passed
npm run build
```