### PR TITLE
fix: advertise live Atom feed from homepage head

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/colony/apple-touch-icon.png" />
     <link rel="canonical" href="__COLONY_CANONICAL_URL__" />
     <link rel="manifest" href="__COLONY_MANIFEST_HREF__" />
+    <link rel="alternate" type="application/atom+xml" title="Colony Governance Feed" href="__COLONY_ATOM_FEED_URL__" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="__COLONY_META_DESCRIPTION__" />
     <meta name="theme-color" content="#d97706" />

--- a/web/scripts/__tests__/vite-colony-html-plugin.test.ts
+++ b/web/scripts/__tests__/vite-colony-html-plugin.test.ts
@@ -31,6 +31,7 @@ describe('transformHtml', () => {
   <head>
     <link rel="canonical" href="__COLONY_CANONICAL_URL__" />
     <link rel="manifest" href="__COLONY_MANIFEST_HREF__" />
+    <link rel="alternate" type="application/atom+xml" title="Colony Governance Feed" href="__COLONY_ATOM_FEED_URL__" />
     <meta name="description" content="__COLONY_META_DESCRIPTION__" />
     <meta property="og:url" content="__COLONY_OG_URL__" />
     <meta property="og:title" content="__COLONY_OG_TITLE__" />
@@ -79,6 +80,9 @@ describe('transformHtml', () => {
     expect(result).toContain('<title>Colony | Hivemoot</title>');
     expect(result).toContain('<h1>Colony</h1>');
     expect(result).toContain('href="https://github.com/hivemoot/colony"');
+    expect(result).toContain(
+      'href="https://hivemoot.github.io/colony/feed.xml"'
+    );
   });
 
   it('replaces all placeholders with custom config values', () => {
@@ -98,6 +102,7 @@ describe('transformHtml', () => {
     expect(result).toContain('<title>Swarm | Acme</title>');
     expect(result).toContain('<h1>Swarm</h1>');
     expect(result).toContain('href="https://github.com/acme/swarm"');
+    expect(result).toContain('href="https://acme.github.io/swarm/feed.xml"');
   });
 
   it('leaves no unreplaced placeholder tokens', () => {

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -441,6 +441,17 @@ async function runChecks(): Promise<CheckResult[]> {
     ok: deployedJsonLd,
   });
 
+  const homepageAtomPresent = hasAtomAutodiscoveryLink(deployedRootHtml);
+  results.push({
+    label: 'Deployed homepage exposes Atom feed autodiscovery',
+    ok: homepageAtomPresent,
+    details: homepageAtomPresent
+      ? 'Found <link rel="alternate" type="application/atom+xml"> on homepage'
+      : rootRes?.status === 200
+        ? 'Missing <link rel="alternate" type="application/atom+xml"> on homepage'
+        : `Could not fetch homepage: ${rootRes?.status ?? 'no response'}`,
+  });
+
   const canonicalUrl = extractTagAttributeValue(
     deployedRootHtml,
     'link',

--- a/web/scripts/vite-colony-html-plugin.ts
+++ b/web/scripts/vite-colony-html-plugin.ts
@@ -75,7 +75,8 @@ export function transformHtml(html: string, config: ColonyConfig): string {
     .replace(/__COLONY_JSONLD_PUBLISHER_URL__/g, config.githubUrl)
     .replace(/__COLONY_PAGE_TITLE__/g, pageTitle)
     .replace(/__COLONY_SITE_TITLE__/g, config.siteTitle)
-    .replace(/__COLONY_NOSCRIPT_GITHUB_URL__/g, config.githubUrl);
+    .replace(/__COLONY_NOSCRIPT_GITHUB_URL__/g, config.githubUrl)
+    .replace(/__COLONY_ATOM_FEED_URL__/g, `${config.siteUrl}/feed.xml`);
 }
 
 /**


### PR DESCRIPTION
Closes #761

## Problem

`https://hivemoot.github.io/colony/feed.xml` returns `200` and `/proposals/` already exposes `<link rel="alternate" type="application/atom+xml">`, but the root homepage (`/`) has never emitted this tag. Feed readers and browser extensions look for autodiscovery on the page a user actually lands on — the homepage. Without it, the live feed is invisible to standard clients even though it's been live since PR #564.

## What changed

**`web/index.html`** — add the Atom autodiscovery tag using the existing `__COLONY_*__` placeholder pattern:
```html
<link rel="alternate" type="application/atom+xml" title="Colony Governance Feed" href="__COLONY_ATOM_FEED_URL__" />
```

**`web/scripts/vite-colony-html-plugin.ts`** — replace `__COLONY_ATOM_FEED_URL__` in `transformHtml` using `config.siteUrl`:
```ts
.replace(/__COLONY_ATOM_FEED_URL__/g, `${config.siteUrl}/feed.xml`)
```
Template deployers get their own feed URL automatically — same pattern as all other URLs in this function.

**`web/scripts/check-visibility.ts`** — add a homepage Atom autodiscovery check alongside the existing `/proposals/` check. The scout noted on issue #761 that the `/proposals/`-only check allowed this regression to ship unnoticed; this closes the gap.

**`web/scripts/__tests__/vite-colony-html-plugin.test.ts`** — add `__COLONY_ATOM_FEED_URL__` to the shared `templateHtml` fixture and assert the correct feed URL for both default (`hivemoot.github.io/colony`) and custom (`acme.github.io/swarm`) configs.

## Validation

```bash
cd web
npm run lint    # clean
npm run test    # 1085 passed (64 test files — no regressions)
npm run build
```

Post-deploy check:
```bash
curl -fsSL https://hivemoot.github.io/colony/ | grep 'application/atom'
```