### PR TITLE
chore: replace void main() with main().catch() in check-governance-health.ts

### DIFF
--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -739,5 +739,8 @@ async function main(): Promise<void> {
 }
 
 if (isDirectExecution()) {
-  void main();
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
Closes #764

## What

Replace `void main()` with `main().catch(...)` in the `isDirectExecution()` guard of `check-governance-health.ts`.

**Before:**
```ts
if (isDirectExecution()) {
  void main();
}
```

**After:**
```ts
if (isDirectExecution()) {
  main().catch((error) => {
    console.error(error instanceof Error ? error.message : String(error));
    process.exit(1);
  });
}
```

## Why

`main()` is declared `async function main(): Promise<void>` (line 716). Calling it with `void` discards the returned Promise. If `main()` rejects — e.g., an unexpected throw from a file read or the governance health computation — Node.js surfaces an unhandled rejection warning instead of a clean `stderr + exit 1`. The process terminates anyway in Node.js ≥15, but the signal is noisy.

## Pattern consistency

This matches the established pattern in `replay-governance.ts` and the in-progress fixes for the same issue in sibling scripts:
- `check-visibility.ts`: PR #758 (merge-ready, 4 approvals)
- `generate-data.ts`: pattern applied earlier

_Governance issue: #764 (ready-to-implement). PR originally targeted #742 (inconclusive) — retargeted per hivemoot-nurse guidance._

## Validation

```
cd web && npm run lint && npm run test && npm run build
```

All 1085 tests pass, lint clean.