### PR TITLE
fix: extract resolveVisibilityToken — correct GITHUB_TOKEN priority

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -8,6 +8,7 @@ import {
   resolveDeployedPageUrl,
   resolveRepositoryHomepage,
   resolveVisibilityRepository,
+  resolveVisibilityToken,
   resolveVisibilityUserAgent,
   type CheckResult,
   type VisibilityReport,
@@ -32,6 +33,26 @@ describe('resolveVisibilityUserAgent', () => {
         VISIBILITY_USER_AGENT: '   ',
       })
     ).toBe('colony-visibility-check');
+  });
+});
+
+describe('resolveVisibilityToken', () => {
+  it('returns undefined when no token env vars are set', () => {
+    expect(resolveVisibilityToken({})).toBeUndefined();
+  });
+
+  it('returns GITHUB_TOKEN when only GITHUB_TOKEN is set', () => {
+    expect(resolveVisibilityToken({ GITHUB_TOKEN: 'ghp_abc' })).toBe('ghp_abc');
+  });
+
+  it('returns GH_TOKEN when only GH_TOKEN is set', () => {
+    expect(resolveVisibilityToken({ GH_TOKEN: 'ghp_xyz' })).toBe('ghp_xyz');
+  });
+
+  it('prefers GITHUB_TOKEN over GH_TOKEN when both are set', () => {
+    expect(
+      resolveVisibilityToken({ GITHUB_TOKEN: 'ghp_abc', GH_TOKEN: 'ghp_xyz' })
+    ).toBe('ghp_abc');
   });
 });
 

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -58,6 +58,12 @@ export function resolveVisibilityRepository(
   return resolveRepository(env);
 }
 
+export function resolveVisibilityToken(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  return env.GITHUB_TOKEN ?? env.GH_TOKEN;
+}
+
 export function buildRepositoryApiUrl(repository: {
   owner: string;
   repo: string;
@@ -305,7 +311,7 @@ async function runChecks(): Promise<CheckResult[]> {
 
   // Repository metadata checks via GitHub API
   try {
-    const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+    const token = resolveVisibilityToken();
     const userAgent = resolveVisibilityUserAgent();
     const headers: Record<string, string> = {
       Accept: 'application/vnd.github.v3+json',


### PR DESCRIPTION
Closes #631

## Problem

`check-visibility.ts:308` resolves the GitHub token with the wrong priority:

```ts
const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
```

`GH_TOKEN` is a CLI-local variable. `GITHUB_TOKEN` is the token GitHub Actions injects automatically. When both are present — e.g., a developer with a local `GH_TOKEN` running checks in CI — the CLI token wins instead of the Actions token. `generate-data.ts:194` already uses the correct order (`GITHUB_TOKEN ?? GH_TOKEN`).

## What changed

- **`check-visibility.ts`**: Added exported `resolveVisibilityToken(env)` helper using `GITHUB_TOKEN ?? GH_TOKEN` (matching `generate-data.ts`). Replaced the inline expression at line 308 with the helper.
- **`check-visibility.test.ts`**: Four tests covering all cases: `GITHUB_TOKEN` only, `GH_TOKEN` only, both set (verify `GITHUB_TOKEN` wins), neither set (returns `undefined`).

## Validation

```bash
cd web
npm run lint          # clean
npx tsc --noEmit      # clean
npx vitest run scripts/__tests__/check-visibility.test.ts  # 32 passed
```