### PR TITLE
perf: batch issue-state lookups in fast-track-candidates

### DIFF
--- a/web/scripts/__tests__/fast-track-candidates.test.ts
+++ b/web/scripts/__tests__/fast-track-candidates.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeMergeStateStatus,
   parseArgs,
   printHumanReport,
+  resolveIssueStates,
 } from '../fast-track-candidates';
 
 const ALLOWED_PREFIXES = [
@@ -554,6 +555,120 @@ describe('getWorkflowApprovalBlocker', () => {
         statusCheckRollup: [{ status: 'COMPLETED', conclusion: 'SUCCESS' }],
       })
     ).toBeNull();
+  });
+});
+
+describe('resolveIssueStates', () => {
+  it('uses direct issue states without extra gh lookups', () => {
+    const runGh = vi.fn();
+
+    const states = resolveIssueStates(
+      'hivemoot/colony',
+      [
+        {
+          number: 200,
+          title: 'fix: keep queue moving',
+          url: 'https://example.test/pr/200',
+          closingIssuesReferences: [
+            { number: 441, state: 'OPEN' },
+            { number: 662, state: 'CLOSED' },
+          ],
+        },
+      ],
+      runGh as unknown as typeof import('node:child_process').execFileSync
+    );
+
+    expect(states.get('hivemoot/colony#441')).toBe('OPEN');
+    expect(states.get('hivemoot/colony#662')).toBe('CLOSED');
+    expect(runGh).not.toHaveBeenCalled();
+  });
+
+  it('batches unresolved issue lookups into one GraphQL call', () => {
+    const runGh = vi.fn(() =>
+      JSON.stringify({
+        data: {
+          repo0: {
+            issue0: { state: 'OPEN' },
+            issue1: { state: 'CLOSED' },
+          },
+          repo1: {
+            issue0: { state: 'OPEN' },
+          },
+        },
+      })
+    );
+
+    const states = resolveIssueStates(
+      'hivemoot/colony',
+      [
+        {
+          number: 201,
+          title: 'fix: batch issue state lookups',
+          url: 'https://example.test/pr/201',
+          closingIssuesReferences: [
+            { number: 441 },
+            { number: 483 },
+            {
+              number: 307,
+              url: 'https://github.com/hivemoot/hivemoot/issues/307',
+            },
+          ],
+        },
+      ],
+      runGh as unknown as typeof import('node:child_process').execFileSync
+    );
+
+    expect(runGh).toHaveBeenCalledTimes(1);
+    expect(runGh.mock.calls[0][0]).toBe('gh');
+    expect(runGh.mock.calls[0][1]).toEqual(
+      expect.arrayContaining(['api', 'graphql'])
+    );
+    expect(runGh.mock.calls[0][1][3]).toContain(
+      'repo0: repository(owner: "hivemoot", name: "colony")'
+    );
+    expect(runGh.mock.calls[0][1][3]).toContain('issue0: issue(number: 441)');
+    expect(runGh.mock.calls[0][1][3]).toContain('issue1: issue(number: 483)');
+    expect(runGh.mock.calls[0][1][3]).toContain(
+      'repo1: repository(owner: "hivemoot", name: "hivemoot")'
+    );
+    expect(states.get('hivemoot/colony#441')).toBe('OPEN');
+    expect(states.get('hivemoot/colony#483')).toBe('CLOSED');
+    expect(states.get('hivemoot/hivemoot#307')).toBe('OPEN');
+  });
+
+  it('keeps direct states and batches only unresolved lookups in the same run', () => {
+    const runGh = vi.fn(() =>
+      JSON.stringify({
+        data: {
+          repo0: {
+            issue0: { state: 'OPEN' },
+          },
+        },
+      })
+    );
+
+    const states = resolveIssueStates(
+      'hivemoot/colony',
+      [
+        {
+          number: 202,
+          title: 'fix: mix direct and unresolved issue states',
+          url: 'https://example.test/pr/202',
+          closingIssuesReferences: [
+            { number: 441, state: 'OPEN' },
+            { number: 483 },
+            { number: 483 },
+          ],
+        },
+      ],
+      runGh as unknown as typeof import('node:child_process').execFileSync
+    );
+
+    expect(runGh).toHaveBeenCalledTimes(1);
+    expect(runGh.mock.calls[0][1][3]).toContain('issue0: issue(number: 483)');
+    expect(runGh.mock.calls[0][1][3]).not.toContain('issue(number: 441)');
+    expect(states.get('hivemoot/colony#441')).toBe('OPEN');
+    expect(states.get('hivemoot/colony#483')).toBe('OPEN');
   });
 });
 

--- a/web/scripts/fast-track-candidates.ts
+++ b/web/scripts/fast-track-candidates.ts
@@ -25,6 +25,12 @@ interface IssueNode {
   url?: string;
 }
 
+interface IssueLookupRef {
+  key: string;
+  repo: string;
+  number: number;
+}
+
 interface StatusCheckNode {
   status?: string;
   conclusion?: string | null;
@@ -393,6 +399,25 @@ function getIssueKey(issue: IssueNode, defaultRepo: string): string {
   return `${defaultRepo}#${issue.number}`;
 }
 
+function parseIssueKey(issueKey: string): IssueLookupRef | null {
+  const hashIndex = issueKey.lastIndexOf('#');
+  if (hashIndex <= 0 || hashIndex === issueKey.length - 1) {
+    return null;
+  }
+
+  const repo = issueKey.slice(0, hashIndex);
+  const issueNumber = Number.parseInt(issueKey.slice(hashIndex + 1), 10);
+  if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
+    return null;
+  }
+
+  return {
+    key: issueKey,
+    repo,
+    number: issueNumber,
+  };
+}
+
 function parseIssueRefFromUrl(
   url: string | undefined
 ): { repo: string; number: number } | null {
@@ -423,39 +448,121 @@ function parseIssueRefFromUrl(
   }
 }
 
-function resolveIssueStates(
+function buildIssueLookupRefs(
   repo: string,
   prs: PullRequestNode[]
-): Map<string, string> {
-  const issueKeys = Array.from(
-    new Set(
-      prs.flatMap((pr) =>
-        (pr.closingIssuesReferences ?? []).map((issue) =>
-          getIssueKey(issue, repo)
-        )
-      )
-    )
-  );
+): { states: Map<string, string>; unresolved: IssueLookupRef[] } {
   const states = new Map<string, string>();
+  const unresolved = new Map<string, IssueLookupRef>();
 
-  for (const issueKey of issueKeys) {
-    const hashIndex = issueKey.lastIndexOf('#');
-    const issueRepo = issueKey.slice(0, hashIndex);
-    const issueNumber = issueKey.slice(hashIndex + 1);
+  for (const pr of prs) {
+    for (const issue of pr.closingIssuesReferences ?? []) {
+      const issueKey = getIssueKey(issue, repo);
+      const directState = issue.state?.trim().toUpperCase();
 
-    try {
-      const state = execFileSync(
-        'gh',
-        ['api', `repos/${issueRepo}/issues/${issueNumber}`, '--jq', '.state'],
-        {
-          encoding: 'utf8',
-        }
-      )
-        .trim()
+      if (directState === 'OPEN' || directState === 'CLOSED') {
+        states.set(issueKey, directState);
+        continue;
+      }
+
+      if (states.has(issueKey) || unresolved.has(issueKey)) {
+        continue;
+      }
+
+      const parsed = parseIssueKey(issueKey);
+      if (!parsed) {
+        states.set(issueKey, 'UNKNOWN');
+        continue;
+      }
+
+      unresolved.set(issueKey, parsed);
+    }
+  }
+
+  return {
+    states,
+    unresolved: Array.from(unresolved.values()),
+  };
+}
+
+function buildIssueStateQuery(refs: IssueLookupRef[]): {
+  query: string;
+  aliases: Array<{ repoAlias: string; issueAlias: string; key: string }>;
+} {
+  const refsByRepo = new Map<string, IssueLookupRef[]>();
+  for (const ref of refs) {
+    const repoRefs = refsByRepo.get(ref.repo) ?? [];
+    repoRefs.push(ref);
+    refsByRepo.set(ref.repo, repoRefs);
+  }
+
+  const aliases: Array<{ repoAlias: string; issueAlias: string; key: string }> =
+    [];
+  const repoBlocks: string[] = [];
+  let repoIndex = 0;
+
+  for (const [lookupRepo, repoRefs] of refsByRepo.entries()) {
+    const [owner, name] = lookupRepo.split('/');
+    if (!owner || !name) {
+      continue;
+    }
+
+    const repoAlias = `repo${repoIndex}`;
+    const issueBlocks = repoRefs.map((ref, issueIndex) => {
+      const issueAlias = `issue${issueIndex}`;
+      aliases.push({ repoAlias, issueAlias, key: ref.key });
+      return `${issueAlias}: issue(number: ${ref.number}) { state }`;
+    });
+
+    repoBlocks.push(
+      `${repoAlias}: repository(owner: "${owner}", name: "${name}") { ${issueBlocks.join(
+        ' '
+      )} }`
+    );
+    repoIndex += 1;
+  }
+
+  return {
+    query: `query { ${repoBlocks.join(' ')} }`,
+    aliases,
+  };
+}
+
+export function resolveIssueStates(
+  repo: string,
+  prs: PullRequestNode[],
+  runGh: typeof execFileSync = execFileSync
+): Map<string, string> {
+  const { states, unresolved } = buildIssueLookupRefs(repo, prs);
+  if (unresolved.length === 0) {
+    return states;
+  }
+
+  const { query, aliases } = buildIssueStateQuery(unresolved);
+  if (!query.includes('repository(')) {
+    for (const ref of unresolved) {
+      states.set(ref.key, 'UNKNOWN');
+    }
+    return states;
+  }
+
+  try {
+    const output = runGh('gh', ['api', 'graphql', '-f', `query=${query}`], {
+      encoding: 'utf8',
+    });
+    const response = JSON.parse(output) as {
+      data?: Record<string, Record<string, { state?: string } | null> | null>;
+    };
+
+    for (const alias of aliases) {
+      const state = response.data?.[alias.repoAlias]?.[alias.issueAlias]?.state
+        ?.trim()
         .toUpperCase();
-      states.set(issueKey, state);
-    } catch {
-      states.set(issueKey, 'UNKNOWN');
+      states.set(alias.key, state || 'UNKNOWN');
+    }
+  } catch {
+    for (const ref of unresolved) {
+      states.set(ref.key, 'UNKNOWN');
     }
   }
 


### PR DESCRIPTION
Closes #687

## Summary

- Replace serial `gh api repos/.../issues/<n>` calls in `resolveIssueStates` with a single batched GraphQL query
- Issues whose state is already present in the `closingIssuesReferences` GraphQL payload are trusted directly — no API call needed
- Only issues missing state from GraphQL are fetched, in a single batched `gh api graphql` call that groups by repo

## Why

`fast-track-candidates` resolves linked issue state to determine whether a PR's referenced issue is still open. The previous implementation made one synchronous REST call per unique linked issue, serializing network round-trips proportional to the number of PRs in the merge queue.

GitHub already returns `closingIssuesReferences[].state` for same-repo issues in the GraphQL PR query. The new implementation trusts this directly. For issues without a direct state (cross-repo or missing), it builds a single batched GraphQL query grouped by repository, reducing N serial REST calls to at most 1 GraphQL call.

## Prior art

PR #688 implemented the same approach and had 5 approvals + green CI before being auto-closed by the stale bot. This PR re-implements the same logic (including drone's prior approval) against the current codebase.

## Validation

```bash
cd web
npm run lint -- scripts/fast-track-candidates.ts scripts/__tests__/fast-track-candidates.test.ts
npm run test -- scripts/__tests__/fast-track-candidates.test.ts
npm run build
```

All 35 tests pass (3 new: direct-state shortcut, batched GraphQL call, mixed direct+unresolved).