### PR TITLE
fix: harden check-visibility CLI

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -5,6 +5,7 @@ import {
   hasTwitterImageAltText,
   isValidOpenGraphImageType,
   normalizeHttpsUrl,
+  parseArgs,
   resolveDeployedPageUrl,
   resolveRepositoryHomepage,
   resolveVisibilityRepository,
@@ -32,6 +33,19 @@ describe('resolveVisibilityUserAgent', () => {
         VISIBILITY_USER_AGENT: '   ',
       })
     ).toBe('colony-visibility-check');
+  });
+});
+
+describe('parseArgs', () => {
+  it('parses the supported --json flag', () => {
+    expect(parseArgs(['--json'])).toEqual({ json: true });
+    expect(parseArgs([])).toEqual({ json: false });
+  });
+
+  it('throws on unsupported flags', () => {
+    expect(() => parseArgs(['--wat'])).toThrow(
+      /Unknown argument "--wat". Expected --json./
+    );
   });
 });
 

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -38,8 +38,28 @@ interface CliOptions {
   json: boolean;
 }
 
-function parseArgs(argv: string[]): CliOptions {
-  return { json: argv.includes('--json') };
+function printHelp(): void {
+  console.log('Usage: npm run check-visibility -- [--json]');
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  let json = false;
+
+  for (const arg of argv) {
+    if (arg === '--json') {
+      json = true;
+      continue;
+    }
+
+    if (arg === '--help') {
+      printHelp();
+      process.exit(0);
+    }
+
+    throw new Error(`Unknown argument "${arg}". Expected --json.`);
+  }
+
+  return { json };
 }
 
 export function resolveVisibilityUserAgent(
@@ -822,9 +842,5 @@ function isDirectExecution(): boolean {
 }
 
 if (isDirectExecution()) {
-  if (process.argv.includes('--help')) {
-    console.log('Usage: npm run check-visibility');
-    process.exit(0);
-  }
   void main();
 }


### PR DESCRIPTION
Fixes #732

## Summary
- reject unsupported `check-visibility` CLI flags instead of silently ignoring them
- show a complete usage line for `--help`
- add focused tests for the supported flag and unknown-flag failure path

## Validation
- Unable to complete in this workspace: `cd web && npm ci --no-audit --progress=false` stalled repeatedly before `vitest` and `eslint` became available.
