### PR TITLE
fix: tighten CLI arg handling

### DIFF
--- a/web/scripts/__tests__/external-outreach-metrics.test.ts
+++ b/web/scripts/__tests__/external-outreach-metrics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  EXTERNAL_OUTREACH_USAGE,
   buildOutreachReport,
   dedupePullRequestRefs,
   extractPullRequestRefsFromText,
@@ -15,34 +16,22 @@ describe('parseArgs', () => {
     expect(opts.baselineStars).toBe(5);
   });
 
-  it('warns and ignores an invalid --baseline-stars value', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const opts = parseArgs(['--baseline-stars=abc']);
-    expect(opts.baselineStars).toBeNull(); // default unchanged
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('--baseline-stars="abc"')
+  it('rejects an invalid --baseline-stars value', () => {
+    expect(() => parseArgs(['--baseline-stars=abc'])).toThrow(
+      /--baseline-stars="abc" must be a non-negative integer/
     );
-    warn.mockRestore();
   });
 
-  it('warns and ignores a partial-numeric --baseline-stars value (5oops)', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const opts = parseArgs(['--baseline-stars=5oops']);
-    expect(opts.baselineStars).toBeNull();
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('--baseline-stars="5oops"')
+  it('rejects a partial-numeric --baseline-stars value (5oops)', () => {
+    expect(() => parseArgs(['--baseline-stars=5oops'])).toThrow(
+      /--baseline-stars="5oops" must be a non-negative integer/
     );
-    warn.mockRestore();
   });
 
-  it('warns and ignores a negative --baseline-stars value', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const opts = parseArgs(['--baseline-stars=-1']);
-    expect(opts.baselineStars).toBeNull();
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('--baseline-stars="-1"')
+  it('rejects a negative --baseline-stars value', () => {
+    expect(() => parseArgs(['--baseline-stars=-1'])).toThrow(
+      /--baseline-stars="-1" must be a non-negative integer/
     );
-    warn.mockRestore();
   });
 
   it('accepts a valid --issue value', () => {
@@ -50,22 +39,25 @@ describe('parseArgs', () => {
     expect(opts.issue).toBe(298);
   });
 
-  it('warns and ignores an invalid --issue value', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const opts = parseArgs(['--issue=abc']);
-    expect(opts.issue).toBeNull();
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('--issue="abc"'));
-    warn.mockRestore();
+  it('rejects an invalid --issue value', () => {
+    expect(() => parseArgs(['--issue=abc'])).toThrow(
+      /--issue="abc" must be a positive integer/
+    );
   });
 
-  it('warns and ignores a partial-numeric --issue value (123abc)', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const opts = parseArgs(['--issue=123abc']);
-    expect(opts.issue).toBeNull();
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('--issue="123abc"')
+  it('rejects a partial-numeric --issue value (123abc)', () => {
+    expect(() => parseArgs(['--issue=123abc'])).toThrow(
+      /--issue="123abc" must be a positive integer/
     );
-    warn.mockRestore();
+  });
+
+  it('surfaces help without exiting the process inside parseArgs', () => {
+    const opts = parseArgs(['--help']);
+    expect(opts.help).toBe(true);
+  });
+
+  it('includes usage guidance in validation errors', () => {
+    expect(() => parseArgs(['--issue=0'])).toThrow(EXTERNAL_OUTREACH_USAGE);
   });
 });
 

--- a/web/scripts/__tests__/external-outreach-metrics.test.ts
+++ b/web/scripts/__tests__/external-outreach-metrics.test.ts
@@ -56,6 +56,12 @@ describe('parseArgs', () => {
     expect(opts.help).toBe(true);
   });
 
+  it('rejects unsupported flags', () => {
+    expect(() => parseArgs(['--wat'])).toThrow(
+      /Unknown argument --wat\.\nUsage: npm run external-outreach-metrics/
+    );
+  });
+
   it('includes usage guidance in validation errors', () => {
     expect(() => parseArgs(['--issue=0'])).toThrow(EXTERNAL_OUTREACH_USAGE);
   });

--- a/web/scripts/__tests__/replay-governance.test.ts
+++ b/web/scripts/__tests__/replay-governance.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   formatMissingHistoryFileMessage,
   parseReplayArgs,
+  REPLAY_GOVERNANCE_USAGE,
   replayFromArtifact,
   summarizeGovernanceReplay,
   summarizeNumericValues,
@@ -93,10 +94,16 @@ describe('parseReplayArgs', () => {
     expect(args.from).toBe('2026-02-01T00:00:00Z');
     expect(args.to).toBe('2026-02-10T00:00:00Z');
     expect(args.json).toBe(true);
+    expect(args.help).toBe(false);
+  });
+
+  it('surfaces help without exiting the process inside parseReplayArgs', () => {
+    const args = parseReplayArgs(['--help']);
+    expect(args.help).toBe(true);
   });
 
   it('throws on unsupported flags', () => {
-    expect(() => parseReplayArgs(['--wat'])).toThrow(/Unknown argument/);
+    expect(() => parseReplayArgs(['--wat'])).toThrow(REPLAY_GOVERNANCE_USAGE);
   });
 
   it('throws with a clear message for an invalid --from date', () => {

--- a/web/scripts/external-outreach-metrics.ts
+++ b/web/scripts/external-outreach-metrics.ts
@@ -21,6 +21,7 @@ interface CliOptions {
   issue: number | null;
   prs: string[];
   json: boolean;
+  help: boolean;
 }
 
 interface PullRequestRef {
@@ -71,6 +72,9 @@ interface IssueCommentApiResponse {
   body?: string;
 }
 
+export const EXTERNAL_OUTREACH_USAGE =
+  'Usage: npm run external-outreach-metrics -- [--repo=owner/name] [--baseline-stars=2] [--issue=298] [--pr=owner/repo#123] [--json]';
+
 export function parseArgs(argv: string[]): CliOptions {
   const options: CliOptions = {
     repo: DEFAULT_REPO,
@@ -78,6 +82,7 @@ export function parseArgs(argv: string[]): CliOptions {
     issue: null,
     prs: [],
     json: false,
+    help: false,
   };
 
   for (const arg of argv) {
@@ -87,8 +92,8 @@ export function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--help') {
-      printHelp();
-      process.exit(0);
+      options.help = true;
+      continue;
     }
 
     if (arg.startsWith('--repo=')) {
@@ -105,8 +110,8 @@ export function parseArgs(argv: string[]): CliOptions {
       if (Number.isFinite(value) && value >= 0) {
         options.baselineStars = value;
       } else {
-        console.warn(
-          `Warning: --baseline-stars="${raw}" is not a valid non-negative integer. Ignored.`
+        throw new Error(
+          `--baseline-stars="${raw}" must be a non-negative integer.\n${EXTERNAL_OUTREACH_USAGE}`
         );
       }
       continue;
@@ -118,8 +123,8 @@ export function parseArgs(argv: string[]): CliOptions {
       if (Number.isFinite(value) && value > 0) {
         options.issue = value;
       } else {
-        console.warn(
-          `Warning: --issue="${raw}" is not a valid positive integer. Ignored.`
+        throw new Error(
+          `--issue="${raw}" must be a positive integer.\n${EXTERNAL_OUTREACH_USAGE}`
         );
       }
       continue;
@@ -138,9 +143,7 @@ export function parseArgs(argv: string[]): CliOptions {
 }
 
 function printHelp(): void {
-  console.log(
-    'Usage: npm run external-outreach-metrics -- [--repo=owner/name] [--baseline-stars=2] [--issue=298] [--pr=owner/repo#123] [--json]'
-  );
+  console.log(EXTERNAL_OUTREACH_USAGE);
 }
 
 export function parsePullRequestRef(input: string): PullRequestRef | null {
@@ -382,6 +385,11 @@ function printHumanReport(report: OutreachReport): void {
 
 function main(): void {
   const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
   const refs = resolveTrackedPullRequestRefs(options);
 
   const currentStars = loadCurrentStars(options.repo);
@@ -402,5 +410,10 @@ function main(): void {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
 }

--- a/web/scripts/external-outreach-metrics.ts
+++ b/web/scripts/external-outreach-metrics.ts
@@ -137,6 +137,8 @@ export function parseArgs(argv: string[]): CliOptions {
       }
       continue;
     }
+
+    throw new Error(`Unknown argument ${arg}.\n${EXTERNAL_OUTREACH_USAGE}`);
   }
 
   return options;

--- a/web/scripts/replay-governance.ts
+++ b/web/scripts/replay-governance.ts
@@ -22,6 +22,7 @@ export interface ReplayOptions {
   from: string | null;
   to: string | null;
   json: boolean;
+  help: boolean;
 }
 
 export interface SubMetricSummary {
@@ -55,15 +56,24 @@ export interface GovernanceReplaySummary {
   subMetrics: GovernanceSubMetrics | null;
 }
 
+export const REPLAY_GOVERNANCE_USAGE =
+  'Usage: npm run replay-governance -- [--file=path] [--from=ISO-8601] [--to=ISO-8601] [--json]';
+
 export function parseReplayArgs(args: string[]): ReplayOptions {
   let file = DEFAULT_HISTORY_FILE;
   let from: string | null = null;
   let to: string | null = null;
   let json = false;
+  let help = false;
 
   for (const arg of args) {
     if (arg === '--json') {
       json = true;
+      continue;
+    }
+
+    if (arg === '--help') {
+      help = true;
       continue;
     }
 
@@ -87,7 +97,7 @@ export function parseReplayArgs(args: string[]): ReplayOptions {
     }
 
     throw new Error(
-      `Unknown argument "${arg}". Expected --file=, --from=, --to=, or --json.`
+      `Unknown argument "${arg}". Expected --file=, --from=, --to=, --json, or --help.\n${REPLAY_GOVERNANCE_USAGE}`
     );
   }
 
@@ -95,7 +105,7 @@ export function parseReplayArgs(args: string[]): ReplayOptions {
     throw new Error('--from cannot be later than --to');
   }
 
-  return { file, from, to, json };
+  return { file, from, to, json, help };
 }
 
 export function summarizeNumericValues(
@@ -277,6 +287,11 @@ function formatTextOutput(params: {
 
 async function main(): Promise<void> {
   const options = parseReplayArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(REPLAY_GOVERNANCE_USAGE);
+    return;
+  }
+
   if (!existsSync(options.file)) {
     throw new Error(formatMissingHistoryFileMessage(options.file));
   }


### PR DESCRIPTION
Fixes #644

## Summary
- make `external-outreach-metrics` fail fast on invalid numeric flags instead of silently continuing
- handle `--help` explicitly in the public CLI parsers so help can be exercised without process exits inside parser code
- add parser tests for the new validation and usage output paths

## Validation
- `cd web && npm run test -- scripts/__tests__/external-outreach-metrics.test.ts scripts/__tests__/replay-governance.test.ts`
- `cd web && npm run external-outreach-metrics -- --help`
- `cd web && npm run external-outreach-metrics -- --baseline-stars=abc`
- `cd web && npm run replay-governance -- --help`
- `cd web && npm run replay-governance -- --from=not-a-date`

## Notes
- The local checkout needed dependency installation before script verification; CI should provide the authoritative run for the commands above.
