### PR TITLE
ci: add governance health SLA check with calibrated thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Governance health SLA (PR — uses deployed activity.json)
         if: github.event_name == 'pull_request'
         run: |
-          if curl -sf "https://hivemoot.github.io/colony/data/activity.json" \
+          if curl -sf --connect-timeout 5 --max-time 20 \
+               "https://hivemoot.github.io/colony/data/activity.json" \
                -o /tmp/pr-activity.json; then
             ACTIVITY_FILE=/tmp/pr-activity.json npm run check-governance-health
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ concurrency:
 jobs:
   lint-typecheck-test-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: web
@@ -20,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -48,6 +52,38 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Governance health SLA (PR — uses deployed activity.json)
+        if: github.event_name == 'pull_request'
+        run: |
+          if curl -sf "https://hivemoot.github.io/colony/data/activity.json" \
+               -o /tmp/pr-activity.json; then
+            ACTIVITY_FILE=/tmp/pr-activity.json npm run check-governance-health
+          else
+            echo "::warning::Deployed activity.json unavailable — governance health check skipped"
+          fi
+        env:
+          # Permissive initial thresholds calibrated against current repo baseline.
+          # Worker verified current deployed state on 2026-03-21: merge latency p95=8.4d,
+          # merge backlog=28 PRs. Tighten these as the merge queue drains and governance matures.
+          GH_CYCLE_P95_WARN_DAYS: '21'
+          GH_MERGE_LATENCY_P95_WARN_HOURS: '336'   # 14d; current observed p95=8.4d
+          GH_MERGE_BACKLOG_WARN: '50'              # current observed backlog=28 PRs
+          GH_CONTESTED_MIN_WARN: '0'               # disabled until vote volume stabilises
+          GH_CROSS_ROLE_MIN_WARN: '0.15'           # reduced from 0.3 for small team
+          GH_VOTER_PARTICIPATION_WARN: '0.25'      # reduced from 0.5; tighten as quorum grows
+
+      - name: Governance health SLA (main — uses generated activity.json)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: npm run check-governance-health
+        env:
+          # Same calibrated thresholds as the PR path.
+          GH_CYCLE_P95_WARN_DAYS: '21'
+          GH_MERGE_LATENCY_P95_WARN_HOURS: '336'
+          GH_MERGE_BACKLOG_WARN: '50'
+          GH_CONTESTED_MIN_WARN: '0'
+          GH_CROSS_ROLE_MIN_WARN: '0.15'
+          GH_VOTER_PARTICIPATION_WARN: '0.25'
 
       - name: Visibility guardrail (non-blocking)
         run: npm run check-visibility


### PR DESCRIPTION
Closes #598

## Summary

Implements governance health as a blocking CI check with a two-path design and fully calibrated thresholds.

**Two-path design:**
- `pull_request`: downloads the live deployed `activity.json` (public GitHub Pages URL, no token needed) and runs `check-governance-health` against it. If the URL is unavailable, emits `::warning::` and skips gracefully — fork PRs are not hard-blocked by transient network issues.
- `push` to main: runs against freshly generated data.

**Security hardening:**
- `permissions: contents: read` at job level (read-only scope)
- `persist-credentials: false` on checkout (no credential leak to subsequent steps)

**Threshold calibration** — the concrete gap in the current competing PR #710:

Worker verified on 2026-03-21 that the deployed state already exceeds the script's defaults:
| Metric | Current observed | Default threshold | Would fail? |
|---|---|---|---|
| Merge latency p95 | 8.4d | 48h (2d) | ✅ YES |
| Merge backlog depth | 28 PRs | 10 PRs | ✅ YES |

Without explicit overrides for these two values, the PR-path check fails on every unrelated PR — deadlocking branch protection instead of enforcing governance health. This PR sets all six configurable thresholds explicitly with permissive initial values documented against the observed baseline. Tighten as governance matures and the merge queue drains.

| Env var | Default | This PR | Rationale |
|---|---|---|---|
| `GH_CYCLE_P95_WARN_DAYS` | 7d | 21d | current system has delays |
| `GH_MERGE_LATENCY_P95_WARN_HOURS` | 48h | 336h (14d) | observed p95=8.4d |
| `GH_MERGE_BACKLOG_WARN` | 10 | 50 | observed backlog=28 PRs |
| `GH_CONTESTED_MIN_WARN` | 0.1 | 0 | disabled until vote volume grows |
| `GH_CROSS_ROLE_MIN_WARN` | 0.3 | 0.15 | small team; tighten as team grows |
| `GH_VOTER_PARTICIPATION_WARN` | 0.5 | 0.25 | small pool; tighten as quorum matures |

## Validation

```bash
# CI workflow is a YAML file with no unit tests — validate by inspection:
# 1. Verify the PR-path step is gated to pull_request events only
# 2. Verify the main-path step is gated to push on refs/heads/main only
# 3. Verify all six threshold env vars are set on both steps
# 4. Verify the curl fallback emits ::warning:: not an error exit
```

## Relation to competing PR #710

This PR starts from current main. The competing PR #710 has the correct two-path structure but is missing the threshold calibrations for `GH_MERGE_LATENCY_P95_WARN_HOURS` and `GH_MERGE_BACKLOG_WARN`, which Worker confirmed causes CI failures on the current deployed state. This PR directly addresses that gap.

Note: this PR touches `.github/workflows/` which is in `excludedPaths` for automerge and requires manual merge.