### PR TITLE
feat: add Pagefind full-text search to static proposal and agent pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,16 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify Pagefind artifacts
+        run: |
+          if [ -d dist/proposals ] || [ -d dist/proposal ] || [ -d dist/agent ]; then
+            test -f dist/_pagefind/pagefind.js
+            test -f dist/_pagefind/pagefind-entry.json
+            find dist/_pagefind -type f -name '*.pf_meta' | grep -q .
+          else
+            echo "No generated static pages found; skipping Pagefind artifact assertion."
+          fi
+
       - name: Visibility guardrail (non-blocking)
         run: npm run check-visibility
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Verify Pagefind artifacts
         run: |
-          if [ -d dist/proposals ] || [ -d dist/proposal ] || [ -d dist/agent ]; then
+          if [ -f dist/proposals/index.html ] || [ -d dist/proposal ] || [ -d dist/agent ]; then
             test -f dist/_pagefind/pagefind.js
             test -f dist/_pagefind/pagefind-entry.json
             find dist/_pagefind -type f -name '*.pf_meta' | grep -q .

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "jsdom": "^27.4.0",
+        "pagefind": "^1.4.0",
         "prettier": "^3.8.1",
         "tailwindcss": "^4.1.18",
         "tsx": "^4.20.3",
@@ -1254,6 +1255,90 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.4.0.tgz",
+      "integrity": "sha512-2vMqkbv3lbx1Awea90gTaBsvpzgRs7MuSgKDxW0m9oV1GPZCZbZBJg/qL83GIUEN2BFlY46dtUZi54pwH+/pTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.4.0.tgz",
+      "integrity": "sha512-WcJVypXSZ+9HpiqZjFXMUobfFfZZ6NzIYtkhQ9eOhZrQpeY5uQFqNWLCk7w9RkMUwBv1HAMDW3YJQl/8OqsV0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
+      "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
+      "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
@@ -5537,6 +5622,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pagefind": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.4.0.tgz",
+      "integrity": "sha512-z2kY1mQlL4J8q5EIsQkLzQjilovKzfNVhX8De6oyE6uHpfFtyBaqUpcl/XzJC/4fjD8vBDyh1zolimIcVrCn9g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.4.0",
+        "@pagefind/darwin-x64": "1.4.0",
+        "@pagefind/freebsd-x64": "1.4.0",
+        "@pagefind/linux-arm64": "1.4.0",
+        "@pagefind/linux-x64": "1.4.0",
+        "@pagefind/windows-x64": "1.4.0"
       }
     },
     "node_modules/parent-module": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "postbuild": "tsx scripts/build-pagefind.ts",
     "build:with-data": "npm run generate-data && npm run build",
     "preview": "vite preview",
     "test": "vitest run",
@@ -51,6 +52,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^27.4.0",
+    "pagefind": "^1.4.0",
     "prettier": "^3.8.1",
     "tailwindcss": "^4.1.18",
     "tsx": "^4.20.3",

--- a/web/public/static-page-search.js
+++ b/web/public/static-page-search.js
@@ -86,6 +86,8 @@
     window.__COLONY_STATIC_SEARCH_TEST__ = {
       normalizeBasePath,
       normalizeResultUrl,
+      getActiveSearch: () => activeSearch,
+      handleSearchInput,
     };
   }
 
@@ -215,12 +217,16 @@
     });
   });
 
-  input.addEventListener('input', () => {
+  function handleSearchInput() {
     const query = input.value.trim();
 
     if (debounceTimer) {
       window.clearTimeout(debounceTimer);
     }
+
+    // Invalidate any in-flight search immediately so stale results never
+    // render into an empty or too-short input state.
+    activeSearch++;
 
     if (!query) {
       clearResults();
@@ -237,5 +243,7 @@
     debounceTimer = window.setTimeout(() => {
       void runSearch(query);
     }, 180);
-  });
+  }
+
+  input.addEventListener('input', handleSearchInput);
 })();

--- a/web/public/static-page-search.js
+++ b/web/public/static-page-search.js
@@ -1,0 +1,241 @@
+(() => {
+  const panel = document.querySelector('.search-panel[data-base-path]');
+  if (!(panel instanceof HTMLElement)) {
+    return;
+  }
+
+  const input = document.getElementById('archive-search-input');
+  const status = document.getElementById('archive-search-status');
+  const results = document.getElementById('archive-search-results');
+
+  if (
+    !(input instanceof HTMLInputElement) ||
+    !(status instanceof HTMLElement) ||
+    !(results instanceof HTMLElement)
+  ) {
+    return;
+  }
+
+  function normalizeBasePath(rawValue) {
+    const raw = (rawValue || '/').trim();
+    if (!raw) {
+      return '/';
+    }
+
+    let normalized = raw;
+    if (!normalized.startsWith('/')) {
+      normalized = `/${normalized}`;
+    }
+    if (!normalized.endsWith('/')) {
+      normalized = `${normalized}/`;
+    }
+    return normalized;
+  }
+
+  function toPlainText(value) {
+    return String(value || '')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  const basePath = normalizeBasePath(panel.dataset.basePath);
+  const pagefindScriptUrl = `${basePath}_pagefind/pagefind.js`;
+
+  let pagefindModulePromise;
+  let activeSearch = 0;
+  let debounceTimer = 0;
+
+  function setStatus(message) {
+    status.textContent = message;
+  }
+
+  function clearResults() {
+    results.innerHTML = '';
+  }
+
+  function normalizeResultUrl(rawUrl) {
+    const value = String(rawUrl || '').trim();
+    if (!value) {
+      return basePath;
+    }
+
+    let parsedUrl;
+    try {
+      parsedUrl = new URL(value, window.location.origin);
+    } catch (_error) {
+      return basePath;
+    }
+
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return basePath;
+    }
+
+    if (parsedUrl.origin !== window.location.origin) {
+      return basePath;
+    }
+
+    const path = parsedUrl.pathname.startsWith(basePath)
+      ? parsedUrl.pathname
+      : `${basePath}${parsedUrl.pathname.replace(/^\/+/, '')}`;
+
+    return `${path}${parsedUrl.search}${parsedUrl.hash}`;
+  }
+
+  if (panel.dataset.exposeInternals === 'true') {
+    window.__COLONY_STATIC_SEARCH_TEST__ = {
+      normalizeBasePath,
+      normalizeResultUrl,
+    };
+  }
+
+  function resolvePagefindApi(moduleValue) {
+    if (moduleValue && typeof moduleValue.search === 'function') {
+      return moduleValue;
+    }
+
+    if (
+      moduleValue &&
+      moduleValue.default &&
+      typeof moduleValue.default.search === 'function'
+    ) {
+      return moduleValue.default;
+    }
+
+    throw new Error('Pagefind search API not found in module export.');
+  }
+
+  function renderResults(entries) {
+    clearResults();
+
+    const fragment = document.createDocumentFragment();
+
+    for (const entry of entries) {
+      const item = document.createElement('li');
+      item.className = 'search-result';
+
+      const link = document.createElement('a');
+      link.className = 'search-result-link';
+      link.href = entry.url;
+      link.textContent = entry.title;
+      item.appendChild(link);
+
+      if (entry.metaLine) {
+        const meta = document.createElement('p');
+        meta.className = 'search-result-meta';
+        meta.textContent = entry.metaLine;
+        item.appendChild(meta);
+      }
+
+      if (entry.snippet) {
+        const snippet = document.createElement('p');
+        snippet.className = 'search-result-snippet';
+        snippet.textContent = entry.snippet;
+        item.appendChild(snippet);
+      }
+
+      fragment.appendChild(item);
+    }
+
+    results.appendChild(fragment);
+  }
+
+  async function loadPagefind() {
+    if (!pagefindModulePromise) {
+      pagefindModulePromise = import(pagefindScriptUrl);
+    }
+
+    const loadedModule = await pagefindModulePromise;
+    return resolvePagefindApi(loadedModule);
+  }
+
+  async function runSearch(query) {
+    const searchId = ++activeSearch;
+
+    setStatus('Searching...');
+
+    try {
+      const pagefind = await loadPagefind();
+      const searchResponse = await pagefind.search(query);
+      const resultItems = await Promise.all(
+        (searchResponse.results || []).slice(0, 8).map(async (result) => {
+          const data = await result.data();
+          const meta = data.meta || {};
+          const title =
+            toPlainText(meta.title) ||
+            toPlainText(data.excerpt) ||
+            normalizeResultUrl(data.url);
+
+          const metaParts = [];
+          if (meta.phase) {
+            metaParts.push(toPlainText(meta.phase));
+          }
+          if (meta.author) {
+            metaParts.push(`by ${toPlainText(meta.author)}`);
+          }
+          if (meta.agent && !meta.author) {
+            metaParts.push(`agent ${toPlainText(meta.agent)}`);
+          }
+
+          return {
+            url: normalizeResultUrl(data.url),
+            title,
+            metaLine: metaParts.join(' | '),
+            snippet: toPlainText(data.excerpt || data.content).slice(0, 180),
+          };
+        })
+      );
+
+      if (searchId !== activeSearch) {
+        return;
+      }
+
+      if (resultItems.length === 0) {
+        clearResults();
+        setStatus('No results found.');
+        return;
+      }
+
+      renderResults(resultItems);
+      setStatus(`Showing ${resultItems.length} result${resultItems.length === 1 ? '' : 's'}.`);
+    } catch (_error) {
+      if (searchId !== activeSearch) {
+        return;
+      }
+      clearResults();
+      setStatus('Search is temporarily unavailable.');
+    }
+  }
+
+  input.addEventListener('focus', () => {
+    void loadPagefind().catch(() => {
+      if (!status.textContent) {
+        setStatus('Search is temporarily unavailable.');
+      }
+    });
+  });
+
+  input.addEventListener('input', () => {
+    const query = input.value.trim();
+
+    if (debounceTimer) {
+      window.clearTimeout(debounceTimer);
+    }
+
+    if (!query) {
+      clearResults();
+      setStatus('');
+      return;
+    }
+
+    if (query.length < 2) {
+      clearResults();
+      setStatus('Type at least 2 characters to search.');
+      return;
+    }
+
+    debounceTimer = window.setTimeout(() => {
+      void runSearch(query);
+    }, 180);
+  });
+})();

--- a/web/scripts/__tests__/static-page-search.test.ts
+++ b/web/scripts/__tests__/static-page-search.test.ts
@@ -12,6 +12,8 @@ const SEARCH_SCRIPT_SOURCE = readFileSync(SEARCH_SCRIPT_PATH, 'utf8');
 
 type SearchInternals = {
   normalizeResultUrl: (value: string) => string;
+  getActiveSearch: () => number;
+  handleSearchInput: () => void;
 };
 
 function mountSearchDom(basePath = '/colony/'): void {
@@ -75,5 +77,98 @@ describe('static-page-search URL normalization', () => {
         `${window.location.origin}/proposal/1/?q=test#part`
       )
     ).toBe('/colony/proposal/1/?q=test#part');
+  });
+});
+
+describe('static-page-search stale-results protection', () => {
+  afterEach(() => {
+    delete (
+      window as typeof window & {
+        __COLONY_STATIC_SEARCH_TEST__?: unknown;
+      }
+    ).__COLONY_STATIC_SEARCH_TEST__;
+    document.body.innerHTML = '';
+  });
+
+  function mountAndLoad(basePath = '/colony/'): SearchInternals {
+    mountSearchDom(basePath);
+    const internals = loadSearchScript();
+    expect(internals).toBeDefined();
+    return internals!;
+  }
+
+  it('increments activeSearch when input is cleared, invalidating in-flight searches', () => {
+    const internals = mountAndLoad();
+    const input = document.getElementById(
+      'archive-search-input'
+    ) as HTMLInputElement;
+
+    const before = internals.getActiveSearch();
+
+    // Simulate a real query being typed.
+    input.value = 'governance';
+    internals.handleSearchInput();
+    expect(internals.getActiveSearch()).toBeGreaterThan(before);
+
+    const afterQuery = internals.getActiveSearch();
+
+    // Clear the input — this must also advance activeSearch so any in-flight
+    // search from the previous query cannot render stale results.
+    input.value = '';
+    internals.handleSearchInput();
+    expect(internals.getActiveSearch()).toBeGreaterThan(afterQuery);
+  });
+
+  it('increments activeSearch when query drops below the 2-character minimum', () => {
+    const internals = mountAndLoad();
+    const input = document.getElementById(
+      'archive-search-input'
+    ) as HTMLInputElement;
+
+    // Start a real query.
+    input.value = 'gov';
+    internals.handleSearchInput();
+    const afterQuery = internals.getActiveSearch();
+
+    // Delete back to a single character — stale results must be blocked.
+    input.value = 'g';
+    internals.handleSearchInput();
+    expect(internals.getActiveSearch()).toBeGreaterThan(afterQuery);
+  });
+
+  it('clears the results and status elements on empty input', () => {
+    const internals = mountAndLoad();
+    const input = document.getElementById(
+      'archive-search-input'
+    ) as HTMLInputElement;
+    const status = document.getElementById('archive-search-status')!;
+    const results = document.getElementById('archive-search-results')!;
+
+    // Seed visible state that a stale search might have left behind.
+    results.innerHTML = '<li>stale result</li>';
+    status.textContent = 'Showing 1 result.';
+
+    input.value = '';
+    internals.handleSearchInput();
+
+    expect(results.innerHTML).toBe('');
+    expect(status.textContent).toBe('');
+  });
+
+  it('clears results and shows minimum-length hint when query is too short', () => {
+    const internals = mountAndLoad();
+    const input = document.getElementById(
+      'archive-search-input'
+    ) as HTMLInputElement;
+    const status = document.getElementById('archive-search-status')!;
+    const results = document.getElementById('archive-search-results')!;
+
+    results.innerHTML = '<li>stale result</li>';
+
+    input.value = 'x';
+    internals.handleSearchInput();
+
+    expect(results.innerHTML).toBe('');
+    expect(status.textContent).toBe('Type at least 2 characters to search.');
   });
 });

--- a/web/scripts/__tests__/static-page-search.test.ts
+++ b/web/scripts/__tests__/static-page-search.test.ts
@@ -93,8 +93,8 @@ describe('static-page-search stale-results protection', () => {
   function mountAndLoad(basePath = '/colony/'): SearchInternals {
     mountSearchDom(basePath);
     const internals = loadSearchScript();
-    expect(internals).toBeDefined();
-    return internals!;
+    if (!internals) throw new Error('Search internals not initialized');
+    return internals;
   }
 
   it('increments activeSearch when input is cleared, invalidating in-flight searches', () => {
@@ -141,8 +141,12 @@ describe('static-page-search stale-results protection', () => {
     const input = document.getElementById(
       'archive-search-input'
     ) as HTMLInputElement;
-    const status = document.getElementById('archive-search-status')!;
-    const results = document.getElementById('archive-search-results')!;
+    const status = document.getElementById(
+      'archive-search-status'
+    ) as HTMLElement;
+    const results = document.getElementById(
+      'archive-search-results'
+    ) as HTMLElement;
 
     // Seed visible state that a stale search might have left behind.
     results.innerHTML = '<li>stale result</li>';
@@ -160,8 +164,12 @@ describe('static-page-search stale-results protection', () => {
     const input = document.getElementById(
       'archive-search-input'
     ) as HTMLInputElement;
-    const status = document.getElementById('archive-search-status')!;
-    const results = document.getElementById('archive-search-results')!;
+    const status = document.getElementById(
+      'archive-search-status'
+    ) as HTMLElement;
+    const results = document.getElementById(
+      'archive-search-results'
+    ) as HTMLElement;
 
     results.innerHTML = '<li>stale result</li>';
 

--- a/web/scripts/__tests__/static-page-search.test.ts
+++ b/web/scripts/__tests__/static-page-search.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SEARCH_SCRIPT_PATH = resolve(
+  __dirname,
+  '../../public/static-page-search.js'
+);
+const SEARCH_SCRIPT_SOURCE = readFileSync(SEARCH_SCRIPT_PATH, 'utf8');
+
+type SearchInternals = {
+  normalizeResultUrl: (value: string) => string;
+};
+
+function mountSearchDom(basePath = '/colony/'): void {
+  document.body.innerHTML = `
+    <section class="search-panel" data-base-path="${basePath}" data-expose-internals="true">
+      <input id="archive-search-input" />
+      <p id="archive-search-status"></p>
+      <ol id="archive-search-results"></ol>
+    </section>
+  `;
+}
+
+function loadSearchScript(): SearchInternals | undefined {
+  window.eval(SEARCH_SCRIPT_SOURCE);
+  return (
+    window as typeof window & {
+      __COLONY_STATIC_SEARCH_TEST__?: SearchInternals;
+    }
+  ).__COLONY_STATIC_SEARCH_TEST__;
+}
+
+describe('static-page-search URL normalization', () => {
+  afterEach(() => {
+    delete (
+      window as typeof window & {
+        __COLONY_STATIC_SEARCH_TEST__?: unknown;
+      }
+    ).__COLONY_STATIC_SEARCH_TEST__;
+    document.body.innerHTML = '';
+  });
+
+  it('rejects unsafe or off-origin result URLs', () => {
+    mountSearchDom('/colony/');
+    const internals = loadSearchScript();
+    expect(internals).toBeDefined();
+
+    expect(internals?.normalizeResultUrl('javascript:alert(1)')).toBe(
+      '/colony/'
+    );
+    expect(internals?.normalizeResultUrl('data:text/html,hello')).toBe(
+      '/colony/'
+    );
+    expect(
+      internals?.normalizeResultUrl('https://evil.example/proposal/1/')
+    ).toBe('/colony/');
+  });
+
+  it('normalizes same-origin result URLs into the configured base path', () => {
+    mountSearchDom('/colony/');
+    const internals = loadSearchScript();
+    expect(internals).toBeDefined();
+
+    expect(internals?.normalizeResultUrl('/proposal/1/')).toBe(
+      '/colony/proposal/1/'
+    );
+    expect(internals?.normalizeResultUrl('/colony/proposal/1/')).toBe(
+      '/colony/proposal/1/'
+    );
+    expect(
+      internals?.normalizeResultUrl(
+        `${window.location.origin}/proposal/1/?q=test#part`
+      )
+    ).toBe('/colony/proposal/1/?q=test#part');
+  });
+});

--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -95,6 +95,9 @@ describe('generateStaticPages', () => {
     // breadcrumb links to /proposals/ hub, not the SPA hash
     expect(html).toContain('href="/colony/proposals/"');
     expect(html).toContain('>Proposals<');
+    expect(html).toContain('data-pagefind-body');
+    expect(html).toContain('Search Colony archive');
+    expect(html).toContain('data-pagefind-ignore');
   });
 
   it('generates agent pages', () => {
@@ -315,6 +318,10 @@ describe('generateStaticPages', () => {
     expect(html).toContain('/proposal/99/');
     // Twitter
     expect(html).toContain('twitter:card');
+    // Pagefind meta
+    expect(html).toContain('data-pagefind-meta="kind" content="proposal"');
+    expect(html).toContain('data-pagefind-meta="author" content="test-agent"');
+    expect(html).toContain('data-pagefind-meta="url[href]"');
   });
 
   it('includes proper meta tags in agent pages', () => {
@@ -346,6 +353,9 @@ describe('generateStaticPages', () => {
     expect(html).toContain('test-agent | Colony Agents');
     expect(html).toContain('/agent/test-agent/');
     expect(html).toContain('twitter:card');
+    // Pagefind meta
+    expect(html).toContain('data-pagefind-meta="kind" content="agent"');
+    expect(html).toContain('data-pagefind-meta="agent" content="test-agent"');
   });
 
   it('handles proposals without votes or transitions', () => {
@@ -743,6 +753,9 @@ describe('generateStaticPages', () => {
     expect(html).toContain('Voting');
     expect(html).toContain('rel="canonical"');
     expect(html).toContain('/proposals/');
+    expect(html).toContain(
+      'data-pagefind-meta="kind" content="proposal-index"'
+    );
   });
 
   it('proposals index groups active and decided proposals', () => {
@@ -1018,9 +1031,13 @@ describe('generateStaticPages', () => {
     expect(proposalHtml).toContain('href="/my-app/proposals/"');
     expect(proposalHtml).toContain('href="/my-app/#proposal-7"');
     expect(proposalHtml).toContain('href="/my-app/favicon.ico"');
+    expect(proposalHtml).toContain('data-base-path="/my-app/"');
+    expect(proposalHtml).toContain('src="/my-app/static-page-search.js"');
     expect(agentHtml).toContain('href="/my-app/"');
     expect(agentHtml).toContain('href="/my-app/agents/"');
     expect(agentHtml).toContain('href="/my-app/favicon.ico"');
+    expect(agentHtml).toContain('data-base-path="/my-app/"');
+    expect(agentHtml).toContain('src="/my-app/static-page-search.js"');
 
     // Internal links (href/src attributes) must not use hardcoded /colony/
     // (External GitHub URLs like github.com/hivemoot/colony are fine)

--- a/web/scripts/build-pagefind.ts
+++ b/web/scripts/build-pagefind.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SITE_DIR = 'dist';
+const OUTPUT_SUBDIR = '_pagefind';
+
+function hasStaticPages(siteDir: string): boolean {
+  return (
+    existsSync(join(siteDir, 'proposals', 'index.html')) ||
+    existsSync(join(siteDir, 'proposal')) ||
+    existsSync(join(siteDir, 'agent'))
+  );
+}
+
+function hasMetaFile(directory: string): boolean {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (hasMetaFile(fullPath)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.pf_meta')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function assertArtifactsExist(siteDir: string, outputSubdir: string): void {
+  const outputDir = join(siteDir, outputSubdir);
+  const requiredFiles = [
+    join(outputDir, 'pagefind.js'),
+    join(outputDir, 'pagefind-entry.json'),
+  ];
+
+  for (const required of requiredFiles) {
+    if (!existsSync(required)) {
+      throw new Error(`[pagefind] Missing required artifact: ${required}`);
+    }
+  }
+
+  if (!hasMetaFile(outputDir)) {
+    throw new Error(
+      `[pagefind] Static pages exist but no .pf_meta files found in ${outputDir}.`
+    );
+  }
+}
+
+function buildPagefindIndex(): void {
+  if (!hasStaticPages(SITE_DIR)) {
+    console.log(
+      `[pagefind] No generated static pages found in ${SITE_DIR}. Skipping index build.`
+    );
+    return;
+  }
+
+  execFileSync(
+    'npx',
+    [
+      '--no-install',
+      'pagefind',
+      '--site',
+      SITE_DIR,
+      '--output-subdir',
+      OUTPUT_SUBDIR,
+    ],
+    { stdio: 'inherit' }
+  );
+
+  assertArtifactsExist(SITE_DIR, OUTPUT_SUBDIR);
+
+  console.log(
+    `[pagefind] Search index generated in ${SITE_DIR}/${OUTPUT_SUBDIR}`
+  );
+}
+
+buildPagefindIndex();

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -38,6 +38,8 @@ interface PageMeta {
   jsonLd?: object;
   /** Optional extra <link> or <meta> tags injected into <head>. */
   extraHeadTags?: string;
+  /** Optional Pagefind meta tags for search indexing. */
+  pagefindMeta?: Record<string, string>;
 }
 
 /**
@@ -87,6 +89,19 @@ function escapeHtml(str: string): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+function renderPagefindMeta(meta: Record<string, string> | undefined): string {
+  if (!meta) {
+    return '';
+  }
+
+  return Object.entries(meta)
+    .map(
+      ([name, value]) =>
+        `  <meta data-pagefind-meta="${escapeHtml(name)}" content="${escapeHtml(value)}" />`
+    )
+    .join('\n');
 }
 
 /**
@@ -200,6 +215,8 @@ function renderMarkdown(md: string): string {
 
 function htmlShell(meta: PageMeta, content: string): string {
   const fullUrl = `${BASE_URL}${meta.canonicalPath}`;
+  const pagefindMetaTags = renderPagefindMeta(meta.pagefindMeta);
+  const pagefindMetaBlock = pagefindMetaTags ? `${pagefindMetaTags}\n` : '';
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -207,7 +224,7 @@ function htmlShell(meta: PageMeta, content: string): string {
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>${escapeHtml(meta.title)}</title>
   <meta name="description" content="${escapeHtml(meta.description)}" />
-  <link rel="canonical" href="${escapeHtml(fullUrl)}" />
+${pagefindMetaBlock}  <link data-pagefind-meta="url[href]" rel="canonical" href="${escapeHtml(fullUrl)}" />
   <link rel="icon" href="${basePath()}favicon.ico" sizes="any" />
   <link rel="apple-touch-icon" sizes="180x180" href="${basePath()}apple-touch-icon.png" />${meta.extraHeadTags ? `\n  ${meta.extraHeadTags}` : ''}
   <meta property="og:type" content="website" />
@@ -246,6 +263,23 @@ function htmlShell(meta: PageMeta, content: string): string {
     .stat-value { font-size: 1.5rem; font-weight: 700; color: #b45309; }
     @media (prefers-color-scheme: dark) { .stat-value { color: #fbbf24; } }
     .stat-label { font-size: 0.75rem; color: #6b7280; }
+    .search-panel { margin-bottom: 1.25rem; border-radius: 0.5rem; border: 1px solid #e5e5e5; background: #fff; padding: 1rem; }
+    @media (prefers-color-scheme: dark) { .search-panel { background: #262626; border-color: #404040; } }
+    .search-label { display: block; font-size: 0.875rem; font-weight: 600; margin-bottom: 0.5rem; }
+    .search-input { width: 100%; border: 1px solid #d4d4d4; border-radius: 0.375rem; padding: 0.625rem 0.75rem; font-size: 0.9375rem; }
+    .search-input:focus { outline: 2px solid #b45309; outline-offset: 2px; border-color: #b45309; }
+    @media (prefers-color-scheme: dark) { .search-input { background: #171717; border-color: #525252; color: #e5e5e5; } }
+    .search-status { margin-top: 0.5rem; font-size: 0.8125rem; color: #6b7280; min-height: 1.1rem; }
+    .search-results { margin-top: 0.75rem; list-style: none; display: grid; gap: 0.625rem; }
+    .search-result { border-top: 1px solid #e5e5e5; padding-top: 0.625rem; }
+    .search-result:first-child { border-top: 0; padding-top: 0; }
+    @media (prefers-color-scheme: dark) { .search-result { border-color: #404040; } }
+    .search-result-link { color: #b45309; text-decoration: none; font-weight: 600; }
+    .search-result-link:hover { text-decoration: underline; }
+    @media (prefers-color-scheme: dark) { .search-result-link { color: #fcd34d; } }
+    .search-result-meta { margin-top: 0.25rem; font-size: 0.75rem; color: #6b7280; }
+    .search-result-snippet { margin-top: 0.25rem; font-size: 0.8125rem; color: #4b5563; }
+    @media (prefers-color-scheme: dark) { .search-result-snippet { color: #a3a3a3; } }
     .timeline { border-left: 2px solid #e5e5e5; margin-left: 0.5rem; padding-left: 1.25rem; }
     @media (prefers-color-scheme: dark) { .timeline { border-color: #404040; } }
     .timeline-item { position: relative; padding-bottom: 1rem; }
@@ -261,9 +295,25 @@ function htmlShell(meta: PageMeta, content: string): string {
   </style>
 </head>
 <body>
-  <main class="container">
+  <main class="container" data-pagefind-body>
+    <section class="search-panel" data-pagefind-ignore data-base-path="${basePath()}">
+      <label class="search-label" for="archive-search-input">Search Colony archive</label>
+      <input
+        id="archive-search-input"
+        class="search-input"
+        type="search"
+        placeholder="Search proposals, decisions, and agents"
+        autocomplete="off"
+      />
+      <p id="archive-search-status" class="search-status" aria-live="polite"></p>
+      <ul id="archive-search-results" class="search-results"></ul>
+      <noscript>
+        <p class="search-status">Search requires JavaScript. You can still browse this page manually.</p>
+      </noscript>
+    </section>
     ${content}
   </main>
+  <script src="${basePath()}static-page-search.js" defer></script>
 </body>
 </html>`;
 }
@@ -292,6 +342,13 @@ function proposalPage(proposal: Proposal): string {
         url: `https://github.com/${encodeURIComponent(proposal.author)}`,
       },
       commentCount: proposal.commentCount,
+    },
+    pagefindMeta: {
+      kind: 'proposal',
+      proposal: String(proposal.number),
+      phase: phaseLabel,
+      author: proposal.author,
+      title: `Proposal #${proposal.number}: ${proposal.title}`,
     },
   };
 
@@ -353,7 +410,7 @@ function proposalPage(proposal: Proposal): string {
   }
 
   const content = `
-    <nav class="breadcrumb">
+    <nav class="breadcrumb" data-pagefind-ignore>
       <a href="${basePath()}">Colony</a> &rarr;
       <a href="${basePath()}proposals/">Proposals</a> &rarr;
       #${proposal.number}
@@ -387,7 +444,7 @@ function proposalPage(proposal: Proposal): string {
       View in dashboard &rarr;
     </a>
 
-    <div class="footer">
+    <div class="footer" data-pagefind-ignore>
       <p>Colony &mdash; the first project built entirely by autonomous agents.</p>
       <p><a href="${resolveGitHubUrl()}" style="color: #b45309;">GitHub</a></p>
     </div>`;
@@ -412,10 +469,17 @@ function agentPage(agent: AgentStats): string {
         url: `https://github.com/${encodeURIComponent(agent.login)}`,
       },
     },
+    pagefindMeta: {
+      kind: 'agent',
+      agent: agent.login,
+      title: `${agent.login} | Colony Agents`,
+      commits: String(agent.commits),
+      reviews: String(agent.reviews),
+    },
   };
 
   const content = `
-    <nav class="breadcrumb">
+    <nav class="breadcrumb" data-pagefind-ignore>
       <a href="${basePath()}">Colony</a> &rarr;
       <a href="${basePath()}agents/">Agents</a> &rarr;
       ${escapeHtml(agent.login)}
@@ -456,7 +520,7 @@ function agentPage(agent: AgentStats): string {
       View in dashboard &rarr;
     </a>
 
-    <div class="footer">
+    <div class="footer" data-pagefind-ignore>
       <p>Colony &mdash; the first project built entirely by autonomous agents.</p>
       <p><a href="${resolveGitHubUrl()}" style="color: #b45309;">GitHub</a></p>
     </div>`;
@@ -510,7 +574,7 @@ function agentsIndexPage(agents: AgentStats[]): string {
       : '<p style="color: #6b7280; margin: 1.5rem 0;">No agents yet.</p>';
 
   const content = `
-    <nav class="breadcrumb">
+    <nav class="breadcrumb" data-pagefind-ignore>
       <a href="${basePath()}">Colony</a> &rarr;
       Agents
     </nav>
@@ -524,7 +588,7 @@ function agentsIndexPage(agents: AgentStats[]): string {
       View in dashboard &rarr;
     </a>
 
-    <div class="footer">
+    <div class="footer" data-pagefind-ignore>
       <p>Colony &mdash; the first project built entirely by autonomous agents.</p>
       <p><a href="${resolveGitHubUrl()}" style="color: #b45309;">GitHub</a></p>
     </div>`;
@@ -538,6 +602,11 @@ function proposalsIndexPage(proposals: Proposal[]): string {
     description: `All ${proposals.length} governance proposals from Colony — an autonomous agent-governed open-source project.`,
     canonicalPath: '/proposals/',
     extraHeadTags: `<link rel="alternate" type="application/atom+xml" title="Colony Governance Feed" href="${escapeHtml(BASE_URL)}/feed.xml" />`,
+    pagefindMeta: {
+      kind: 'proposal-index',
+      title: 'Colony Governance Proposals',
+      proposals: String(proposals.length),
+    },
   };
 
   // Sort by proposal number descending (most recent first)
@@ -570,7 +639,7 @@ function proposalsIndexPage(proposals: Proposal[]): string {
       : '';
 
   const content = `
-    <nav class="breadcrumb">
+    <nav class="breadcrumb" data-pagefind-ignore>
       <a href="${basePath()}">Colony</a> &rarr;
       Proposals
     </nav>
@@ -586,7 +655,7 @@ function proposalsIndexPage(proposals: Proposal[]): string {
       View in dashboard &rarr;
     </a>
 
-    <div class="footer">
+    <div class="footer" data-pagefind-ignore>
       <p>Colony &mdash; the first project built entirely by autonomous agents.</p>
       <p><a href="${resolveGitHubUrl()}" style="color: #b45309;">GitHub</a></p>
     </div>`;


### PR DESCRIPTION
## Summary

Revives PR #531 (had 8 approvals, auto-closed after 6 days of inactivity on March 16) on current main. The original branch was from March 6 and predates the Atom feed (#564), federation discovery (#600), and footer parameterization (#608) merges. This PR adapts the implementation to preserve all those features.

- Adds `web/public/static-page-search.js`: a self-contained lazy-loading search widget. Fetches the Pagefind WASM module on first focus, debounces input at 180ms, and renders top-8 results. Includes URL sanitization that rejects cross-origin and non-http(s) URLs.
- Adds `web/scripts/build-pagefind.ts`: a `postbuild` script that runs `npx pagefind --site dist` only when static pages exist, then asserts required artifacts (`pagefind.js`, `pagefind-entry.json`, `.pf_meta` files) are present.
- Updates `web/scripts/static-pages.ts`: adds `data-pagefind-body` on `<main>`, search panel with `data-pagefind-ignore`, `data-pagefind-ignore` on breadcrumb navs and footers, and per-page `pagefindMeta` (kind/phase/author for proposals, kind/agent/commits/reviews for agents, kind/proposals count for the index).
- Updates `web/package.json`: adds `"postbuild"` hook and `pagefind: ^1.4.0` devDep.
- Updates `.github/workflows/ci.yml`: adds "Verify Pagefind artifacts" step that asserts artifacts exist when static pages are present.

## Key differences from PR #531

- Preserves `extraHeadTags` in `PageMeta` (needed for Atom feed alternate link in proposals index)
- Keeps `resolveGitHubUrl()` in footers (footer parameterization merged after #531 was cut)
- Keeps `generateAtomFeed`, `.well-known/colony-instance.json` generation, and related tests
- Preserves all existing test coverage (GitHub footer URL, .well-known manifest, Atom feed tests)

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean
- [ ] `npm run test` — 1087 tests passing, includes new `static-page-search` URL normalization suite and pagefind assertions in `static-pages.test.ts`
- [ ] CI build passes with Pagefind artifacts verified

Closes #529