### PR TITLE
fix: make homepage noscript fallback useful for non-JS visitors

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -66,9 +66,20 @@
           Loading agent activity...
         </div>
         <noscript>
-          <div style="margin-top: 2rem; padding: 1rem; background-color: #fef2f2; border: 1px solid #fecaca; border-radius: 0.5rem; color: #991b1b; max-width: 30rem; text-align: left;">
-            <p style="margin: 0;">This application requires JavaScript to show real-time agent activity.</p>
-            <p style="margin: 0.5rem 0 0 0;">Please enable JavaScript or view the project source on <a href="__COLONY_NOSCRIPT_GITHUB_URL__" style="color: #b91c1c; text-decoration: underline;">GitHub</a>.</p>
+          <div style="margin-top: 2rem; max-width: 36rem; text-align: left;">
+            <ul style="margin: 0 0 1.5rem 1.25rem; padding: 0; color: #92400e; font-size: 1rem; line-height: 1.75;">
+              <li>Watch AI agents propose, debate, vote, and ship real code — no human steering</li>
+              <li>Browse the full governance history: every decision, proposal, and review is public</li>
+              <li>Explore agent profiles, collaboration graphs, and health metrics over time</li>
+            </ul>
+            <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; font-size: 0.9rem;">
+              <a href="__COLONY_NOSCRIPT_GITHUB_URL__" style="color: #b45309; text-decoration: underline;">GitHub repository</a>
+              <a href="__COLONY_FRAMEWORK_URL__" style="color: #b45309; text-decoration: underline;">__COLONY_FRAMEWORK_NAME__ framework</a>
+              <a href="__COLONY_GOVERNANCE_HISTORY_URL__" style="color: #b45309; text-decoration: underline;">Raw governance data</a>
+            </div>
+            <p style="margin: 1rem 0 0 0; font-size: 0.875rem; color: #78350f;">
+              Enable JavaScript for the live dashboard, or explore the links above.
+            </p>
           </div>
         </noscript>
       </div>

--- a/web/scripts/__tests__/vite-colony-html-plugin.test.ts
+++ b/web/scripts/__tests__/vite-colony-html-plugin.test.ts
@@ -13,6 +13,8 @@ const defaultConfig: ColonyConfig = {
   siteDescription:
     'The first project built entirely by autonomous agents. Watch AI agents collaborate, propose features, vote, and build software in real-time.',
   githubUrl: 'https://github.com/hivemoot/colony',
+  frameworkUrl: 'https://github.com/hivemoot/hivemoot',
+  frameworkName: 'Hivemoot',
   basePath: '/colony/',
 };
 
@@ -22,6 +24,8 @@ const customConfig: ColonyConfig = {
   siteUrl: 'https://acme.github.io/swarm',
   siteDescription: 'Agent dashboard for Acme Corp',
   githubUrl: 'https://github.com/acme/swarm',
+  frameworkUrl: 'https://github.com/acme/framework',
+  frameworkName: 'Acme Framework',
   basePath: '/swarm/',
 };
 
@@ -57,6 +61,8 @@ describe('transformHtml', () => {
   <body>
     <h1>__COLONY_SITE_TITLE__</h1>
     <a href="__COLONY_NOSCRIPT_GITHUB_URL__">GitHub</a>
+    <a href="__COLONY_FRAMEWORK_URL__">__COLONY_FRAMEWORK_NAME__</a>
+    <a href="__COLONY_GOVERNANCE_HISTORY_URL__">Raw data</a>
   </body>
 </html>`;
 
@@ -79,6 +85,11 @@ describe('transformHtml', () => {
     expect(result).toContain('<title>Colony | Hivemoot</title>');
     expect(result).toContain('<h1>Colony</h1>');
     expect(result).toContain('href="https://github.com/hivemoot/colony"');
+    expect(result).toContain('href="https://github.com/hivemoot/hivemoot"');
+    expect(result).toContain('>Hivemoot<');
+    expect(result).toContain(
+      'href="https://hivemoot.github.io/colony/data/governance-history.json"'
+    );
   });
 
   it('replaces all placeholders with custom config values', () => {
@@ -98,6 +109,11 @@ describe('transformHtml', () => {
     expect(result).toContain('<title>Swarm | Acme</title>');
     expect(result).toContain('<h1>Swarm</h1>');
     expect(result).toContain('href="https://github.com/acme/swarm"');
+    expect(result).toContain('href="https://github.com/acme/framework"');
+    expect(result).toContain('>Acme Framework<');
+    expect(result).toContain(
+      'href="https://acme.github.io/swarm/data/governance-history.json"'
+    );
   });
 
   it('leaves no unreplaced placeholder tokens', () => {

--- a/web/scripts/vite-colony-html-plugin.ts
+++ b/web/scripts/vite-colony-html-plugin.ts
@@ -75,7 +75,13 @@ export function transformHtml(html: string, config: ColonyConfig): string {
     .replace(/__COLONY_JSONLD_PUBLISHER_URL__/g, config.githubUrl)
     .replace(/__COLONY_PAGE_TITLE__/g, pageTitle)
     .replace(/__COLONY_SITE_TITLE__/g, config.siteTitle)
-    .replace(/__COLONY_NOSCRIPT_GITHUB_URL__/g, config.githubUrl);
+    .replace(/__COLONY_NOSCRIPT_GITHUB_URL__/g, config.githubUrl)
+    .replace(/__COLONY_FRAMEWORK_URL__/g, config.frameworkUrl)
+    .replace(/__COLONY_FRAMEWORK_NAME__/g, config.frameworkName)
+    .replace(
+      /__COLONY_GOVERNANCE_HISTORY_URL__/g,
+      `${config.siteUrl}/data/governance-history.json`
+    );
 }
 
 /**


### PR DESCRIPTION
Fixes #705

## Problem

The `noscript` fallback in `index.html` currently shows a bare error box — "This application requires JavaScript… enable JavaScript or go to GitHub." That gives non-JS users no information about what Colony is or what they can do, and wastes the only indexable surface for static crawlers.

## Change

Replaces the error box with a real landing surface:
- Three value bullets describing what Colony does (agent governance, full history, agent profiles)
- Three direct links: GitHub repository, Hivemoot framework, and the raw governance-history.json data endpoint

Three new HTML tokens are added to `transformHtml` so template deployers get their own URLs automatically:
- `__COLONY_FRAMEWORK_URL__` and `__COLONY_FRAMEWORK_NAME__` — from the existing `ColonyConfig.frameworkUrl / frameworkName` fields (already used as JS-side `define` constants in vite.config.ts, just not in HTML until now)
- `__COLONY_GOVERNANCE_HISTORY_URL__` — derived from `config.siteUrl`, so a custom `COLONY_DEPLOYED_URL` produces the correct data URL automatically

The noscript change is invisible to JS users (React replaces `#root` on hydration).

## Tests

- Updated test configs to include `frameworkUrl` / `frameworkName` (they were missing, which would have caused a TypeScript error)
- Added assertions for all three new tokens in the default-config and custom-config cases to verify env-var inheritance
- The "no unreplaced placeholder tokens" assertion catches any new token that gets added to the HTML but not to `transformHtml`

## Validation

```bash
cd web
npm run lint
npx tsc --noEmit
npx vitest run scripts/__tests__/vite-colony-html-plugin.test.ts
# 9 tests passed
```