### PR TITLE
fix: add Open Graph image alt metadata

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -17,6 +17,7 @@
     <meta property="og:title" content="__COLONY_OG_TITLE__" />
     <meta property="og:description" content="__COLONY_OG_DESCRIPTION__" />
     <meta property="og:image" content="__COLONY_OG_IMAGE__" />
+    <meta property="og:image:alt" content="__COLONY_SOCIAL_IMAGE_ALT__" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -28,7 +29,7 @@
     <meta name="twitter:title" content="__COLONY_TWITTER_TITLE__" />
     <meta name="twitter:description" content="__COLONY_TWITTER_DESCRIPTION__" />
     <meta name="twitter:image" content="__COLONY_TWITTER_IMAGE__" />
-    <meta name="twitter:image:alt" content="Colony dashboard — autonomous agent collaboration in real-time" />
+    <meta name="twitter:image:alt" content="__COLONY_SOCIAL_IMAGE_ALT__" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildRepositoryApiUrl,
   hasAtomAutodiscoveryLink,
+  hasOpenGraphImageAltText,
   hasTwitterImageAltText,
   isValidOpenGraphImageType,
   normalizeHttpsUrl,
@@ -181,6 +182,16 @@ describe('hasTwitterImageAltText', () => {
 
   it('rejects blank alt text', () => {
     expect(hasTwitterImageAltText('   ')).toBe(false);
+  });
+});
+
+describe('hasOpenGraphImageAltText', () => {
+  it('accepts non-empty alt text', () => {
+    expect(hasOpenGraphImageAltText('Colony dashboard preview')).toBe(true);
+  });
+
+  it('rejects blank alt text', () => {
+    expect(hasOpenGraphImageAltText('   ')).toBe(false);
   });
 });
 

--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -917,6 +917,7 @@ describe('buildExternalVisibility', () => {
                 <link rel="canonical" href="${baseUrl}/" />
                 <link rel="manifest" href="${baseUrl}/manifest.webmanifest" />
                 <meta property="og:image" content="${baseUrl}/og-image.png" />
+                <meta property="og:image:alt" content="Colony dashboard screenshot" />
                 <meta property="og:image:width" content="1200" />
                 <meta property="og:image:height" content="630" />
                 <meta property="og:image:type" content="image/png" />
@@ -1014,6 +1015,9 @@ describe('buildExternalVisibility', () => {
     ).toBe(true);
     expect(
       visibility.checks.find((c) => c.id === 'deployed-og-image-type')?.ok
+    ).toBe(true);
+    expect(
+      visibility.checks.find((c) => c.id === 'deployed-og-image-alt')?.ok
     ).toBe(true);
     expect(visibility.checks.find((c) => c.id === 'deployed-favicon')?.ok).toBe(
       true
@@ -1474,6 +1478,64 @@ describe('buildExternalVisibility', () => {
     expect(twitterAltCheck?.ok).toBe(false);
     expect(twitterAltCheck?.details).toContain(
       'Missing twitter:image:alt metadata on deployed homepage'
+    );
+  });
+
+  it('flags missing og:image:alt on deployed homepage', async () => {
+    const baseUrl = 'https://hivemoot.github.io/colony';
+    vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async (input: RequestInfo | URL): Promise<Response> => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+
+        if (url === baseUrl) {
+          return new Response(
+            `<html>
+              <head>
+                <meta property="og:image" content="${baseUrl}/og-image.png" />
+                <meta property="og:image:type" content="image/png" />
+                <meta name="twitter:image" content="${baseUrl}/twitter-image.png" />
+                <meta name="twitter:image:alt" content="Colony screenshot" />
+                <script type="application/ld+json">{}</script>
+              </head>
+            </html>`,
+            { status: 200 }
+          );
+        }
+        if (
+          url === `${baseUrl}/og-image.png` ||
+          url === `${baseUrl}/twitter-image.png`
+        ) {
+          return new Response('image-bytes', { status: 200 });
+        }
+        return new Response('ok', { status: 200 });
+      }
+    );
+
+    const visibility = await buildExternalVisibility([
+      {
+        owner: 'hivemoot',
+        name: 'colony',
+        url: 'https://github.com/hivemoot/colony',
+        stars: 1,
+        forks: 1,
+        openIssues: 1,
+        homepage: `${baseUrl}/`,
+        topics: REQUIRED_DISCOVERABILITY_TOPICS,
+        description: 'Open-source dashboard for autonomous agent governance',
+      },
+    ]);
+
+    const ogAltCheck = visibility.checks.find(
+      (c) => c.id === 'deployed-og-image-alt'
+    );
+    expect(ogAltCheck?.ok).toBe(false);
+    expect(ogAltCheck?.details).toContain(
+      'Missing og:image:alt metadata on deployed homepage'
     );
   });
 

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -138,6 +138,10 @@ export function hasTwitterImageAltText(rawValue: string): boolean {
   return rawValue.trim().length > 0;
 }
 
+export function hasOpenGraphImageAltText(rawValue: string): boolean {
+  return rawValue.trim().length > 0;
+}
+
 function resolveHttpsUrl(rawValue: string, baseUrl: string): string {
   return normalizeHttpsUrl(rawValue, `${baseUrl}/`);
 }
@@ -536,6 +540,22 @@ async function runChecks(): Promise<CheckResult[]> {
       : !ogImageTypeRaw
         ? 'Missing og:image:type metadata on deployed homepage'
         : `Invalid og:image:type value: ${ogImageTypeRaw}`,
+  });
+
+  const ogImageAltRaw = extractTagAttributeValue(
+    deployedRootHtml,
+    'meta',
+    'property',
+    'og:image:alt',
+    'content'
+  );
+  const hasOgImageAlt = hasOpenGraphImageAltText(ogImageAltRaw);
+  results.push({
+    label: 'Deployed Open Graph image alt text is declared',
+    ok: hasOgImageAlt,
+    details: hasOgImageAlt
+      ? 'og:image:alt metadata is present'
+      : 'Missing og:image:alt metadata on deployed homepage',
   });
 
   const twitterImageRaw = extractTagAttributeValue(

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -1450,6 +1450,23 @@ export async function buildExternalVisibility(
         : `Invalid og:image:type value: ${ogImageTypeRaw}`,
   });
 
+  const ogImageAltRaw = extractTagAttributeValue(
+    deployedRootHtml,
+    'meta',
+    'property',
+    'og:image:alt',
+    'content'
+  );
+  const hasOgImageAlt = ogImageAltRaw.trim().length > 0;
+  checks.push({
+    id: 'deployed-og-image-alt',
+    label: 'Deployed Open Graph image alt text is declared',
+    ok: hasOgImageAlt,
+    details: hasOgImageAlt
+      ? 'og:image:alt metadata is present'
+      : 'Missing og:image:alt metadata on deployed homepage',
+  });
+
   const twitterImageRaw = extractTagAttributeValue(
     deployedRootHtml,
     'meta',

--- a/web/scripts/vite-colony-html-plugin.ts
+++ b/web/scripts/vite-colony-html-plugin.ts
@@ -51,6 +51,7 @@ export function transformHtml(html: string, config: ColonyConfig): string {
   const siteUrlWithSlash = config.siteUrl + '/';
   const ogImageUrl = `${config.siteUrl}/og-image.png`;
   const pageTitle = `${config.siteTitle} | ${config.orgName}`;
+  const socialImageAlt = `${config.siteTitle} dashboard — ${config.siteDescription}`;
 
   return html
     .replace(/__COLONY_CANONICAL_URL__/g, siteUrlWithSlash)
@@ -68,6 +69,7 @@ export function transformHtml(html: string, config: ColonyConfig): string {
     .replace(/__COLONY_TWITTER_TITLE__/g, pageTitle)
     .replace(/__COLONY_TWITTER_DESCRIPTION__/g, config.siteDescription)
     .replace(/__COLONY_TWITTER_IMAGE__/g, ogImageUrl)
+    .replace(/__COLONY_SOCIAL_IMAGE_ALT__/g, socialImageAlt)
     .replace(/__COLONY_JSONLD_NAME__/g, config.siteTitle)
     .replace(/__COLONY_JSONLD_URL__/g, siteUrlWithSlash)
     .replace(/__COLONY_JSONLD_DESCRIPTION__/g, config.siteDescription)

--- a/web/shared/types.ts
+++ b/web/shared/types.ts
@@ -122,6 +122,7 @@ export interface VisibilityCheck {
     | 'deployed-og-image'
     | 'deployed-og-image-dimensions'
     | 'deployed-og-image-type'
+    | 'deployed-og-image-alt'
     | 'deployed-twitter-image'
     | 'deployed-twitter-image-alt'
     | 'deployed-pwa-manifest'

--- a/web/src/Meta.test.ts
+++ b/web/src/Meta.test.ts
@@ -45,6 +45,9 @@ describe('index.html metadata', () => {
       /<meta\s+[^>]*property="og:image"\s+content="__COLONY_OG_IMAGE__"\s*\/?>/s
     );
     expect(html).toMatch(
+      /<meta\s+property="og:image:alt"\s+content="__COLONY_SOCIAL_IMAGE_ALT__"\s*\/?>/
+    );
+    expect(html).toMatch(
       /<meta\s+property="og:image:width"\s+content="1200"\s*\/?>/
     );
     expect(html).toMatch(
@@ -75,7 +78,7 @@ describe('index.html metadata', () => {
       /<meta\s+[^>]*name="twitter:image"\s+content="__COLONY_TWITTER_IMAGE__"\s*\/?>/s
     );
     expect(html).toMatch(
-      /<meta\s+name="twitter:image:alt"\s+content="Colony dashboard — autonomous agent collaboration in real-time"\s*\/?>/
+      /<meta\s+name="twitter:image:alt"\s+content="__COLONY_SOCIAL_IMAGE_ALT__"\s*\/?>/
     );
   });
 


### PR DESCRIPTION
Fixes #701

## Summary
- add `og:image:alt` to the homepage metadata template and reuse the same build-time alt text token for both Open Graph and Twitter images
- extend `check-visibility` and generated external visibility data to flag missing Open Graph image alt text on deployed pages
- cover the new metadata and visibility behavior with targeted tests

## Validation
- attempted: `cd web && npm test -- --run src/Meta.test.ts scripts/__tests__/check-visibility.test.ts scripts/__tests__/generate-data.test.ts`
- attempted: `cd web && npm run lint`
- attempted: `cd web && npm run build`
- blocked locally: this workspace did not produce `vitest`, `eslint`, or `tsc` binaries after `npm install`, so validation could not complete in this run
