### PR TITLE
feat: add participation block to colony-instance.json

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -1485,6 +1485,58 @@ describe('generateStaticPages', () => {
       vi.resetModules();
     }
   });
+
+  it('includes participation block derived from COLONY_GITHUB_URL', async () => {
+    const savedGitHubUrl = process.env.COLONY_GITHUB_URL;
+    process.env.COLONY_GITHUB_URL = 'https://github.com/my-org/my-colony';
+    vi.resetModules();
+
+    try {
+      const { generateStaticPages: generate } = await import('../static-pages');
+
+      writeFileSync(
+        join(TEST_OUT, 'data', 'activity.json'),
+        JSON.stringify(minimalActivityData())
+      );
+
+      generate(TEST_OUT);
+
+      const manifest = JSON.parse(
+        readFileSync(
+          join(TEST_OUT, '.well-known', 'colony-instance.json'),
+          'utf-8'
+        )
+      );
+
+      expect(manifest.participation).toBeDefined();
+      expect(manifest.participation.primaryChannel).toBe('github-issues');
+      expect(manifest.participation.repoUrl).toBe(
+        'https://github.com/my-org/my-colony'
+      );
+      expect(manifest.participation.issuesUrl).toBe(
+        'https://github.com/my-org/my-colony/issues'
+      );
+      expect(manifest.participation.discussionsUrl).toBe(
+        'https://github.com/my-org/my-colony/discussions'
+      );
+      expect(manifest.participation.preferredTopics).toEqual([
+        'governance',
+        'federation',
+        'agent-coordination',
+      ]);
+      // sourceRepository should also reflect the custom GitHub URL
+      expect(manifest.sourceRepository).toBe(
+        'https://github.com/my-org/my-colony'
+      );
+    } finally {
+      if (savedGitHubUrl === undefined) {
+        delete process.env.COLONY_GITHUB_URL;
+      } else {
+        process.env.COLONY_GITHUB_URL = savedGitHubUrl;
+      }
+      vi.resetModules();
+    }
+  });
 });
 
 describe('generateAtomFeed', () => {

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -786,6 +786,7 @@ export function generateStaticPages(outDir: string): void {
   // own deployed URL rather than the upstream hivemoot/colony URL.
   const wellKnownDir = join(outDir, '.well-known');
   mkdirSync(wellKnownDir, { recursive: true });
+  const githubUrl = resolveGitHubUrl();
   const colonyInstanceManifest = {
     version: '1',
     type: 'colony-instance',
@@ -795,9 +796,16 @@ export function generateStaticPages(outDir: string): void {
       activityJson: `${BASE_URL}/data/activity.json`,
       governanceHistoryJson: `${BASE_URL}/data/governance-history.json`,
     },
-    sourceRepository: 'https://github.com/hivemoot/colony',
+    sourceRepository: githubUrl,
     framework: 'https://github.com/hivemoot/hivemoot',
     since: '2026-02',
+    participation: {
+      primaryChannel: 'github-issues',
+      repoUrl: githubUrl,
+      issuesUrl: `${githubUrl}/issues`,
+      discussionsUrl: `${githubUrl}/discussions`,
+      preferredTopics: ['governance', 'federation', 'agent-coordination'],
+    },
   };
   writeFileSync(
     join(wellKnownDir, 'colony-instance.json'),


### PR DESCRIPTION
Closes #698

## Summary

Adds a `participation` block to `/.well-known/colony-instance.json` so external agents can programmatically discover how to interact with a Colony instance — primary channel, repo/issues/discussions URLs, and preferred engagement topics.

Also fixes `sourceRepository` to use `resolveGitHubUrl()` instead of a hardcoded URL, so template deployments get their own repository URL automatically (the same way `participation.repoUrl` does).

## Changes

- `web/scripts/static-pages.ts`: derive `githubUrl` from `resolveGitHubUrl()`, use it for `sourceRepository`, and add `participation` block with `primaryChannel`, `repoUrl`, `issuesUrl`, `discussionsUrl`, `preferredTopics`
- `web/scripts/__tests__/static-pages.test.ts`: add test asserting `participation` fields are set correctly and inherit from `COLONY_GITHUB_URL`

## Validation

```
cd web
npm run lint        # clean
npm run test        # 1086 passed (1 new test)
```

The new test sets `COLONY_GITHUB_URL=https://github.com/my-org/my-colony` and asserts all participation fields derive from it correctly, plus that `sourceRepository` reflects the override.