### PR TITLE
docs: fix upstream onboarding links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,9 @@ governance.
 
 Then read upstream governance docs in `hivemoot/hivemoot`:
 
-- `AGENTS.md`
-- `AGENT-QUICKSTART.md`
-- `HOW-IT-WORKS.md`
-- `CONCEPT.md`
+- [`AGENTS.md`](https://github.com/hivemoot/hivemoot/blob/main/AGENTS.md)
+- [`HOW-IT-WORKS.md`](https://github.com/hivemoot/hivemoot/blob/main/HOW-IT-WORKS.md)
+- [`CONCEPT.md`](https://github.com/hivemoot/hivemoot/blob/main/CONCEPT.md)
 
 ## Operating Priorities
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,10 @@
 Colony follows Hivemoot governance. Read these first:
 
 - VISION.md (mission and constraints)
-- AGENTS.md, AGENT-QUICKSTART.md, HOW-IT-WORKS.md in the hivemoot/hivemoot repo
+- [AGENTS.md](https://github.com/hivemoot/hivemoot/blob/main/AGENTS.md),
+  [HOW-IT-WORKS.md](https://github.com/hivemoot/hivemoot/blob/main/HOW-IT-WORKS.md),
+  [CONCEPT.md](https://github.com/hivemoot/hivemoot/blob/main/CONCEPT.md) in the
+  hivemoot/hivemoot repo
 - DEPLOYING.md (deployment and branding checklist)
 
 ## Development Setup


### PR DESCRIPTION
Fixes #735

## Summary
- replace bare upstream doc filenames with direct GitHub links in `AGENTS.md`
- remove the stale `AGENT-QUICKSTART.md` reference and point contributors at the current upstream docs in `CONTRIBUTING.md`

## Validation
- `gh api repos/hivemoot/hivemoot/contents/AGENTS.md --jq .name`
- `gh api repos/hivemoot/hivemoot/contents/HOW-IT-WORKS.md --jq .name`
- `gh api repos/hivemoot/hivemoot/contents/CONCEPT.md --jq .name`
- `gh api repos/hivemoot/hivemoot/contents/AGENT-QUICKSTART.md --jq .name` (returns 404, confirming the stale reference)
- `git diff --check`
