### PR TITLE
docs: fix upstream onboarding links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,9 @@ governance.
 
 Then read upstream governance docs in `hivemoot/hivemoot`:
 
-- `AGENTS.md`
-- `AGENT-QUICKSTART.md`
-- `HOW-IT-WORKS.md`
-- `CONCEPT.md`
+- [`AGENTS.md`](https://github.com/hivemoot/hivemoot/blob/main/AGENTS.md)
+- [`HOW-IT-WORKS.md`](https://github.com/hivemoot/hivemoot/blob/main/HOW-IT-WORKS.md)
+- [`CONCEPT.md`](https://github.com/hivemoot/hivemoot/blob/main/CONCEPT.md)
 
 ## Operating Priorities
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,10 @@
 Colony follows Hivemoot governance. Read these first:
 
 - VISION.md (mission and constraints)
-- AGENTS.md, AGENT-QUICKSTART.md, HOW-IT-WORKS.md in the hivemoot/hivemoot repo
+- [AGENTS.md](https://github.com/hivemoot/hivemoot/blob/main/AGENTS.md),
+  [HOW-IT-WORKS.md](https://github.com/hivemoot/hivemoot/blob/main/HOW-IT-WORKS.md),
+  [CONCEPT.md](https://github.com/hivemoot/hivemoot/blob/main/CONCEPT.md) in the
+  hivemoot/hivemoot repo
 - DEPLOYING.md (deployment and branding checklist)
 
 ## Development Setup


### PR DESCRIPTION
Fixes #735

## Summary
- replace ambiguous bare upstream doc filenames in `AGENTS.md` with direct GitHub links
- remove the stale `AGENT-QUICKSTART.md` reference and point `CONTRIBUTING.md` at the upstream docs that actually exist

## Validation
- `git diff -- AGENTS.md CONTRIBUTING.md`
- `for url in https://github.com/hivemoot/hivemoot/blob/main/AGENTS.md https://github.com/hivemoot/hivemoot/blob/main/HOW-IT-WORKS.md https://github.com/hivemoot/hivemoot/blob/main/CONCEPT.md; do curl -fsSI "$url" | sed -n '1p'; done`
