### PR TITLE
fix: honor base path for site icons

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐝</text></svg>" />
-    <link rel="icon" href="/colony/favicon.ico" sizes="any" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/colony/apple-touch-icon.png" />
+    <link rel="icon" href="__COLONY_FAVICON_HREF__" sizes="any" />
+    <link rel="apple-touch-icon" sizes="180x180" href="__COLONY_APPLE_TOUCH_ICON_HREF__" />
     <link rel="canonical" href="__COLONY_CANONICAL_URL__" />
     <link rel="manifest" href="__COLONY_MANIFEST_HREF__" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/web/scripts/__tests__/vite-colony-html-plugin.test.ts
+++ b/web/scripts/__tests__/vite-colony-html-plugin.test.ts
@@ -29,6 +29,8 @@ describe('transformHtml', () => {
   const templateHtml = `<!doctype html>
 <html lang="en">
   <head>
+    <link rel="icon" href="__COLONY_FAVICON_HREF__" sizes="any" />
+    <link rel="apple-touch-icon" sizes="180x180" href="__COLONY_APPLE_TOUCH_ICON_HREF__" />
     <link rel="canonical" href="__COLONY_CANONICAL_URL__" />
     <link rel="manifest" href="__COLONY_MANIFEST_HREF__" />
     <meta name="description" content="__COLONY_META_DESCRIPTION__" />
@@ -63,6 +65,8 @@ describe('transformHtml', () => {
   it('replaces all placeholders with default config values', () => {
     const result = transformHtml(templateHtml, defaultConfig);
 
+    expect(result).toContain('href="/colony/favicon.ico"');
+    expect(result).toContain('href="/colony/apple-touch-icon.png"');
     expect(result).toContain('href="https://hivemoot.github.io/colony/"');
     expect(result).toContain('href="manifest.webmanifest"');
     expect(result).toContain(
@@ -84,6 +88,8 @@ describe('transformHtml', () => {
   it('replaces all placeholders with custom config values', () => {
     const result = transformHtml(templateHtml, customConfig);
 
+    expect(result).toContain('href="/swarm/favicon.ico"');
+    expect(result).toContain('href="/swarm/apple-touch-icon.png"');
     expect(result).toContain('href="https://acme.github.io/swarm/"');
     expect(result).toContain('href="manifest.webmanifest"');
     expect(result).toContain('content="Swarm - Agent dashboard for Acme Corp"');
@@ -120,6 +126,8 @@ describe('transformHtml', () => {
 
     // Manifest href should be relative so Vite prefixes it exactly once
     expect(result).toMatch(/href="manifest\.webmanifest"/);
+    expect(result).toContain('href="/colony/favicon.ico"');
+    expect(result).toContain('href="/colony/apple-touch-icon.png"');
 
     // No broken double-prefix patterns should exist
     expect(result).not.toContain('/colony/https://');

--- a/web/scripts/vite-colony-html-plugin.ts
+++ b/web/scripts/vite-colony-html-plugin.ts
@@ -51,8 +51,12 @@ export function transformHtml(html: string, config: ColonyConfig): string {
   const siteUrlWithSlash = config.siteUrl + '/';
   const ogImageUrl = `${config.siteUrl}/og-image.png`;
   const pageTitle = `${config.siteTitle} | ${config.orgName}`;
+  const faviconHref = `${config.basePath}favicon.ico`;
+  const appleTouchIconHref = `${config.basePath}apple-touch-icon.png`;
 
   return html
+    .replace(/__COLONY_FAVICON_HREF__/g, faviconHref)
+    .replace(/__COLONY_APPLE_TOUCH_ICON_HREF__/g, appleTouchIconHref)
     .replace(/__COLONY_CANONICAL_URL__/g, siteUrlWithSlash)
     .replace(/__COLONY_MANIFEST_HREF__/g, 'manifest.webmanifest')
     .replace(

--- a/web/src/Meta.test.ts
+++ b/web/src/Meta.test.ts
@@ -6,10 +6,10 @@ describe('index.html metadata', () => {
   it('contains basic meta tags', () => {
     expect(html).toMatch(/<meta\s+charset="UTF-8"\s*\/?>/);
     expect(html).toMatch(
-      /<link\s+rel="icon"\s+href="\/colony\/favicon\.ico"\s+sizes="any"\s*\/?>/
+      /<link\s+rel="icon"\s+href="__COLONY_FAVICON_HREF__"\s+sizes="any"\s*\/?>/
     );
     expect(html).toMatch(
-      /<link\s+rel="apple-touch-icon"\s+sizes="180x180"\s+href="\/colony\/apple-touch-icon\.png"\s*\/?>/
+      /<link\s+rel="apple-touch-icon"\s+sizes="180x180"\s+href="__COLONY_APPLE_TOUCH_ICON_HREF__"\s*\/?>/
     );
     expect(html).toMatch(
       /<link\s+rel="canonical"\s+href="__COLONY_CANONICAL_URL__"\s*\/?>/


### PR DESCRIPTION
## Summary
- replace hardcoded `/colony/` favicon and apple-touch-icon paths in `web/index.html` with build-time placeholders
- resolve those placeholders from `config.basePath` in the Vite HTML plugin so custom `COLONY_BASE_PATH` deployments keep icon metadata valid
- extend metadata/plugin tests to cover both default and custom base-path outputs

## Why
Template deployments can already change `COLONY_BASE_PATH`, and static pages plus the PWA manifest respect it. The main entry HTML did not, which meant a non-`/colony/` deployment could ship broken root icon links even though the rest of the site was parameterized.

Follow-up to #284.

## Validation
- `cd web && npm test -- --runInBand web/src/Meta.test.ts web/scripts/__tests__/vite-colony-html-plugin.test.ts`  
  blocked: local `node_modules` was only partially populated after repeated `npm ci` / `npm install` stalls, so `vitest` was not available on PATH in this environment
- diff review of `transformHtml` and updated regression tests
