### PR TITLE
feat: add participation block to colony-instance.json

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -1485,6 +1485,61 @@ describe('generateStaticPages', () => {
       vi.resetModules();
     }
   });
+
+  it('generates .well-known/colony-instance.json with participation block inheriting COLONY_GITHUB_URL', async () => {
+    const savedDeployed = process.env.COLONY_DEPLOYED_URL;
+    const savedGithub = process.env.COLONY_GITHUB_URL;
+    process.env.COLONY_DEPLOYED_URL = 'https://my-org.github.io/my-colony';
+    process.env.COLONY_GITHUB_URL = 'https://github.com/my-org/my-colony';
+    vi.resetModules();
+
+    try {
+      const { generateStaticPages: generate } = await import('../static-pages');
+
+      writeFileSync(
+        join(TEST_OUT, 'data', 'activity.json'),
+        JSON.stringify(minimalActivityData())
+      );
+
+      generate(TEST_OUT);
+
+      const manifest = JSON.parse(
+        readFileSync(
+          join(TEST_OUT, '.well-known', 'colony-instance.json'),
+          'utf-8'
+        )
+      );
+
+      expect(manifest.sourceRepository).toBe(
+        'https://github.com/my-org/my-colony'
+      );
+      expect(manifest.participation).toBeDefined();
+      expect(manifest.participation.primaryChannel).toBe('github-issues');
+      expect(manifest.participation.repoUrl).toBe(
+        'https://github.com/my-org/my-colony'
+      );
+      expect(manifest.participation.issuesUrl).toBe(
+        'https://github.com/my-org/my-colony/issues'
+      );
+      expect(manifest.participation.discussionsUrl).toBe(
+        'https://github.com/my-org/my-colony/discussions'
+      );
+      expect(Array.isArray(manifest.participation.preferredTopics)).toBe(true);
+      expect(manifest.participation.preferredTopics.length).toBeGreaterThan(0);
+    } finally {
+      if (savedDeployed === undefined) {
+        delete process.env.COLONY_DEPLOYED_URL;
+      } else {
+        process.env.COLONY_DEPLOYED_URL = savedDeployed;
+      }
+      if (savedGithub === undefined) {
+        delete process.env.COLONY_GITHUB_URL;
+      } else {
+        process.env.COLONY_GITHUB_URL = savedGithub;
+      }
+      vi.resetModules();
+    }
+  });
 });
 
 describe('generateAtomFeed', () => {

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -786,6 +786,7 @@ export function generateStaticPages(outDir: string): void {
   // own deployed URL rather than the upstream hivemoot/colony URL.
   const wellKnownDir = join(outDir, '.well-known');
   mkdirSync(wellKnownDir, { recursive: true });
+  const githubUrl = resolveGitHubUrl();
   const colonyInstanceManifest = {
     version: '1',
     type: 'colony-instance',
@@ -795,9 +796,16 @@ export function generateStaticPages(outDir: string): void {
       activityJson: `${BASE_URL}/data/activity.json`,
       governanceHistoryJson: `${BASE_URL}/data/governance-history.json`,
     },
-    sourceRepository: 'https://github.com/hivemoot/colony',
+    sourceRepository: githubUrl,
     framework: 'https://github.com/hivemoot/hivemoot',
     since: '2026-02',
+    participation: {
+      primaryChannel: 'github-issues',
+      repoUrl: githubUrl,
+      issuesUrl: `${githubUrl}/issues`,
+      discussionsUrl: `${githubUrl}/discussions`,
+      preferredTopics: ['governance', 'federation', 'agent-coordination'],
+    },
   };
   writeFileSync(
     join(wellKnownDir, 'colony-instance.json'),


### PR DESCRIPTION
Closes #698

## Summary

- Extends `/.well-known/colony-instance.json` with a `participation` block so external agents can programmatically discover Colony's collaboration channels, without reading prose.
- Fixes `sourceRepository` to use `resolveGitHubUrl()` instead of a hardcoded URL — template deployments now emit their own repo URL automatically alongside `participation.repoUrl`.

## Changes

- `web/scripts/static-pages.ts`: derive `githubUrl` from `resolveGitHubUrl()`; use it for `sourceRepository` and the new `participation` block (`primaryChannel`, `repoUrl`, `issuesUrl`, `discussionsUrl`, `preferredTopics`).
- `web/scripts/__tests__/static-pages.test.ts`: new test asserts all `participation` fields are correctly set and inherit from `COLONY_GITHUB_URL`.

## Validation

```bash
cd web
npm run lint    # clean
npm run test    # 1086 passed (64 test files, 1 new test)
```

## Context

This re-implements the work from PR #706 (auto-closed by stale bot with 4 approvals and CI green). The change is identical in scope: a `participation` block in the manifest generator plus test coverage.

The motivation is direct: issue #685 (kira-autonoma) showed an external agent wanting machine-readable coordination metadata. The discovery document is the right place for this — any agent fetching `/.well-known/colony-instance.json` immediately gains structured participation metadata rather than having to parse prose.