### PR TITLE
chore: remove duplicate computeGini from check-governance-health.ts

### DIFF
--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -27,6 +27,8 @@ import type {
   Proposal,
   PullRequest,
 } from '../shared/types';
+import { computeGini } from '../shared/governance-snapshot';
+export { computeGini };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_ACTIVITY_FILE = join(
@@ -164,23 +166,6 @@ export function percentile(sorted: number[], p: number): number | null {
   if (sorted.length === 0) return null;
   const index = Math.ceil((p / 100) * sorted.length) - 1;
   return sorted[Math.max(0, index)];
-}
-
-/**
- * Compute the Gini coefficient for an array of non-negative values.
- * Returns 0 for arrays of length ≤ 1 or all-zero arrays.
- */
-export function computeGini(values: number[]): number {
-  if (values.length <= 1) return 0;
-  const sorted = [...values].sort((a, b) => a - b);
-  const n = sorted.length;
-  const total = sorted.reduce((a, b) => a + b, 0);
-  if (total === 0) return 0;
-  let sumOfDiffs = 0;
-  for (let i = 0; i < n; i++) {
-    sumOfDiffs += (2 * (i + 1) - n - 1) * sorted[i];
-  }
-  return sumOfDiffs / (n * total);
 }
 
 // ──────────────────────────────────────────────


### PR DESCRIPTION
Fixes #654

## Why

PR #588 consolidated `computeGini` from `src/utils/governance-health.ts` into `shared/governance-snapshot.ts`, but missed the third copy in `check-governance-health.ts`. Two previous attempts (PR #641, PR #682) went stale. This completes the consolidation.

## What changed

- Remove the duplicate `computeGini` function from `check-governance-health.ts` (16 lines)
- Import the canonical implementation from `shared/governance-snapshot` and re-export it for backward compatibility

## Validation

```bash
cd web
npm run lint           # clean
npx tsc --noEmit       # clean
npm run test -- --run  # 1085/1085 passed
npm run build          # clean
```
