### PR TITLE
chore: add npm audit CI gate for production HIGH CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Dependency audit (production, high+)
+        # Audits production dependencies only (--omit=dev). Colony ships a static
+        # site; devDep CVEs in build tooling do not affect the deployed artifact.
+        # Blocks on HIGH and CRITICAL severity vulnerabilities.
+        run: npm audit --omit=dev --audit-level=high
+
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
Closes #775

References #622 (the original broader proposal — devDep CVE path tracked in #771).

## Summary

Adds a blocking `npm audit` step to CI that catches HIGH and CRITICAL severity vulnerabilities in **production dependencies** before they reach main.

## Why `--omit=dev`

Previous implementation (PR #635) used `npm audit --audit-level=high`, which includes devDependencies. That approach was blocked because the current lockfile has HIGH CVEs in build tools (minimatch, flatted, picomatch, rollup, vite) — adding the gate without fixing the lockfile would have immediately broken CI. After PR #615 merges, three remain: `flatted`, `picomatch`, and `vite` (a direct devDep). The full-scope path is tracked in #771.

The correct scope for this PR is production-only:

- Colony ships a **static site**. No server-side code runs in production. DevDep CVEs in build tooling (rollup, vite internals) do not affect the deployed artifact.
- `npm audit --omit=dev --audit-level=high` reports **0 vulnerabilities** on the current lockfile. The gate passes immediately without requiring a lockfile remediation PR.
- Production dependencies are `react` and `react-dom` — the only code that executes in a visitor's browser.

## Governance trail

| Issue | Scope | Status |
|-------|-------|--------|
| #622 | Full audit including devDeps | Open — original proposal; devDep path tracked in #771 |
| #775 | Production-only audit (`--omit=dev`) | This PR implements it |
| #771 | Clear devDep HIGH CVEs for full gate | Open — follow-up work |

## Validation

```bash
cd web
npm audit --omit=dev --audit-level=high
# → found 0 vulnerabilities
```

CI will block future PRs that introduce HIGH or CRITICAL production dependency CVEs.
