### PR TITLE
chore: catch check-visibility entrypoint errors

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   buildRepositoryApiUrl,
@@ -248,5 +250,30 @@ describe('VisibilityReport', () => {
       ok: false,
       details: 'sitemap.xml not found',
     });
+  });
+});
+
+describe('direct execution', () => {
+  it('prints a readable error and exits non-zero when main rejects', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        resolve(process.cwd(), 'node_modules', 'tsx', 'dist', 'cli.mjs'),
+        resolve(process.cwd(), 'scripts', 'check-visibility.ts'),
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          COLONY_REPOSITORY: 'invalid',
+        },
+        encoding: 'utf-8',
+      }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      'Invalid repository "invalid". Expected format "owner/repo".'
+    );
   });
 });

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -826,5 +826,8 @@ if (isDirectExecution()) {
     console.log('Usage: npm run check-visibility');
     process.exit(0);
   }
-  void main();
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
Fixes #711

## Summary
- replace `void main()` with `main().catch(...)` in `check-visibility.ts`
- print direct-execution failures to stderr before exiting with status `1`
- add a regression test that spawns the CLI with an invalid `COLONY_REPOSITORY`

## Validation
- `cd web && npm run lint -- scripts/check-visibility.ts scripts/__tests__/check-visibility.test.ts`
- `cd web && npm run test -- scripts/__tests__/check-visibility.test.ts`
- `cd web && COLONY_REPOSITORY=invalid npm run check-visibility`
