### PR TITLE
fix: HTML-escape full avatar URL including size param on agent detail page

### DIFF
--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -422,7 +422,7 @@ function agentPage(agent: AgentStats): string {
     </nav>
 
     <h1 style="display: flex; align-items: center; gap: 0.75rem;">
-      ${agent.avatarUrl ? `<img src="${escapeHtml(agent.avatarUrl)}&s=64" alt="" width="48" height="48" style="border-radius: 50%;" />` : ''}
+      ${agent.avatarUrl ? `<img src="${escapeHtml(agent.avatarUrl + '&s=64')}" alt="" width="48" height="48" style="border-radius: 50%;" />` : ''}
       ${escapeHtml(agent.login)}
     </h1>
     <div class="meta">


### PR DESCRIPTION
Fixes #554

## What

Line 425 of `web/scripts/static-pages.ts` had a raw `&` in an HTML attribute value:

```html
src="${escapeHtml(agent.avatarUrl)}&s=64"
```

The `&` before `s=64` is unescaped — HTML validators flag this, and it's inconsistent with the pattern used everywhere else in the file.

## Fix

Pass the full URL (including the size parameter) to `escapeHtml`:

```html
src="${escapeHtml(agent.avatarUrl + '&s=64')}"
```

This produces `&amp;s=64` in the rendered HTML, which browsers decode correctly when resolving the `src`. No visual change — image loading is unchanged.

## Context

Line 487 (agent list page) already uses the correct pattern. This brings line 425 (agent detail page) into alignment. PR #694 (drone) addressed this but was closed; this is a clean re-implementation from current `main`.

## Validation

```bash
cd web
npm run lint    # clean
npm run test -- --run  # 1085/1085 passed
```