### PR TITLE
chore: add chaossMetricsJson to colony-instance.json dataEndpoints

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -1473,6 +1473,9 @@ describe('generateStaticPages', () => {
       expect(manifest.dataEndpoints.governanceHistoryJson).toBe(
         'https://my-org.github.io/my-project/data/governance-history.json'
       );
+      expect(manifest.dataEndpoints.chaossMetricsJson).toBe(
+        'https://my-org.github.io/my-project/data/metrics/snapshot.json'
+      );
       expect(manifest.dashboardUrl).not.toContain('hivemoot.github.io');
       expect(manifest.version).toBe('1');
       expect(manifest.type).toBe('colony-instance');

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -794,6 +794,7 @@ export function generateStaticPages(outDir: string): void {
     dataEndpoints: {
       activityJson: `${BASE_URL}/data/activity.json`,
       governanceHistoryJson: `${BASE_URL}/data/governance-history.json`,
+      chaossMetricsJson: `${BASE_URL}/data/metrics/snapshot.json`,
     },
     sourceRepository: 'https://github.com/hivemoot/colony',
     framework: 'https://github.com/hivemoot/hivemoot',


### PR DESCRIPTION
Closes #745

## Summary

PR #600 explicitly deferred the CHAOSS metrics endpoint from the federation discovery manifest:

> Drop chaossMetricsJson from the manifest for now — it will be added in a follow-up PR once the metrics snapshot endpoint from #599 is deployed and the advertised URL is actually live.

PR #599 merged 2026-03-13. This PR delivers the promised follow-up.

## What changed

- `web/scripts/static-pages.ts`: Added `chaossMetricsJson` to `dataEndpoints` in the colony-instance.json manifest
- `web/scripts/__tests__/static-pages.test.ts`: Added assertion that `chaossMetricsJson` uses `COLONY_DEPLOYED_URL` correctly (same pattern as existing `activityJson` and `governanceHistoryJson` assertions)

## Why this matters

External tooling listed in the Horizon 4 roadmap — GrimoireLab, Augur, Cauldron.io — uses `colony-instance.json` to discover Colony's data API. Without `chaossMetricsJson`, those tools either hard-code the path or miss the endpoint entirely. The fix is one line; the test confirms URL templating works correctly with custom `COLONY_DEPLOYED_URL`.

## Verification

All 1085 tests pass. Lint and typecheck clean.