### PR TITLE
fix: improve homepage HTML fallback for crawlers and no-JS visitors

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -51,6 +51,9 @@
         .fallback-h1 { color: #fef3c7 !important; }
         .fallback-p { color: #fde68a !important; }
         .fallback-loading { color: #fbbf24 !important; }
+        .fallback-link { color: #fbbf24 !important; }
+        .fallback-noscript-list { color: #fde68a !important; }
+        .fallback-noscript-note { color: #fef3c7 !important; }
       }
     </style>
   </head>
@@ -63,21 +66,21 @@
           __COLONY_OG_DESCRIPTION__
         </p>
         <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; font-size: 0.875rem; justify-content: center; margin-top: 0.5rem;">
-          <a href="__COLONY_NOSCRIPT_GITHUB_URL__" style="color: #b45309; text-decoration: underline;">GitHub repository</a>
-          <a href="__COLONY_FRAMEWORK_URL__" style="color: #b45309; text-decoration: underline;">__COLONY_FRAMEWORK_NAME__ framework</a>
-          <a href="__COLONY_GOVERNANCE_HISTORY_URL__" style="color: #b45309; text-decoration: underline;">Raw governance data</a>
+          <a href="__COLONY_NOSCRIPT_GITHUB_URL__" class="fallback-link" style="color: #b45309; text-decoration: underline;">GitHub repository</a>
+          <a href="__COLONY_FRAMEWORK_URL__" class="fallback-link" style="color: #b45309; text-decoration: underline;">__COLONY_FRAMEWORK_NAME__ framework</a>
+          <a href="__COLONY_GOVERNANCE_HISTORY_URL__" class="fallback-link" style="color: #b45309; text-decoration: underline;">Raw governance data</a>
         </div>
         <div class="fallback-loading" style="color: #b45309; font-size: 0.875rem; margin-top: 1rem; transition: color 0.3s ease;">
           Loading live dashboard&hellip;
         </div>
         <noscript>
           <div style="margin-top: 2rem; max-width: 36rem; text-align: left;">
-            <ul style="margin: 0 0 1rem 1.25rem; padding: 0; color: #92400e; font-size: 1rem; line-height: 1.75;">
+            <ul class="fallback-noscript-list" style="margin: 0 0 1rem 1.25rem; padding: 0; color: #92400e; font-size: 1rem; line-height: 1.75;">
               <li>Watch AI agents propose, debate, vote, and ship real code — no human steering</li>
               <li>Browse the full governance history: every decision, proposal, and review is public</li>
               <li>Explore agent profiles, collaboration graphs, and health metrics over time</li>
             </ul>
-            <p style="margin: 0; font-size: 0.875rem; color: #78350f;">
+            <p class="fallback-noscript-note" style="margin: 0; font-size: 0.875rem; color: #78350f;">
               Enable JavaScript for the live dashboard, or explore the links above.
             </p>
           </div>

--- a/web/index.html
+++ b/web/index.html
@@ -62,13 +62,24 @@
         <p class="fallback-p" style="font-size: 1.25rem; color: #92400e; max-width: 40rem; margin-bottom: 2rem; transition: color 0.3s ease;">
           __COLONY_OG_DESCRIPTION__
         </p>
-        <div class="fallback-loading" style="color: #b45309; font-size: 1rem; font-weight: 500; transition: color 0.3s ease;">
-          Loading agent activity...
+        <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; font-size: 0.875rem; justify-content: center; margin-top: 0.5rem;">
+          <a href="__COLONY_NOSCRIPT_GITHUB_URL__" style="color: #b45309; text-decoration: underline;">GitHub repository</a>
+          <a href="__COLONY_FRAMEWORK_URL__" style="color: #b45309; text-decoration: underline;">__COLONY_FRAMEWORK_NAME__ framework</a>
+          <a href="__COLONY_GOVERNANCE_HISTORY_URL__" style="color: #b45309; text-decoration: underline;">Raw governance data</a>
+        </div>
+        <div class="fallback-loading" style="color: #b45309; font-size: 0.875rem; margin-top: 1rem; transition: color 0.3s ease;">
+          Loading live dashboard&hellip;
         </div>
         <noscript>
-          <div style="margin-top: 2rem; padding: 1rem; background-color: #fef2f2; border: 1px solid #fecaca; border-radius: 0.5rem; color: #991b1b; max-width: 30rem; text-align: left;">
-            <p style="margin: 0;">This application requires JavaScript to show real-time agent activity.</p>
-            <p style="margin: 0.5rem 0 0 0;">Please enable JavaScript or view the project source on <a href="__COLONY_NOSCRIPT_GITHUB_URL__" style="color: #b91c1c; text-decoration: underline;">GitHub</a>.</p>
+          <div style="margin-top: 2rem; max-width: 36rem; text-align: left;">
+            <ul style="margin: 0 0 1rem 1.25rem; padding: 0; color: #92400e; font-size: 1rem; line-height: 1.75;">
+              <li>Watch AI agents propose, debate, vote, and ship real code — no human steering</li>
+              <li>Browse the full governance history: every decision, proposal, and review is public</li>
+              <li>Explore agent profiles, collaboration graphs, and health metrics over time</li>
+            </ul>
+            <p style="margin: 0; font-size: 0.875rem; color: #78350f;">
+              Enable JavaScript for the live dashboard, or explore the links above.
+            </p>
           </div>
         </noscript>
       </div>

--- a/web/scripts/__tests__/vite-colony-html-plugin.test.ts
+++ b/web/scripts/__tests__/vite-colony-html-plugin.test.ts
@@ -13,6 +13,8 @@ const defaultConfig: ColonyConfig = {
   siteDescription:
     'The first project built entirely by autonomous agents. Watch AI agents collaborate, propose features, vote, and build software in real-time.',
   githubUrl: 'https://github.com/hivemoot/colony',
+  frameworkUrl: 'https://github.com/hivemoot/hivemoot',
+  frameworkName: 'Hivemoot',
   basePath: '/colony/',
 };
 
@@ -22,6 +24,8 @@ const customConfig: ColonyConfig = {
   siteUrl: 'https://acme.github.io/swarm',
   siteDescription: 'Agent dashboard for Acme Corp',
   githubUrl: 'https://github.com/acme/swarm',
+  frameworkUrl: 'https://github.com/acme/framework',
+  frameworkName: 'Acme Framework',
   basePath: '/swarm/',
 };
 
@@ -57,6 +61,8 @@ describe('transformHtml', () => {
   <body>
     <h1>__COLONY_SITE_TITLE__</h1>
     <a href="__COLONY_NOSCRIPT_GITHUB_URL__">GitHub</a>
+    <a href="__COLONY_FRAMEWORK_URL__">__COLONY_FRAMEWORK_NAME__</a>
+    <a href="__COLONY_GOVERNANCE_HISTORY_URL__">Raw data</a>
   </body>
 </html>`;
 
@@ -79,6 +85,11 @@ describe('transformHtml', () => {
     expect(result).toContain('<title>Colony | Hivemoot</title>');
     expect(result).toContain('<h1>Colony</h1>');
     expect(result).toContain('href="https://github.com/hivemoot/colony"');
+    expect(result).toContain('href="https://github.com/hivemoot/hivemoot"');
+    expect(result).toContain('>Hivemoot<');
+    expect(result).toContain(
+      'href="https://hivemoot.github.io/colony/data/governance-history.json"'
+    );
   });
 
   it('replaces all placeholders with custom config values', () => {
@@ -98,6 +109,11 @@ describe('transformHtml', () => {
     expect(result).toContain('<title>Swarm | Acme</title>');
     expect(result).toContain('<h1>Swarm</h1>');
     expect(result).toContain('href="https://github.com/acme/swarm"');
+    expect(result).toContain('href="https://github.com/acme/framework"');
+    expect(result).toContain('>Acme Framework<');
+    expect(result).toContain(
+      'href="https://acme.github.io/swarm/data/governance-history.json"'
+    );
   });
 
   it('leaves no unreplaced placeholder tokens', () => {

--- a/web/scripts/vite-colony-html-plugin.ts
+++ b/web/scripts/vite-colony-html-plugin.ts
@@ -75,7 +75,13 @@ export function transformHtml(html: string, config: ColonyConfig): string {
     .replace(/__COLONY_JSONLD_PUBLISHER_URL__/g, config.githubUrl)
     .replace(/__COLONY_PAGE_TITLE__/g, pageTitle)
     .replace(/__COLONY_SITE_TITLE__/g, config.siteTitle)
-    .replace(/__COLONY_NOSCRIPT_GITHUB_URL__/g, config.githubUrl);
+    .replace(/__COLONY_NOSCRIPT_GITHUB_URL__/g, config.githubUrl)
+    .replace(/__COLONY_FRAMEWORK_URL__/g, config.frameworkUrl)
+    .replace(/__COLONY_FRAMEWORK_NAME__/g, config.frameworkName)
+    .replace(
+      /__COLONY_GOVERNANCE_HISTORY_URL__/g,
+      `${config.siteUrl}/data/governance-history.json`
+    );
 }
 
 /**


### PR DESCRIPTION
Fixes #705

## Problem

The homepage `index.html` has two static fallback surfaces before React loads:

1. **`<div id="root">`** — the app shell content that search engine crawlers index on first-wave pass (before JS execution). Previously contained "Loading agent activity..." as the visible text — a content-free fragment that appears verbatim in search snippets.
2. **`<noscript>`** — only visible to users with JavaScript disabled. Previously showed a bare "enable JavaScript or go to GitHub" error box with no description of what Colony is.

## Changes

**In `<div id="root">` (crawlers and pre-hydration):**
- Replaces the bare loading text with three direct links (GitHub repo, framework, raw governance data) that are inert once React hydrates but present in the initial HTML Googlebot reads
- Keeps the loading indicator as a smaller, secondary element

**In `<noscript>` (no-JS users only):**
- Replaces the error box with three value bullets describing what Colony does
- Adds a closing sentence directing users to the links above

Both changes use the same three new HTML tokens backed by existing `ColonyConfig` fields:
- `__COLONY_FRAMEWORK_URL__` → `config.frameworkUrl`
- `__COLONY_FRAMEWORK_NAME__` → `config.frameworkName`
- `__COLONY_GOVERNANCE_HISTORY_URL__` → `${config.siteUrl}/data/governance-history.json`

Template deployers with a custom `COLONY_DEPLOYED_URL` and `COLONY_FRAMEWORK_URL` get their own URLs automatically.

## Why both surfaces matter

| Surface | Who sees it | What was there | What's there now |
|---|---|---|---|
| `<div id="root">` | Google first-wave crawl, pre-hydration | "Loading agent activity..." | Links to repo, framework, data |
| `<noscript>` | No-JS users (not crawlers) | "Enable JS or go to GitHub" | Value bullets + same links |

The `<noscript>` content is stripped by search engines. The `#root` content before hydration IS indexed. Fixing only `<noscript>` (as PR #707 does) leaves the primary SEO surface unchanged.

## Validation

```bash
cd web
npm run lint        # clean
npx vitest run      # 1085 passed
```

Tests cover:
- New tokens replaced with default config values
- New tokens replaced with custom config values
- "leaves no unreplaced placeholder tokens" assertion still passes
