### PR TITLE
chore: pin GitHub Actions workflows to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload build artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: web/dist
 
@@ -73,4 +73,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -15,9 +15,9 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -43,7 +43,7 @@ jobs:
         run: timeout 30 bash -c 'until curl -sf http://localhost:4173/colony/ > /dev/null; do sleep 1; done'
 
       - name: Run Lighthouse CI
-        uses: treosh/lighthouse-ci-action@v12
+        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
         with:
           urls: |
             http://localhost:4173/colony/

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -43,7 +43,7 @@ jobs:
         run: timeout 30 bash -c 'until curl -sf http://localhost:4173/colony/ > /dev/null; do sleep 1; done'
 
       - name: Run Lighthouse CI
-        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12
+        uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18 # v12.6.2
         with:
           urls: |
             http://localhost:4173/colony/

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -44,7 +44,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: web/dist
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
Closes #623

## Why

Mutable version tags like `actions/checkout@v4` are vulnerable to tag retargeting and compromised releases. If an action publisher's account is compromised, they can move an existing tag to a malicious commit — and every workflow using that tag silently runs the new code. SHA pinning eliminates that vector: a compromised tag cannot affect a workflow that's already pinned to a specific commit.

OpenSSF Scorecard's `Token-Permissions` and `Pinned-Dependencies` checks treat unpinned actions as findings. PR #645 (OpenSSF Scorecard workflow) itself uses SHA-pinned actions — this PR brings the existing workflows in line with that standard.

## What changed

Pinned all 5 action references across `ci.yml`, `lighthouse.yml`, and `refresh-data.yml`:

| Action | Previous | SHA | Version |
|--------|----------|-----|---------|
| `actions/checkout` | `@v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/setup-node` | `@v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| `actions/upload-pages-artifact` | `@v3` | `56afc609e74202658d3ffba0e8f6dda462b719fa` | v3.0.1 |
| `actions/deploy-pages` | `@v4` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` | v4.0.5 |
| `treosh/lighthouse-ci-action` | `@v12` | `3e7e23fb74242897f95c0ba9cabad3d0227b9b18` | v12 |

## SHA verification

SHAs verified via GitHub API tag resolution:
- Lightweight tags: `GET /repos/{owner}/{repo}/git/ref/tags/{tag}` → commit SHA directly
- Annotated tags (`treosh/lighthouse-ci-action@v12`): resolved tag object `512cc908...` → commit `3e7e23fb...`

The `actions/checkout` SHA matches what PR #645 already uses (`34e114876b0b...` v4.3.1), confirming consistency with the in-flight Scorecard workflow.

## Validation

```bash
git diff --check  # clean
```

No code changes — workflow behavior is identical. Dependabot (once #626 merges) will open PRs when these SHAs fall behind their respective upstream releases.