### PR TITLE
chore: consolidate computeGini helper

### DIFF
--- a/web/scripts/__tests__/check-governance-health.test.ts
+++ b/web/scripts/__tests__/check-governance-health.test.ts
@@ -9,7 +9,6 @@ import {
   buildHealthReport,
   computeCrossRoleReviewRate,
   computeDataWindowDays,
-  computeGini,
   computeMergeBacklogDepth,
   computeMergeLatency,
   computeContestedRate,
@@ -127,37 +126,6 @@ describe('percentile', () => {
     // 10-element array, p95 → index ceil(9.5)-1 = 9 → last element
     const sorted = [1, 2, 3, 4, 5, 6, 7, 8, 9, 100];
     expect(percentile(sorted, 95)).toBe(100);
-  });
-});
-
-// ──────────────────────────────────────────────
-// computeGini
-// ──────────────────────────────────────────────
-
-describe('computeGini', () => {
-  it('returns 0 for empty or single-element array', () => {
-    expect(computeGini([])).toBe(0);
-    expect(computeGini([10])).toBe(0);
-  });
-
-  it('returns 0 for perfectly equal distribution', () => {
-    expect(computeGini([5, 5, 5, 5])).toBe(0);
-  });
-
-  it('returns 0 for all-zero values', () => {
-    expect(computeGini([0, 0, 0])).toBe(0);
-  });
-
-  it('returns near 1 for maximum concentration', () => {
-    // One agent has everything, others have 0
-    const gini = computeGini([0, 0, 0, 100]);
-    expect(gini).toBeGreaterThan(0.7);
-  });
-
-  it('returns a value between 0 and 1 for mixed distribution', () => {
-    const gini = computeGini([10, 20, 30, 40]);
-    expect(gini).toBeGreaterThan(0);
-    expect(gini).toBeLessThan(1);
   });
 });
 

--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -21,6 +21,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { computeGini } from '../shared/governance-snapshot';
 import type {
   ActivityData,
   Comment,
@@ -164,23 +165,6 @@ export function percentile(sorted: number[], p: number): number | null {
   if (sorted.length === 0) return null;
   const index = Math.ceil((p / 100) * sorted.length) - 1;
   return sorted[Math.max(0, index)];
-}
-
-/**
- * Compute the Gini coefficient for an array of non-negative values.
- * Returns 0 for arrays of length ≤ 1 or all-zero arrays.
- */
-export function computeGini(values: number[]): number {
-  if (values.length <= 1) return 0;
-  const sorted = [...values].sort((a, b) => a - b);
-  const n = sorted.length;
-  const total = sorted.reduce((a, b) => a + b, 0);
-  if (total === 0) return 0;
-  let sumOfDiffs = 0;
-  for (let i = 0; i < n; i++) {
-    sumOfDiffs += (2 * (i + 1) - n - 1) * sorted[i];
-  }
-  return sumOfDiffs / (n * total);
 }
 
 // ──────────────────────────────────────────────


### PR DESCRIPTION
Fixes #654

## Summary
- remove the duplicate `computeGini` implementation from `web/scripts/check-governance-health.ts`
- import the canonical helper from `web/shared/governance-snapshot.ts` instead
- drop the redundant script-level `computeGini` tests that only covered the removed duplicate

## Validation
- `cd web && npm install`
- `cd web && npm run lint`
- `cd web && npm run test`
- `cd web && npm run build`
