### PR TITLE
fix: harden public URL config resolvers

### DIFF
--- a/web/scripts/__tests__/colony-config.test.ts
+++ b/web/scripts/__tests__/colony-config.test.ts
@@ -55,6 +55,46 @@ describe('normalizeAbsoluteHttpUrl', () => {
   it('rejects malformed URLs', () => {
     expect(normalizeAbsoluteHttpUrl('not-a-url')).toBe('');
   });
+
+  it('supports stricter public HTTPS normalization when requested', () => {
+    expect(
+      normalizeAbsoluteHttpUrl('https://example.com/path/?utm=1#frag', {
+        requireHttps: true,
+        rejectLocalHosts: true,
+      })
+    ).toBe('https://example.com/path');
+  });
+
+  it('rejects non-https URLs when HTTPS is required', () => {
+    expect(
+      normalizeAbsoluteHttpUrl('http://example.com/path', {
+        requireHttps: true,
+      })
+    ).toBe('');
+  });
+
+  it('rejects localhost and IP literals when local hosts are blocked', () => {
+    expect(
+      normalizeAbsoluteHttpUrl('https://localhost:4173', {
+        rejectLocalHosts: true,
+      })
+    ).toBe('');
+    expect(
+      normalizeAbsoluteHttpUrl('https://dev.localhost/dashboard', {
+        rejectLocalHosts: true,
+      })
+    ).toBe('');
+    expect(
+      normalizeAbsoluteHttpUrl('https://127.0.0.1:8443', {
+        rejectLocalHosts: true,
+      })
+    ).toBe('');
+    expect(
+      normalizeAbsoluteHttpUrl('https://[::1]/', {
+        rejectLocalHosts: true,
+      })
+    ).toBe('');
+  });
 });
 
 describe('resolveDeployedUrl', () => {
@@ -96,6 +136,18 @@ describe('resolveDeployedUrl', () => {
     expect(resolveDeployedUrl({ COLONY_DEPLOYED_URL: 'not-a-url' })).toBe(
       DEFAULT_DEPLOYED_BASE_URL
     );
+  });
+
+  it('falls back to default for insecure or local-only deployed URLs', () => {
+    expect(
+      resolveDeployedUrl({ COLONY_DEPLOYED_URL: 'http://example.com/app' })
+    ).toBe(DEFAULT_DEPLOYED_BASE_URL);
+    expect(
+      resolveDeployedUrl({ COLONY_DEPLOYED_URL: 'https://localhost:4173' })
+    ).toBe(DEFAULT_DEPLOYED_BASE_URL);
+    expect(
+      resolveDeployedUrl({ COLONY_DEPLOYED_URL: 'https://127.0.0.1:4173' })
+    ).toBe(DEFAULT_DEPLOYED_BASE_URL);
   });
 });
 
@@ -192,16 +244,25 @@ describe('resolveSiteUrl', () => {
     );
   });
 
+  it('falls back to default for insecure http URLs', () => {
+    expect(resolveSiteUrl({ COLONY_SITE_URL: 'http://example.com' })).toBe(
+      'https://hivemoot.github.io/colony'
+    );
+  });
+
   it('falls back to default for credential-bearing URL', () => {
     expect(
       resolveSiteUrl({ COLONY_SITE_URL: 'https://user:pass@example.com/app' })
     ).toBe('https://hivemoot.github.io/colony');
   });
 
-  it('accepts http:// URLs', () => {
-    expect(resolveSiteUrl({ COLONY_SITE_URL: 'http://localhost:3000' })).toBe(
-      'http://localhost:3000'
+  it('falls back to default for localhost and IP literal URLs', () => {
+    expect(resolveSiteUrl({ COLONY_SITE_URL: 'https://localhost:3000' })).toBe(
+      'https://hivemoot.github.io/colony'
     );
+    expect(
+      resolveSiteUrl({ COLONY_SITE_URL: 'https://127.0.0.1:3000/app' })
+    ).toBe('https://hivemoot.github.io/colony');
   });
 });
 

--- a/web/scripts/colony-config.ts
+++ b/web/scripts/colony-config.ts
@@ -8,6 +8,8 @@
  * Phase 2 of template parameterization (proposal #284).
  */
 
+import { isIP } from 'node:net';
+
 const DEFAULT_SITE_TITLE = 'Colony';
 const DEFAULT_ORG_NAME = 'Hivemoot';
 const DEFAULT_SITE_URL = 'https://hivemoot.github.io/colony';
@@ -35,7 +37,15 @@ export interface ColonyConfig {
   basePath: string;
 }
 
-export function normalizeAbsoluteHttpUrl(rawValue: string | undefined): string {
+interface NormalizeAbsoluteUrlOptions {
+  requireHttps?: boolean;
+  rejectLocalHosts?: boolean;
+}
+
+export function normalizeAbsoluteHttpUrl(
+  rawValue: string | undefined,
+  options: NormalizeAbsoluteUrlOptions = {}
+): string {
   const raw = rawValue?.trim();
   if (!raw) {
     return '';
@@ -43,12 +53,29 @@ export function normalizeAbsoluteHttpUrl(rawValue: string | undefined): string {
 
   try {
     const parsed = new URL(raw);
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    const allowedProtocols = options.requireHttps
+      ? ['https:']
+      : ['http:', 'https:'];
+    if (!allowedProtocols.includes(parsed.protocol)) {
       return '';
     }
 
     if (parsed.username || parsed.password) {
       return '';
+    }
+
+    if (options.rejectLocalHosts) {
+      const normalizedHostname = parsed.hostname
+        .toLowerCase()
+        .replace(/^\[|\]$/g, '')
+        .replace(/\.$/, '');
+      if (
+        normalizedHostname === 'localhost' ||
+        normalizedHostname.endsWith('.localhost') ||
+        isIP(normalizedHostname) !== 0
+      ) {
+        return '';
+      }
     }
 
     parsed.search = '';
@@ -81,12 +108,16 @@ export function resolveOrgName(
 
 /**
  * Resolve the deployed site URL from COLONY_SITE_URL.
- * Validates as absolute HTTP(S) URL. Falls back to the Hivemoot Colony URL.
+ * Validates as an absolute public HTTPS URL. Falls back to the Hivemoot Colony
+ * URL.
  */
 export function resolveSiteUrl(
   env: Record<string, string | undefined> = process.env
 ): string {
-  const normalized = normalizeAbsoluteHttpUrl(env.COLONY_SITE_URL);
+  const normalized = normalizeAbsoluteHttpUrl(env.COLONY_SITE_URL, {
+    requireHttps: true,
+    rejectLocalHosts: true,
+  });
   return normalized || DEFAULT_SITE_URL;
 }
 
@@ -152,12 +183,16 @@ export function resolveBasePath(
  * Resolve the deployed base URL from COLONY_DEPLOYED_URL.
  * Used by static page generation scripts (static-pages.ts, generate-sitemap.ts)
  * to determine the site root for canonical links and sitemap entries.
- * Falls back to DEFAULT_DEPLOYED_BASE_URL.
+ * Validates as an absolute public HTTPS URL and falls back to
+ * DEFAULT_DEPLOYED_BASE_URL.
  */
 export function resolveDeployedUrl(
   env: Record<string, string | undefined> = process.env
 ): string {
-  const normalized = normalizeAbsoluteHttpUrl(env.COLONY_DEPLOYED_URL);
+  const normalized = normalizeAbsoluteHttpUrl(env.COLONY_DEPLOYED_URL, {
+    requireHttps: true,
+    rejectLocalHosts: true,
+  });
   return normalized || DEFAULT_DEPLOYED_BASE_URL;
 }
 


### PR DESCRIPTION
Fixes #727

## Summary
- reject non-public or insecure values for `COLONY_SITE_URL` and `COLONY_DEPLOYED_URL`
- reuse the existing URL normalizer with stricter options instead of duplicating hostname checks
- add resolver tests for `https` enforcement plus localhost and IP literal rejection

## Validation
- `git diff --check`
- `npm test -- --run web/scripts/__tests__/colony-config.test.ts` (blocked locally: existing `npm install` never completed, so `vitest` was not available in `web/node_modules/.bin`) 
- `npm run lint -- web/scripts/colony-config.ts web/scripts/__tests__/colony-config.test.ts` (blocked for the same reason)
