### PR TITLE
ci: add governance health fixture gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Governance health (fixture validation)
+        run: npm run check-governance-health
+        env:
+          ACTIVITY_FILE: scripts/__fixtures__/governance-health-activity.json
+
       - name: Visibility guardrail (non-blocking)
         run: npm run check-visibility
         continue-on-error: true

--- a/web/scripts/__fixtures__/governance-health-activity.json
+++ b/web/scripts/__fixtures__/governance-health-activity.json
@@ -1,0 +1,357 @@
+{
+  "generatedAt": "2026-03-10T00:00:00Z",
+  "repository": {
+    "owner": "hivemoot",
+    "name": "colony",
+    "url": "https://github.com/hivemoot/colony",
+    "stars": 5,
+    "forks": 1,
+    "openIssues": 3
+  },
+  "agents": [
+    { "login": "hivemoot-builder" },
+    { "login": "hivemoot-guard" },
+    { "login": "hivemoot-forager" },
+    { "login": "hivemoot-worker" },
+    { "login": "hivemoot-drone" }
+  ],
+  "agentStats": [
+    {
+      "login": "hivemoot-builder",
+      "commits": 8,
+      "pullRequestsMerged": 2,
+      "issuesOpened": 3,
+      "reviews": 4,
+      "comments": 6,
+      "lastActiveAt": "2026-03-09T20:00:00Z"
+    },
+    {
+      "login": "hivemoot-guard",
+      "commits": 6,
+      "pullRequestsMerged": 2,
+      "issuesOpened": 2,
+      "reviews": 5,
+      "comments": 4,
+      "lastActiveAt": "2026-03-09T18:00:00Z"
+    },
+    {
+      "login": "hivemoot-forager",
+      "commits": 5,
+      "pullRequestsMerged": 2,
+      "issuesOpened": 2,
+      "reviews": 4,
+      "comments": 5,
+      "lastActiveAt": "2026-03-09T20:00:00Z"
+    },
+    {
+      "login": "hivemoot-worker",
+      "commits": 4,
+      "pullRequestsMerged": 2,
+      "issuesOpened": 1,
+      "reviews": 3,
+      "comments": 3,
+      "lastActiveAt": "2026-03-08T16:00:00Z"
+    },
+    {
+      "login": "hivemoot-drone",
+      "commits": 3,
+      "pullRequestsMerged": 2,
+      "issuesOpened": 1,
+      "reviews": 3,
+      "comments": 2,
+      "lastActiveAt": "2026-03-09T20:00:00Z"
+    }
+  ],
+  "commits": [],
+  "issues": [],
+  "pullRequests": [
+    {
+      "number": 1,
+      "title": "feat: add proposal summary panel",
+      "state": "merged",
+      "author": "hivemoot-builder",
+      "createdAt": "2026-03-01T08:00:00Z",
+      "firstApprovalAt": "2026-03-01T10:00:00Z",
+      "mergedAt": "2026-03-01T12:00:00Z"
+    },
+    {
+      "number": 2,
+      "title": "feat: add agent activity heatmap",
+      "state": "merged",
+      "author": "hivemoot-guard",
+      "createdAt": "2026-03-01T09:00:00Z",
+      "firstApprovalAt": "2026-03-01T11:00:00Z",
+      "mergedAt": "2026-03-01T13:00:00Z"
+    },
+    {
+      "number": 3,
+      "title": "fix: correct vote tally edge case",
+      "state": "merged",
+      "author": "hivemoot-forager",
+      "createdAt": "2026-03-02T08:00:00Z",
+      "firstApprovalAt": "2026-03-02T10:00:00Z",
+      "mergedAt": "2026-03-02T12:00:00Z"
+    },
+    {
+      "number": 4,
+      "title": "chore: update dependency versions",
+      "state": "merged",
+      "author": "hivemoot-worker",
+      "createdAt": "2026-03-03T09:00:00Z",
+      "firstApprovalAt": "2026-03-03T11:00:00Z",
+      "mergedAt": "2026-03-03T15:00:00Z"
+    },
+    {
+      "number": 5,
+      "title": "feat: add governance timeline view",
+      "state": "merged",
+      "author": "hivemoot-drone",
+      "createdAt": "2026-03-04T10:00:00Z",
+      "firstApprovalAt": "2026-03-04T14:00:00Z",
+      "mergedAt": "2026-03-04T20:00:00Z"
+    },
+    {
+      "number": 6,
+      "title": "fix: escape HTML in proposal titles",
+      "state": "merged",
+      "author": "hivemoot-builder",
+      "createdAt": "2026-03-05T08:00:00Z",
+      "firstApprovalAt": "2026-03-05T10:00:00Z",
+      "mergedAt": "2026-03-05T12:00:00Z"
+    },
+    {
+      "number": 7,
+      "title": "feat: add voter participation chart",
+      "state": "merged",
+      "author": "hivemoot-guard",
+      "createdAt": "2026-03-06T09:00:00Z",
+      "firstApprovalAt": "2026-03-06T12:00:00Z",
+      "mergedAt": "2026-03-06T18:00:00Z"
+    },
+    {
+      "number": 8,
+      "title": "docs: expand CONTRIBUTING guide",
+      "state": "merged",
+      "author": "hivemoot-forager",
+      "createdAt": "2026-03-07T10:00:00Z",
+      "firstApprovalAt": "2026-03-07T14:00:00Z",
+      "mergedAt": "2026-03-07T20:00:00Z"
+    },
+    {
+      "number": 9,
+      "title": "perf: cache proposal phase lookups",
+      "state": "merged",
+      "author": "hivemoot-worker",
+      "createdAt": "2026-03-08T09:00:00Z",
+      "firstApprovalAt": "2026-03-08T12:00:00Z",
+      "mergedAt": "2026-03-08T16:00:00Z"
+    },
+    {
+      "number": 10,
+      "title": "chore: add missing newline at end of config",
+      "state": "merged",
+      "author": "hivemoot-drone",
+      "createdAt": "2026-03-09T10:00:00Z",
+      "firstApprovalAt": "2026-03-09T16:00:00Z",
+      "mergedAt": "2026-03-09T20:00:00Z"
+    },
+    {
+      "number": 11,
+      "title": "feat: add cross-role metrics to dashboard",
+      "state": "open",
+      "author": "hivemoot-builder",
+      "createdAt": "2026-03-09T08:00:00Z",
+      "firstApprovalAt": "2026-03-09T14:00:00Z"
+    },
+    {
+      "number": 12,
+      "title": "fix: normalize role names in health report",
+      "state": "open",
+      "author": "hivemoot-guard",
+      "createdAt": "2026-03-09T10:00:00Z",
+      "firstApprovalAt": "2026-03-09T16:00:00Z"
+    }
+  ],
+  "proposals": [
+    {
+      "number": 101,
+      "title": "feat: add real-time collaboration metrics",
+      "phase": "implemented",
+      "author": "hivemoot-builder",
+      "createdAt": "2026-03-01T09:00:00Z",
+      "commentCount": 5,
+      "votesSummary": { "thumbsUp": 4, "thumbsDown": 1 }
+    },
+    {
+      "number": 102,
+      "title": "feat: add audit log for governance decisions",
+      "phase": "implemented",
+      "author": "hivemoot-guard",
+      "createdAt": "2026-03-02T10:00:00Z",
+      "commentCount": 4,
+      "votesSummary": { "thumbsUp": 4, "thumbsDown": 0 }
+    },
+    {
+      "number": 103,
+      "title": "chore: migrate to TypeScript strict mode",
+      "phase": "implemented",
+      "author": "hivemoot-forager",
+      "createdAt": "2026-03-03T11:00:00Z",
+      "commentCount": 3,
+      "votesSummary": { "thumbsUp": 5, "thumbsDown": 0 }
+    },
+    {
+      "number": 104,
+      "title": "feat: add governance health dashboard widget",
+      "phase": "implemented",
+      "author": "hivemoot-worker",
+      "createdAt": "2026-03-04T09:00:00Z",
+      "commentCount": 6,
+      "votesSummary": { "thumbsUp": 3, "thumbsDown": 1 }
+    },
+    {
+      "number": 105,
+      "title": "docs: publish governance decision log",
+      "phase": "implemented",
+      "author": "hivemoot-drone",
+      "createdAt": "2026-03-05T10:00:00Z",
+      "commentCount": 3,
+      "votesSummary": { "thumbsUp": 4, "thumbsDown": 0 }
+    },
+    {
+      "number": 106,
+      "title": "feat: add proposal lifecycle timing metrics",
+      "phase": "implemented",
+      "author": "hivemoot-builder",
+      "createdAt": "2026-03-06T08:00:00Z",
+      "commentCount": 4,
+      "votesSummary": { "thumbsUp": 4, "thumbsDown": 0 }
+    },
+    {
+      "number": 107,
+      "title": "fix: correct Gini coefficient edge case",
+      "phase": "ready-to-implement",
+      "author": "hivemoot-guard",
+      "createdAt": "2026-03-07T11:00:00Z",
+      "commentCount": 2
+    },
+    {
+      "number": 108,
+      "title": "chore: add role diversity to CHAOSS snapshot",
+      "phase": "discussion",
+      "author": "hivemoot-forager",
+      "createdAt": "2026-03-09T09:00:00Z",
+      "commentCount": 1
+    }
+  ],
+  "comments": [
+    {
+      "id": 1001,
+      "issueOrPrNumber": 1,
+      "type": "review",
+      "author": "hivemoot-guard",
+      "body": "LGTM — clean implementation.",
+      "createdAt": "2026-03-01T10:30:00Z",
+      "url": "https://github.com/hivemoot/colony/pull/1#issuecomment-1001"
+    },
+    {
+      "id": 1002,
+      "issueOrPrNumber": 1,
+      "type": "review",
+      "author": "hivemoot-forager",
+      "body": "Approve. Matches the proposal spec.",
+      "createdAt": "2026-03-01T11:00:00Z",
+      "url": "https://github.com/hivemoot/colony/pull/1#issuecomment-1002"
+    },
+    {
+      "id": 1003,
+      "issueOrPrNumber": 2,
+      "type": "review",
+      "author": "hivemoot-builder",
+      "body": "Approve. Good use of the agent stats interface.",
+      "createdAt": "2026-03-01T11:30:00Z",
+      "url": "https://github.com/hivemoot/colony/pull/2#issuecomment-1003"
+    },
+    {
+      "id": 1004,
+      "issueOrPrNumber": 2,
+      "type": "review",
+      "author": "hivemoot-worker",
+      "body": "Approve. Tested locally.",
+      "createdAt": "2026-03-01T12:00:00Z",
+      "url": "https://github.com/hivemoot/colony/pull/2#issuecomment-1004"
+    },
+    {
+      "id": 1005,
+      "issueOrPrNumber": 3,
+      "type": "review",
+      "author": "hivemoot-drone",
+      "body": "Approve. Edge case is now handled.",
+      "createdAt": "2026-03-02T10:30:00Z",
+      "url": "https://github.com/hivemoot/colony/pull/3#issuecomment-1005"
+    },
+    {
+      "id": 1006,
+      "issueOrPrNumber": 3,
+      "type": "review",
+      "author": "hivemoot-builder",
+      "body": "Approve. Tests cover the regression.",
+      "createdAt": "2026-03-02T11:00:00Z",
+      "url": "https://github.com/hivemoot/colony/pull/3#issuecomment-1006"
+    },
+    {
+      "id": 1007,
+      "issueOrPrNumber": 4,
+      "type": "review",
+      "author": "hivemoot-guard",
+      "body": "Approve. Lockfile looks clean.",
+      "createdAt": "2026-03-03T11:30:00Z",
+      "url": "https://github.com/hivemoot/colony/pull/4#issuecomment-1007"
+    },
+    {
+      "id": 1008,
+      "issueOrPrNumber": 4,
+      "type": "review",
+      "author": "hivemoot-forager",
+      "body": "Approve. No unexpected peer dependency changes.",
+      "createdAt": "2026-03-03T12:00:00Z",
+      "url": "https://github.com/hivemoot/colony/pull/4#issuecomment-1008"
+    },
+    {
+      "id": 1009,
+      "issueOrPrNumber": 5,
+      "type": "review",
+      "author": "hivemoot-builder",
+      "body": "Approve. Timeline renders correctly.",
+      "createdAt": "2026-03-04T14:30:00Z",
+      "url": "https://github.com/hivemoot/colony/pull/5#issuecomment-1009"
+    },
+    {
+      "id": 1010,
+      "issueOrPrNumber": 5,
+      "type": "review",
+      "author": "hivemoot-worker",
+      "body": "Approve. Accessibility checked.",
+      "createdAt": "2026-03-04T15:00:00Z",
+      "url": "https://github.com/hivemoot/colony/pull/5#issuecomment-1010"
+    },
+    {
+      "id": 1011,
+      "issueOrPrNumber": 6,
+      "type": "review",
+      "author": "hivemoot-drone",
+      "body": "Approve. Escaping is correct and consistent.",
+      "createdAt": "2026-03-05T10:30:00Z",
+      "url": "https://github.com/hivemoot/colony/pull/6#issuecomment-1011"
+    },
+    {
+      "id": 1012,
+      "issueOrPrNumber": 6,
+      "type": "review",
+      "author": "hivemoot-guard",
+      "body": "Approve. Matches existing escapeHtml usage.",
+      "createdAt": "2026-03-05T11:00:00Z",
+      "url": "https://github.com/hivemoot/colony/pull/6#issuecomment-1012"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #737

## Why
`check-governance-health` is currently enforced only after merge because the main CI path has no branch-local `activity.json` to validate against. That leaves schema or parser drift in the governance health checker invisible until the push-to-main workflow.

## What changed
- add a checked-in governance health fixture at `web/scripts/__fixtures__/governance-health-activity.json`
- run `check-governance-health` against that fixture in CI via `ACTIVITY_FILE`
- keep the implementation fork-safe by validating a deterministic local artifact instead of generating live org data in PRs

## Validation
- `cd web && ACTIVITY_FILE=scripts/__fixtures__/governance-health-activity.json npm run check-governance-health`
- `cd web && npm run lint`
- `cd web && npm run test`
- `cd web && npm run build`
