### PR TITLE
fix: suppress no-token timeline noise

### DIFF
--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from 'node:os';
 import {
   resolveRepository,
   resolveRequiredDiscoverabilityTopics,
+  resolveGitHubToken,
+  hasGitHubToken,
   resolveRepositories,
   resolveRepositoryHomepage,
   updateSitemapLastmod,
@@ -19,6 +21,7 @@ import {
   extractGovernanceIncidents,
   deduplicateAgents,
   extractPhaseTransitions,
+  fetchPhaseTransitions,
   filterAndMapProposals,
   enrichPullRequestsWithApprovalTimes,
   type GitHubCommit,
@@ -94,6 +97,41 @@ describe('resolveRepository', () => {
   it('should fall back to defaults when COLONY_REPOSITORY is blank', () => {
     const result = resolveRepository({ COLONY_REPOSITORY: '   ' });
     expect(result).toEqual({ owner: 'hivemoot', repo: 'colony' });
+  });
+});
+
+describe('resolveGitHubToken', () => {
+  it('returns GITHUB_TOKEN when it is set', () => {
+    expect(resolveGitHubToken({ GITHUB_TOKEN: 'github-token' })).toBe(
+      'github-token'
+    );
+  });
+
+  it('returns GH_TOKEN when GITHUB_TOKEN is not set', () => {
+    expect(resolveGitHubToken({ GH_TOKEN: 'gh-token' })).toBe('gh-token');
+  });
+
+  it('prefers GITHUB_TOKEN when both tokens are set', () => {
+    expect(
+      resolveGitHubToken({
+        GITHUB_TOKEN: 'github-token',
+        GH_TOKEN: 'gh-token',
+      })
+    ).toBe('github-token');
+  });
+
+  it('returns undefined when neither token is set', () => {
+    expect(resolveGitHubToken({})).toBeUndefined();
+  });
+});
+
+describe('hasGitHubToken', () => {
+  it('returns true when either token is configured', () => {
+    expect(hasGitHubToken({ GH_TOKEN: 'gh-token' })).toBe(true);
+  });
+
+  it('returns false when neither token is configured', () => {
+    expect(hasGitHubToken({})).toBe(false);
   });
 });
 
@@ -279,6 +317,29 @@ describe('mapCommits', () => {
     const result = mapCommits(raw);
 
     expect(result.commits[0]).not.toHaveProperty('repo');
+  });
+});
+
+describe('fetchPhaseTransitions', () => {
+  it('skips timeline fetches entirely when no token is configured', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const proposals = [
+      {
+        number: 42,
+        title: 'Proposal',
+        phase: 'discussion',
+        author: 'hivemoot-nurse',
+        createdAt: '2026-03-01T00:00:00Z',
+        commentCount: 0,
+      },
+    ];
+
+    await fetchPhaseTransitions('hivemoot', 'colony', proposals, {});
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(proposals[0].phaseTransitions).toBeUndefined();
   });
 });
 

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -191,7 +191,7 @@ export async function fetchJson<T>(endpoint: string): Promise<T> {
   };
 
   // Use GITHUB_TOKEN/GH_TOKEN if available (CI or local environment)
-  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const token = resolveGitHubToken();
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }
@@ -205,6 +205,18 @@ export async function fetchJson<T>(endpoint: string): Promise<T> {
   }
 
   return response.json() as Promise<T>;
+}
+
+export function resolveGitHubToken(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  return env.GITHUB_TOKEN ?? env.GH_TOKEN;
+}
+
+export function hasGitHubToken(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return Boolean(resolveGitHubToken(env));
 }
 
 export function resolveRepository(env = process.env): {
@@ -691,11 +703,16 @@ export function extractPhaseTransitions(
     );
 }
 
-async function fetchPhaseTransitions(
+export async function fetchPhaseTransitions(
   owner: string,
   repo: string,
-  proposals: Proposal[]
+  proposals: Proposal[],
+  env: NodeJS.ProcessEnv = process.env
 ): Promise<void> {
+  if (!hasGitHubToken(env)) {
+    return;
+  }
+
   await Promise.all(
     proposals.map(async (proposal) => {
       try {
@@ -2093,6 +2110,13 @@ function toRepoTag(repo: { owner: string; name: string }): string {
 
 async function main(): Promise<void> {
   try {
+    const hasGitHubTokenConfigured = hasGitHubToken();
+    if (!hasGitHubTokenConfigured) {
+      console.warn(
+        '[generate-data] No GITHUB_TOKEN or GH_TOKEN set; timeline fetch will be skipped and generated data will be partial. Set GITHUB_TOKEN or GH_TOKEN for complete output.'
+      );
+    }
+
     const data = await generateActivityData();
 
     // Ensure output directory exists
@@ -2128,9 +2152,9 @@ async function main(): Promise<void> {
     );
     const permissionGaps: string[] = [];
 
-    if (!process.env.GITHUB_TOKEN && !process.env.GH_TOKEN) {
+    if (!hasGitHubTokenConfigured) {
       permissionGaps.push(
-        'Generated without GITHUB_TOKEN/GH_TOKEN; API responses may be rate-limited.'
+        'Generated without GITHUB_TOKEN/GH_TOKEN; timeline fetch skipped and generated data may be partial.'
       );
     }
 

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -207,7 +207,9 @@ export async function fetchJson<T>(endpoint: string): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-export function resolveGitHubToken(env: NodeJS.ProcessEnv = process.env): string | undefined {
+export function resolveGitHubToken(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
   return env.GITHUB_TOKEN ?? env.GH_TOKEN;
 }
 

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -207,15 +207,11 @@ export async function fetchJson<T>(endpoint: string): Promise<T> {
   return response.json() as Promise<T>;
 }
 
-export function resolveGitHubToken(
-  env: NodeJS.ProcessEnv = process.env
-): string | undefined {
+export function resolveGitHubToken(env: NodeJS.ProcessEnv = process.env): string | undefined {
   return env.GITHUB_TOKEN ?? env.GH_TOKEN;
 }
 
-export function hasGitHubToken(
-  env: NodeJS.ProcessEnv = process.env
-): boolean {
+export function hasGitHubToken(env: NodeJS.ProcessEnv = process.env): boolean {
   return Boolean(resolveGitHubToken(env));
 }
 


### PR DESCRIPTION
Fixes #618

## Why

`generate-data.ts` still produced noisy per-proposal timeline warnings when no GitHub token was configured. That made first-run local deploy output look broken even though the script could continue with partial data.

## What changed

- add `resolveGitHubToken()` / `hasGitHubToken()` so token detection is centralized
- emit one pre-flight warning in `main()` when neither `GITHUB_TOKEN` nor `GH_TOKEN` is set
- skip `fetchPhaseTransitions()` entirely in the no-token path instead of logging one warning per proposal
- add focused tests for token resolution precedence and the no-token timeline skip path

## Validation

- `git diff --check`
- `cd web && timeout 180s npm ci --no-audit --progress=false` *(timed out in this workspace; no `node_modules` were produced, so `vitest`, `eslint`, and `tsc` were not available for follow-up commands)*

