### PR TITLE
polish: harden check-bot-write-access CLI

### DIFF
--- a/web/scripts/__tests__/check-bot-write-access.test.ts
+++ b/web/scripts/__tests__/check-bot-write-access.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   findInstallation,
   formatTextResult,
@@ -25,6 +25,36 @@ describe('parseArgs', () => {
       appSlug: 'example-bot',
       json: true,
     });
+  });
+
+  it('prints help and exits 0 for --help', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+
+    try {
+      expect(() => parseArgs(['--help'])).toThrow('process.exit');
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining('Usage: npm run check-bot-write-access')
+      );
+      expect(exit).toHaveBeenCalledWith(0);
+    } finally {
+      log.mockRestore();
+      exit.mockRestore();
+    }
+  });
+
+  it('rejects unknown flags', () => {
+    expect(() => parseArgs(['--verbose'])).toThrow(
+      'Unknown argument: --verbose'
+    );
+  });
+
+  it('rejects positional arguments', () => {
+    expect(() => parseArgs(['example-org'])).toThrow(
+      'Unknown argument: example-org'
+    );
   });
 });
 

--- a/web/scripts/check-bot-write-access.ts
+++ b/web/scripts/check-bot-write-access.ts
@@ -65,6 +65,8 @@ export function parseArgs(argv: string[]): CliOptions {
       printHelp();
       process.exit(0);
     }
+
+    throw new Error(`Unknown argument: ${arg}`);
   }
 
   return options;
@@ -249,5 +251,11 @@ const isMainModule =
   process.argv[1] === fileURLToPath(import.meta.url);
 
 if (isMainModule) {
-  main();
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  }
 }


### PR DESCRIPTION
## Summary

- reject unknown CLI arguments in `check-bot-write-access`
- print a clean error message and exit 1 when argument parsing fails
- add tests for `--help`, unknown flags, and positional arguments

## Why

`check-bot-write-access` accepted `--help`, but every other unexpected argument was silently ignored. That makes typos easy to miss and leaves the script with a weaker CLI contract than the newer tooling in this repo.

## Validation

- `cd web && npm run test -- --run web/scripts/__tests__/check-bot-write-access.test.ts` *(blocked in this checkout: `web/node_modules` is absent and `npm install` did not complete during this run)*
- `cd web && npx eslint scripts/check-bot-write-access.ts scripts/__tests__/check-bot-write-access.test.ts` *(blocked for the same reason)*
