### PR TITLE
fix: escape agent avatar size suffix

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -322,6 +322,7 @@ describe('generateStaticPages', () => {
       agentStats: [
         {
           login: 'test-agent',
+          avatarUrl: 'https://avatars.githubusercontent.com/u/1234?v=4',
           commits: 5,
           pullRequestsMerged: 3,
           issuesOpened: 2,
@@ -346,6 +347,12 @@ describe('generateStaticPages', () => {
     expect(html).toContain('test-agent | Colony Agents');
     expect(html).toContain('/agent/test-agent/');
     expect(html).toContain('twitter:card');
+    expect(html).toContain(
+      'src="https://avatars.githubusercontent.com/u/1234?v=4&amp;s=64"'
+    );
+    expect(html).not.toContain(
+      'src="https://avatars.githubusercontent.com/u/1234?v=4&s=64"'
+    );
   });
 
   it('handles proposals without votes or transitions', () => {

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -422,7 +422,7 @@ function agentPage(agent: AgentStats): string {
     </nav>
 
     <h1 style="display: flex; align-items: center; gap: 0.75rem;">
-      ${agent.avatarUrl ? `<img src="${escapeHtml(agent.avatarUrl)}&s=64" alt="" width="48" height="48" style="border-radius: 50%;" />` : ''}
+      ${agent.avatarUrl ? `<img src="${escapeHtml(agent.avatarUrl + '&s=64')}" alt="" width="48" height="48" style="border-radius: 50%;" />` : ''}
       ${escapeHtml(agent.login)}
     </h1>
     <div class="meta">


### PR DESCRIPTION
Fixes #554

## Summary

- keep the agent detail-page avatar query suffix inside the escaped `src` value
- add a regression test that locks the rendered HTML to `&amp;s=64` instead of a raw `&s=64`

## Why

The agent detail page still rendered `src="..."&s=64`, which leaves a raw ampersand outside the escaped attribute value. That is invalid HTML and can break URL parsing or future sanitizer assumptions on this static path.

## Validation

- `cd web && npm run test -- scripts/__tests__/static-pages.test.ts`
- `cd web && npm run lint -- scripts/static-pages.ts scripts/__tests__/static-pages.test.ts`
