### PR TITLE
fix: suppress no-token timeline noise

### DIFF
--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -202,7 +202,7 @@ describe('resolveRepositories', () => {
 });
 
 describe('generateActivityData', () => {
-  it('skips proposal timeline fetches when no GitHub token is configured', async () => {
+  it('skips proposal metadata fetches when no GitHub token is configured', async () => {
     const originalGithubRepository = process.env.GITHUB_REPOSITORY;
     const originalGithubToken = process.env.GITHUB_TOKEN;
     const originalGhToken = process.env.GH_TOKEN;
@@ -262,7 +262,7 @@ describe('generateActivityData', () => {
                 body: 'Make something visible.',
                 state: 'open',
                 state_reason: null,
-                labels: [{ name: 'hivemoot:discussion' }],
+                labels: [{ name: 'hivemoot:ready-to-implement' }],
                 created_at: '2026-02-10T00:00:00Z',
                 closed_at: null,
                 user: { login: 'hivemoot-builder' },
@@ -298,8 +298,13 @@ describe('generateActivityData', () => {
 
       expect(data.proposals).toHaveLength(1);
       expect(data.proposals[0]?.phaseTransitions).toBeUndefined();
+      expect(data.proposals[0]?.votesSummary).toBeUndefined();
       expect(fetchMock).not.toHaveBeenCalledWith(
         expect.stringContaining('/issues/42/timeline?per_page=100'),
+        expect.anything()
+      );
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('/issues/42/comments'),
         expect.anything()
       );
       expect(
@@ -311,6 +316,17 @@ describe('generateActivityData', () => {
                 ? input.toString()
                 : input.url;
           return url.includes('/issues/42/timeline?per_page=100');
+        })
+      ).toBe(false);
+      expect(
+        fetchMock.mock.calls.some(([input]) => {
+          const url =
+            typeof input === 'string'
+              ? input
+              : input instanceof URL
+                ? input.toString()
+                : input.url;
+          return url.includes('/issues/42/comments');
         })
       ).toBe(false);
     } finally {

--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   resolveRepository,
+  resolveGitHubToken,
+  hasGitHubToken,
   resolveRequiredDiscoverabilityTopics,
   resolveRepositories,
   resolveRepositoryHomepage,
@@ -20,6 +22,7 @@ import {
   deduplicateAgents,
   extractPhaseTransitions,
   filterAndMapProposals,
+  generateActivityData,
   enrichPullRequestsWithApprovalTimes,
   type GitHubCommit,
   type GitHubEvent,
@@ -97,6 +100,32 @@ describe('resolveRepository', () => {
   });
 });
 
+describe('resolveGitHubToken', () => {
+  it('prefers GITHUB_TOKEN over GH_TOKEN', () => {
+    expect(
+      resolveGitHubToken({
+        GITHUB_TOKEN: 'github-token',
+        GH_TOKEN: 'gh-token',
+      } as NodeJS.ProcessEnv)
+    ).toBe('github-token');
+  });
+
+  it('falls back to GH_TOKEN and ignores blank values', () => {
+    expect(
+      resolveGitHubToken({
+        GITHUB_TOKEN: '   ',
+        GH_TOKEN: '  gh-token  ',
+      } as NodeJS.ProcessEnv)
+    ).toBe('gh-token');
+    expect(
+      hasGitHubToken({
+        GITHUB_TOKEN: ' ',
+        GH_TOKEN: '\n',
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+});
+
 describe('resolveRepositories', () => {
   it('should fall back to single repo when COLONY_REPOSITORIES is not set', () => {
     const result = resolveRepositories({});
@@ -169,6 +198,140 @@ describe('resolveRepositories', () => {
       { owner: 'hivemoot', repo: 'colony' },
       { owner: 'hivemoot', repo: 'hivemoot' },
     ]);
+  });
+});
+
+describe('generateActivityData', () => {
+  it('skips proposal timeline fetches when no GitHub token is configured', async () => {
+    const originalGithubRepository = process.env.GITHUB_REPOSITORY;
+    const originalGithubToken = process.env.GITHUB_TOKEN;
+    const originalGhToken = process.env.GH_TOKEN;
+
+    delete process.env.GITHUB_REPOSITORY;
+    delete process.env.GITHUB_TOKEN;
+    delete process.env.GH_TOKEN;
+
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+
+        if (!url.startsWith('https://api.github.com')) {
+          return new Response('', { status: 404 });
+        }
+
+        const endpoint = url.replace('https://api.github.com', '');
+
+        if (endpoint === '/repos/hivemoot/colony') {
+          return new Response(
+            JSON.stringify({
+              stargazers_count: 1,
+              forks_count: 1,
+              open_issues_count: 1,
+              subscribers_count: 1,
+              homepage: null,
+              description:
+                'Open-source dashboard for autonomous agent governance',
+              topics: REQUIRED_DISCOVERABILITY_TOPICS,
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          );
+        }
+
+        if (endpoint === '/repos/hivemoot/colony/commits?per_page=50') {
+          return new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+
+        if (
+          endpoint ===
+          '/repos/hivemoot/colony/issues?state=open&per_page=100&page=1'
+        ) {
+          return new Response(
+            JSON.stringify([
+              {
+                number: 42,
+                title: 'Proposal',
+                body: 'Make something visible.',
+                state: 'open',
+                state_reason: null,
+                labels: [{ name: 'hivemoot:discussion' }],
+                created_at: '2026-02-10T00:00:00Z',
+                closed_at: null,
+                user: { login: 'hivemoot-builder' },
+                comments: 0,
+              },
+            ]),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          );
+        }
+
+        if (
+          endpoint.startsWith('/repos/hivemoot/colony/issues?state=open') ||
+          endpoint.startsWith('/repos/hivemoot/colony/issues?state=closed') ||
+          endpoint === '/repos/hivemoot/colony/pulls?state=open&per_page=50' ||
+          endpoint ===
+            '/repos/hivemoot/colony/pulls?state=closed&per_page=50' ||
+          endpoint === '/repos/hivemoot/colony/events?per_page=100'
+        ) {
+          return new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      });
+
+    try {
+      const data = await generateActivityData();
+
+      expect(data.proposals).toHaveLength(1);
+      expect(data.proposals[0]?.phaseTransitions).toBeUndefined();
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('/issues/42/timeline?per_page=100'),
+        expect.anything()
+      );
+      expect(
+        fetchMock.mock.calls.some(([input]) => {
+          const url =
+            typeof input === 'string'
+              ? input
+              : input instanceof URL
+                ? input.toString()
+                : input.url;
+          return url.includes('/issues/42/timeline?per_page=100');
+        })
+      ).toBe(false);
+    } finally {
+      if (originalGithubRepository === undefined) {
+        delete process.env.GITHUB_REPOSITORY;
+      } else {
+        process.env.GITHUB_REPOSITORY = originalGithubRepository;
+      }
+
+      if (originalGithubToken === undefined) {
+        delete process.env.GITHUB_TOKEN;
+      } else {
+        process.env.GITHUB_TOKEN = originalGithubToken;
+      }
+
+      if (originalGhToken === undefined) {
+        delete process.env.GH_TOKEN;
+      } else {
+        process.env.GH_TOKEN = originalGhToken;
+      }
+    }
   });
 });
 

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -638,6 +638,7 @@ async function fetchProposals(
   repoTag?: string
 ): Promise<Proposal[]> {
   const proposals = filterAndMapProposals(rawIssues, repoTag);
+  const canEnrichProposalMetadata = hasGitHubToken();
 
   // Fetch votes for all proposals that have been through a voting round.
   // The Queen's voting comment persists after phase transitions, so we can
@@ -654,33 +655,36 @@ async function fetchProposals(
     votablePhases.includes(p.phase)
   );
 
-  await Promise.all(
-    votingProposals.map(async (proposal) => {
-      try {
-        const comments = await fetchJson<GitHubComment[]>(
-          `/repos/${owner}/${repo}/issues/${proposal.number}/comments`
-        );
-        const votingComment = comments.find(
-          (c) =>
-            (c.user.login === 'hivemoot[bot]' || c.user.login === 'hivemoot') &&
-            (c.body.includes('React to THIS comment to vote') ||
-              (c.body.includes('hivemoot-metadata') &&
-                c.body.includes('"type":"voting"')))
-        );
-        if (votingComment && votingComment.reactions) {
-          proposal.votesSummary = {
-            thumbsUp: votingComment.reactions['+1'] || 0,
-            thumbsDown: votingComment.reactions['-1'] || 0,
-          };
+  if (canEnrichProposalMetadata) {
+    await Promise.all(
+      votingProposals.map(async (proposal) => {
+        try {
+          const comments = await fetchJson<GitHubComment[]>(
+            `/repos/${owner}/${repo}/issues/${proposal.number}/comments`
+          );
+          const votingComment = comments.find(
+            (c) =>
+              (c.user.login === 'hivemoot[bot]' ||
+                c.user.login === 'hivemoot') &&
+              (c.body.includes('React to THIS comment to vote') ||
+                (c.body.includes('hivemoot-metadata') &&
+                  c.body.includes('"type":"voting"')))
+          );
+          if (votingComment && votingComment.reactions) {
+            proposal.votesSummary = {
+              thumbsUp: votingComment.reactions['+1'] || 0,
+              thumbsDown: votingComment.reactions['-1'] || 0,
+            };
+          }
+        } catch (e) {
+          console.warn(
+            `Failed to fetch reactions for issue #${proposal.number}`,
+            e
+          );
         }
-      } catch (e) {
-        console.warn(
-          `Failed to fetch reactions for issue #${proposal.number}`,
-          e
-        );
-      }
-    })
-  );
+      })
+    );
+  }
 
   return proposals.sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
@@ -2113,7 +2117,7 @@ async function main(): Promise<void> {
   try {
     if (!hasGitHubToken()) {
       console.warn(
-        '[generate-data] No GITHUB_TOKEN or GH_TOKEN set. Skipping proposal timeline fetches and using unauthenticated GitHub API requests, so output may be partial. Set GITHUB_TOKEN or GH_TOKEN for complete output.'
+        '[generate-data] No GITHUB_TOKEN or GH_TOKEN set. Skipping proposal timeline and voting-comment fetches and using unauthenticated GitHub API requests, so output may be partial. Set GITHUB_TOKEN or GH_TOKEN for complete output.'
       );
     }
 
@@ -2154,7 +2158,7 @@ async function main(): Promise<void> {
 
     if (!hasGitHubToken()) {
       permissionGaps.push(
-        'Generated without GITHUB_TOKEN/GH_TOKEN; proposal timelines were skipped and API responses may be rate-limited.'
+        'Generated without GITHUB_TOKEN/GH_TOKEN; proposal timelines and voting comments were skipped and API responses may be rate-limited.'
       );
     }
 

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -183,6 +183,22 @@ export interface GitHubTimelineEvent {
   created_at: string;
 }
 
+export function resolveGitHubToken(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  const githubToken = env.GITHUB_TOKEN?.trim();
+  if (githubToken) {
+    return githubToken;
+  }
+
+  const ghToken = env.GH_TOKEN?.trim();
+  return ghToken || undefined;
+}
+
+export function hasGitHubToken(env: NodeJS.ProcessEnv = process.env): boolean {
+  return resolveGitHubToken(env) !== undefined;
+}
+
 export async function fetchJson<T>(endpoint: string): Promise<T> {
   const url = `${GITHUB_API}${endpoint}`;
   const headers: Record<string, string> = {
@@ -191,7 +207,7 @@ export async function fetchJson<T>(endpoint: string): Promise<T> {
   };
 
   // Use GITHUB_TOKEN/GH_TOKEN if available (CI or local environment)
-  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const token = resolveGitHubToken();
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }
@@ -1887,7 +1903,9 @@ async function fetchRepoActivity(
     issueResult.rawIssues,
     repoTag
   );
-  await fetchPhaseTransitions(owner, repo, proposals);
+  if (hasGitHubToken()) {
+    await fetchPhaseTransitions(owner, repo, proposals);
+  }
   await enrichPullRequestsWithApprovalTimes(owner, repo, prResult.pullRequests);
 
   const openIssues = calculateOpenIssues(repoMetadata, prResult.pullRequests);
@@ -1926,7 +1944,7 @@ async function fetchRepoActivity(
   };
 }
 
-async function generateActivityData(): Promise<ActivityData> {
+export async function generateActivityData(): Promise<ActivityData> {
   const repos = resolveRepositories();
   const isMultiRepo = repos.length > 1;
 
@@ -2093,6 +2111,12 @@ function toRepoTag(repo: { owner: string; name: string }): string {
 
 async function main(): Promise<void> {
   try {
+    if (!hasGitHubToken()) {
+      console.warn(
+        '[generate-data] No GITHUB_TOKEN or GH_TOKEN set. Skipping proposal timeline fetches and using unauthenticated GitHub API requests, so output may be partial. Set GITHUB_TOKEN or GH_TOKEN for complete output.'
+      );
+    }
+
     const data = await generateActivityData();
 
     // Ensure output directory exists
@@ -2128,9 +2152,9 @@ async function main(): Promise<void> {
     );
     const permissionGaps: string[] = [];
 
-    if (!process.env.GITHUB_TOKEN && !process.env.GH_TOKEN) {
+    if (!hasGitHubToken()) {
       permissionGaps.push(
-        'Generated without GITHUB_TOKEN/GH_TOKEN; API responses may be rate-limited.'
+        'Generated without GITHUB_TOKEN/GH_TOKEN; proposal timelines were skipped and API responses may be rate-limited.'
       );
     }
 


### PR DESCRIPTION
Fixes #618

## Summary
- add centralized GitHub token detection for generate-data
- warn once when no token is configured and skip proposal timeline fetches in that path
- cover token resolution precedence and the no-token timeline skip path with tests

## Validation
- `cd web && npm run lint`
- `cd web && npm run test`
- `cd web && npm run build`
