### PR TITLE
fix: avoid redundant fast-track issue lookups

### DIFF
--- a/web/scripts/__tests__/fast-track-candidates.test.ts
+++ b/web/scripts/__tests__/fast-track-candidates.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeMergeStateStatus,
   parseArgs,
   printHumanReport,
+  resolveIssueStates,
 } from '../fast-track-candidates';
 
 const ALLOWED_PREFIXES = [
@@ -554,6 +555,68 @@ describe('getWorkflowApprovalBlocker', () => {
         statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
       })
     ).toBeNull();
+  });
+});
+
+describe('resolveIssueStates', () => {
+  it('reuses direct issue states from the PR payload without extra gh calls', () => {
+    const runCommand = vi.fn();
+
+    const states = resolveIssueStates(
+      'hivemoot/colony',
+      [
+        {
+          number: 200,
+          title: 'fix: avoid extra lookups',
+          url: 'https://example.test/pr/200',
+          closingIssuesReferences: [
+            { number: 307, state: 'OPEN' },
+            {
+              number: 445,
+              state: 'CLOSED',
+              url: 'https://github.com/hivemoot/hivemoot/issues/445',
+            },
+          ],
+        },
+      ],
+      runCommand
+    );
+
+    expect(states.get('hivemoot/colony#307')).toBe('OPEN');
+    expect(states.get('hivemoot/hivemoot#445')).toBe('CLOSED');
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('only queries gh for linked issues whose state is missing', () => {
+    const runCommand = vi.fn((args: string[]) => {
+      expect(args).toEqual([
+        'api',
+        'repos/hivemoot/colony/issues/308',
+        '--jq',
+        '.state',
+      ]);
+      return 'open\n';
+    });
+
+    const states = resolveIssueStates(
+      'hivemoot/colony',
+      [
+        {
+          number: 201,
+          title: 'fix: query missing states only',
+          url: 'https://example.test/pr/201',
+          closingIssuesReferences: [
+            { number: 307, state: 'OPEN' },
+            { number: 308 },
+          ],
+        },
+      ],
+      runCommand
+    );
+
+    expect(states.get('hivemoot/colony#307')).toBe('OPEN');
+    expect(states.get('hivemoot/colony#308')).toBe('OPEN');
+    expect(runCommand).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/web/scripts/fast-track-candidates.ts
+++ b/web/scripts/fast-track-candidates.ts
@@ -96,6 +96,8 @@ interface CliOptions {
   json: boolean;
 }
 
+type RunCommand = (args: string[]) => string;
+
 export function parseArgs(argv: string[]): CliOptions {
   const options: CliOptions = {
     repo: DEFAULT_REPO,
@@ -385,6 +387,12 @@ function loadPullRequests(repo: string, limit: number): PullRequestNode[] {
   return parsed;
 }
 
+function runGhCommand(args: string[]): string {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+  });
+}
+
 function getIssueKey(issue: IssueNode, defaultRepo: string): string {
   const fromUrl = parseIssueRefFromUrl(issue.url);
   if (fromUrl) {
@@ -423,34 +431,57 @@ function parseIssueRefFromUrl(
   }
 }
 
-function resolveIssueStates(
+function getKnownIssueState(issue: IssueNode): string | null {
+  const normalized = issue.state?.trim().toUpperCase();
+  if (normalized === 'OPEN' || normalized === 'CLOSED') {
+    return normalized;
+  }
+  return null;
+}
+
+export function resolveIssueStates(
   repo: string,
-  prs: PullRequestNode[]
+  prs: PullRequestNode[],
+  runCommand: RunCommand = runGhCommand
 ): Map<string, string> {
-  const issueKeys = Array.from(
-    new Set(
-      prs.flatMap((pr) =>
-        (pr.closingIssuesReferences ?? []).map((issue) =>
-          getIssueKey(issue, repo)
-        )
-      )
-    )
-  );
   const states = new Map<string, string>();
+  const unresolved = new Map<
+    string,
+    {
+      repo: string;
+      number: string;
+    }
+  >();
 
-  for (const issueKey of issueKeys) {
-    const hashIndex = issueKey.lastIndexOf('#');
-    const issueRepo = issueKey.slice(0, hashIndex);
-    const issueNumber = issueKey.slice(hashIndex + 1);
+  for (const pr of prs) {
+    for (const issue of pr.closingIssuesReferences ?? []) {
+      const key = getIssueKey(issue, repo);
+      if (states.has(key) || unresolved.has(key)) {
+        continue;
+      }
 
+      const knownState = getKnownIssueState(issue);
+      if (knownState) {
+        states.set(key, knownState);
+        continue;
+      }
+
+      const hashIndex = key.lastIndexOf('#');
+      unresolved.set(key, {
+        repo: key.slice(0, hashIndex),
+        number: key.slice(hashIndex + 1),
+      });
+    }
+  }
+
+  for (const [issueKey, issueRef] of unresolved) {
     try {
-      const state = execFileSync(
-        'gh',
-        ['api', `repos/${issueRepo}/issues/${issueNumber}`, '--jq', '.state'],
-        {
-          encoding: 'utf8',
-        }
-      )
+      const state = runCommand([
+        'api',
+        `repos/${issueRef.repo}/issues/${issueRef.number}`,
+        '--jq',
+        '.state',
+      ])
         .trim()
         .toUpperCase();
       states.set(issueKey, state);


### PR DESCRIPTION
Fixes #729

## Why
The fast-track queue check was doing an extra GitHub API request for every linked issue, even when the linked issue state was already present in the PR payload. That makes a maintainer-facing throughput script slower and more brittle under slow GitHub responses.

## What changed
- reuse `closingIssuesReferences[].state` when it already reports `OPEN` or `CLOSED`
- only fall back to `gh api repos/.../issues/...` for linked issues whose state is missing
- add tests for the no-extra-call path and the missing-state fallback path

## Validation
- attempted local validation, but `npm` in this environment hangs and left a partial install tree before I killed the stuck processes