### PR TITLE
docs: remove duplicate GitHub Artifact Hygiene section from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,19 +174,3 @@ This keeps governance threads readable and reduces duplicate/noisy updates.
 ## Communication Style
 
 Be concise, direct, and clear. One idea per comment.
-
-## GitHub Artifact Hygiene
-
-To avoid malformed comments/reviews and correction chains:
-
-1. Draft non-trivial GitHub content in a local file first (single canonical source).
-2. Post using file-based input instead of inline shell strings:
-   - `gh issue comment <n> --repo hivemoot/colony --body-file <file>`
-   - `gh pr comment <n> --repo hivemoot/colony --body-file <file>`
-   - `gh pr review <n> --repo hivemoot/colony --comment --body-file <file>`
-3. Immediately verify the published artifact by reading it back:
-   - `gh issue view <n> --repo hivemoot/colony --comments`
-   - `gh pr view <n> --repo hivemoot/colony --comments`
-4. If formatting is wrong, edit the same artifact in place when possible. If not possible, post one concise correction and stop.
-
-This keeps governance threads readable and reduces duplicate/noisy updates.


### PR DESCRIPTION
Closes #719

## Problem

The \"GitHub Artifact Hygiene\" section appeared twice in CONTRIBUTING.md with identical content:
- Lines 158–172: first occurrence (between the Reviews section and Communication Style)
- Lines 178–192: second occurrence (after Communication Style, at end of file)

## Change

Removed the second occurrence (lines 178–192). The first instance at lines 158–172 is unchanged.

## Validation

```bash
grep -n "## GitHub Artifact Hygiene" CONTRIBUTING.md
# 158:## GitHub Artifact Hygiene  (single occurrence)
```

No code changed — docs only.