### PR TITLE
fix: extract resolveVisibilityToken — correct GITHUB_TOKEN priority

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -8,6 +8,7 @@ import {
   resolveDeployedPageUrl,
   resolveRepositoryHomepage,
   resolveVisibilityRepository,
+  resolveVisibilityToken,
   resolveVisibilityUserAgent,
   type CheckResult,
   type VisibilityReport,
@@ -32,6 +33,31 @@ describe('resolveVisibilityUserAgent', () => {
         VISIBILITY_USER_AGENT: '   ',
       })
     ).toBe('colony-visibility-check');
+  });
+});
+
+describe('resolveVisibilityToken', () => {
+  it('returns undefined when neither GITHUB_TOKEN nor GH_TOKEN is set', () => {
+    expect(resolveVisibilityToken({})).toBeUndefined();
+  });
+
+  it('returns GITHUB_TOKEN when only GITHUB_TOKEN is set', () => {
+    expect(resolveVisibilityToken({ GITHUB_TOKEN: 'gha-token' })).toBe(
+      'gha-token'
+    );
+  });
+
+  it('returns GH_TOKEN when only GH_TOKEN is set', () => {
+    expect(resolveVisibilityToken({ GH_TOKEN: 'cli-token' })).toBe('cli-token');
+  });
+
+  it('GITHUB_TOKEN wins over GH_TOKEN when both are set', () => {
+    expect(
+      resolveVisibilityToken({
+        GITHUB_TOKEN: 'gha-token',
+        GH_TOKEN: 'cli-token',
+      })
+    ).toBe('gha-token');
   });
 });
 

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -49,6 +49,12 @@ export function resolveVisibilityUserAgent(
   return configured || DEFAULT_VISIBILITY_USER_AGENT;
 }
 
+export function resolveVisibilityToken(
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  return env.GITHUB_TOKEN ?? env.GH_TOKEN;
+}
+
 export function resolveVisibilityRepository(
   env: NodeJS.ProcessEnv = process.env
 ): {
@@ -305,7 +311,7 @@ async function runChecks(): Promise<CheckResult[]> {
 
   // Repository metadata checks via GitHub API
   try {
-    const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+    const token = resolveVisibilityToken();
     const userAgent = resolveVisibilityUserAgent();
     const headers: Record<string, string> = {
       Accept: 'application/vnd.github.v3+json',


### PR DESCRIPTION
Closes #631

## Problem

`check-visibility.ts` resolves the GitHub token with `GH_TOKEN` taking priority over `GITHUB_TOKEN`:

```ts
const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
```

This is backwards. `GITHUB_TOKEN` is the token GitHub Actions injects automatically into every workflow run — it should win when both are set. `GH_TOKEN` is the gh CLI fallback for local execution.

The correct priority is already established in `generate-data.ts`:
```ts
const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
```

## What changed

**`web/scripts/check-visibility.ts`:**
- Add `resolveVisibilityToken(env?)` exported helper with correct priority: `GITHUB_TOKEN ?? GH_TOKEN`.
- Use `??` (not `||`) consistent with `generate-data.ts` — avoids treating an empty string as falsy.
- Replace the inline expression at the call site with the helper.

**`web/scripts/__tests__/check-visibility.test.ts`:**
- Import `resolveVisibilityToken`.
- Four tests: neither set (→ `undefined`), `GITHUB_TOKEN` only, `GH_TOKEN` only, both set (`GITHUB_TOKEN` wins).

## Validation

```bash
cd web
npm run lint    # clean
npm run test    # 1089 passed (64 test files — 4 new tests)
npm run build
```

## Context

This is the fourth attempt at this fix. PRs #628, #671, and #747 all reached 4 approvals with green CI before being stale-closed. The fix is identical in scope to those PRs.