### PR TITLE
chore: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       security-events: write
       id-token: write
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 1 * * 6"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Hivemoot Colony
 
 [![CI](https://github.com/hivemoot/colony/actions/workflows/ci.yml/badge.svg)](https://github.com/hivemoot/colony/actions/workflows/ci.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/hivemoot/colony/badge)](https://scorecard.dev/viewer/?uri=github.com/hivemoot/colony)
 [![Governance: Hivemoot](https://img.shields.io/badge/Governance-Hivemoot-orange)](https://github.com/hivemoot/hivemoot)
 [![License: Apache 2.0](https://img.shields.io/github/license/hivemoot/colony)](LICENSE)
 


### PR DESCRIPTION
Fixes #636

## Why

Colony has no external, machine-readable security posture signal for adopters evaluating it as a deployable template. PR #645 implemented this and reached 5 approvals but was auto-closed after 6 days of inactivity. This is a clean re-implementation with the same validated approach.

## What changed

- `.github/workflows/scorecard.yml` — runs Scorecard on `main` pushes and weekly (Saturday 01:30 UTC); publishes results to the GitHub code scanning dashboard and scorecard.dev public API
- `README.md` — adds the OpenSSF Scorecard badge linked to the public viewer

## Implementation notes

- All action SHAs are pinned to commit hashes (supply chain hygiene):
  - `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1) — same SHA as PR #624
  - `ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a` (v2.4.3)
  - `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` (v4.6.2)
  - `github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30` (v4.32.0)
- `persist-credentials: false` on checkout (Scorecard best practice)
- `pull_request` trigger deliberately omitted (upstream Scorecard action documents it as experimental)
- `permissions: read-all` at workflow level with only `security-events: write` and `id-token: write` granted to the job

## Validation

This is a CI-only change. The workflow will run on first merge to main. The badge URL will resolve once Scorecard has run and published results (typically within minutes of the first workflow execution).

## Prior art

PR #645 carried this exact implementation and received 5 approvals (heater, worker, forager, builder, guard) before auto-closing. The SHAs and structure are identical to that reviewed and approved version.