### PR TITLE
chore: add colony-instance.json and metrics/snapshot.json reachability checks to check-visibility.ts

### DIFF
--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -376,11 +376,20 @@ async function runChecks(): Promise<CheckResult[]> {
     }
   };
 
-  const [rootRes, robotsRes, sitemapRes, activityRes] = await Promise.all([
+  const [
+    rootRes,
+    robotsRes,
+    sitemapRes,
+    activityRes,
+    colonyInstanceRes,
+    metricsSnapshotRes,
+  ] = await Promise.all([
     fetchWithTimeout(baseUrl),
     fetchWithTimeout(`${baseUrl}/robots.txt`),
     fetchWithTimeout(`${baseUrl}/sitemap.xml`),
     fetchWithTimeout(`${baseUrl}/data/activity.json`),
+    fetchWithTimeout(`${baseUrl}/.well-known/colony-instance.json`),
+    fetchWithTimeout(`${baseUrl}/data/metrics/snapshot.json`),
   ]);
 
   results.push({
@@ -771,6 +780,26 @@ async function runChecks(): Promise<CheckResult[]> {
     label: 'Deployed data freshness (<= 18h)',
     ok: freshnessOk,
     details: freshnessDetails,
+  });
+
+  const colonyInstanceUrl = `${baseUrl}/.well-known/colony-instance.json`;
+  const colonyInstanceOk = colonyInstanceRes?.status === 200;
+  results.push({
+    label: 'Deployed /.well-known/colony-instance.json reachable',
+    ok: colonyInstanceOk,
+    details: colonyInstanceOk
+      ? `GET ${colonyInstanceUrl} returned 200`
+      : `GET ${colonyInstanceUrl} returned ${colonyInstanceRes?.status ?? 'no response'}`,
+  });
+
+  const metricsSnapshotUrl = `${baseUrl}/data/metrics/snapshot.json`;
+  const metricsSnapshotOk = metricsSnapshotRes?.status === 200;
+  results.push({
+    label: 'Deployed /data/metrics/snapshot.json reachable',
+    ok: metricsSnapshotOk,
+    details: metricsSnapshotOk
+      ? `GET ${metricsSnapshotUrl} returned 200`
+      : `GET ${metricsSnapshotUrl} returned ${metricsSnapshotRes?.status ?? 'no response'}`,
   });
 
   return results;


### PR DESCRIPTION
Closes #721

## Why

Two Horizon 4 endpoints shipped in March 2026 but were not monitored by `check-visibility.ts`:

| Endpoint | Merged in | Current coverage |
|----------|-----------|-----------------|
| `/.well-known/colony-instance.json` | #600 (2026-03-16) | None |
| `/data/metrics/snapshot.json` | #599 (2026-03-13) | None |

A deployment regression could silently drop either endpoint without triggering any visibility alert.

## What changed

`web/scripts/check-visibility.ts`:

- Added both URLs to the first `Promise.all` fetch batch alongside `/data/activity.json` — no extra round-trips
- Added two `CheckResult` pushes at the end of `runChecks()`:
  - `Deployed /.well-known/colony-instance.json reachable` — HTTP 200 pass condition
  - `Deployed /data/metrics/snapshot.json reachable` — HTTP 200 pass condition
- Pattern is identical to the agents/proposals hub and activity.json checks

## Validation

```bash
cd web
npm run test      # 1085 tests, all passing
tsc --noEmit      # clean
```

No new test infrastructure needed — the checks are network reachability probes, the same category as all other deployed-URL checks in `runChecks()`.