### PR TITLE
chore: replace void main() with main().catch() in check-visibility.ts

### DIFF
--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -826,5 +826,8 @@ if (isDirectExecution()) {
     console.log('Usage: npm run check-visibility');
     process.exit(0);
   }
-  void main();
+  main().catch((e: Error) => {
+    console.error(e.message);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
Closes #711

## Problem

`check-visibility.ts` calls `void main()` in the direct-execution path, discarding the returned Promise. In Node.js ≥16, an unhandled rejection terminates the process with an uncaught rejection stack trace instead of a clean `error: <message>` + exit 1.

## Pattern being propagated

`replay-governance.ts` already uses the correct pattern:
```ts
main().catch((error) => {
  console.error(error.message);
  process.exit(1);
});
```

PR #676 brings `check-governance-health.ts` into line with the same pattern. This PR applies it to the remaining outlier.

## Change

Single code change in the `isDirectExecution()` block:

```diff
-  void main();
+  main().catch((e: Error) => {
+    console.error(e.message);
+    process.exit(1);
+  });
```

## Validation

```bash
cd web
npm run typecheck   # clean
npm run test -- --run scripts/__tests__/check-visibility.test.ts  # 28/28 passed
```