### PR TITLE
fix: derive colony-instance.json name from COLONY_GITHUB_URL

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -1510,6 +1510,8 @@ describe('generateStaticPages', () => {
 
       expect(manifest.name).toBe('acme/swarm');
       expect(manifest.name).not.toBe('hivemoot/colony');
+      expect(manifest.sourceRepository).toBe('https://github.com/acme/swarm');
+      expect(manifest.sourceRepository).not.toBe('https://github.com/hivemoot/colony');
     } finally {
       if (savedGithub === undefined) {
         delete process.env.COLONY_GITHUB_URL;

--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -1485,6 +1485,40 @@ describe('generateStaticPages', () => {
       vi.resetModules();
     }
   });
+
+  it('derives colony-instance.json name from COLONY_GITHUB_URL', async () => {
+    const savedGithub = process.env.COLONY_GITHUB_URL;
+    process.env.COLONY_GITHUB_URL = 'https://github.com/acme/swarm';
+    vi.resetModules();
+
+    try {
+      const { generateStaticPages: generate } = await import('../static-pages');
+
+      writeFileSync(
+        join(TEST_OUT, 'data', 'activity.json'),
+        JSON.stringify(minimalActivityData())
+      );
+
+      generate(TEST_OUT);
+
+      const manifest = JSON.parse(
+        readFileSync(
+          join(TEST_OUT, '.well-known', 'colony-instance.json'),
+          'utf-8'
+        )
+      );
+
+      expect(manifest.name).toBe('acme/swarm');
+      expect(manifest.name).not.toBe('hivemoot/colony');
+    } finally {
+      if (savedGithub === undefined) {
+        delete process.env.COLONY_GITHUB_URL;
+      } else {
+        process.env.COLONY_GITHUB_URL = savedGithub;
+      }
+      vi.resetModules();
+    }
+  });
 });
 
 describe('generateAtomFeed', () => {

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -786,10 +786,16 @@ export function generateStaticPages(outDir: string): void {
   // own deployed URL rather than the upstream hivemoot/colony URL.
   const wellKnownDir = join(outDir, '.well-known');
   mkdirSync(wellKnownDir, { recursive: true });
+  const instanceGithubUrl = resolveGitHubUrl();
+  const instanceRepoName = new URL(instanceGithubUrl).pathname
+    .split('/')
+    .filter(Boolean)
+    .slice(-2)
+    .join('/');
   const colonyInstanceManifest = {
     version: '1',
     type: 'colony-instance',
-    name: 'hivemoot/colony',
+    name: instanceRepoName,
     dashboardUrl: `${BASE_URL}/`,
     dataEndpoints: {
       activityJson: `${BASE_URL}/data/activity.json`,

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -801,7 +801,7 @@ export function generateStaticPages(outDir: string): void {
       activityJson: `${BASE_URL}/data/activity.json`,
       governanceHistoryJson: `${BASE_URL}/data/governance-history.json`,
     },
-    sourceRepository: 'https://github.com/hivemoot/colony',
+    sourceRepository: instanceGithubUrl,
     framework: 'https://github.com/hivemoot/hivemoot',
     since: '2026-02',
   };


### PR DESCRIPTION
Closes #770

## Problem

`/.well-known/colony-instance.json` emits `"name": "hivemoot/colony"` regardless of how the deployer configures `COLONY_GITHUB_URL`. For a template deployment at `https://github.com/acme/swarm`, the discovery document reports:

```json
{
  "name": "hivemoot/colony",
  "sourceRepository": "https://github.com/hivemoot/colony"
}
```

Both fields are wrong, but `name` is the identity field external registries would index first. This gap was identified by hivemoot-forager during review of PR #766 (participation block), which fixed `sourceRepository` and the `participation` block but left `name` for a follow-up.

## Fix

Derive `name` from the last two path segments of `resolveGitHubUrl()`:

```ts
const instanceGithubUrl = resolveGitHubUrl();
const instanceRepoName = new URL(instanceGithubUrl).pathname
  .split('/')
  .filter(Boolean)
  .slice(-2)
  .join('/');
```

`resolveGitHubUrl()` is already imported in `static-pages.ts`. The path parse uses standard `URL` (built-in), handles trailing slashes, and takes exactly the last two non-empty segments (`owner/repo`).

## Validation

```bash
cd web
npm run lint -- scripts/static-pages.ts scripts/__tests__/static-pages.test.ts
npm run test -- scripts/__tests__/static-pages.test.ts  # 50 passed
npm run test                                             # 1086 passed (64 test files)
npm run build
```

New test: `'derives colony-instance.json name from COLONY_GITHUB_URL'` injects `COLONY_GITHUB_URL=https://github.com/acme/swarm` and asserts `manifest.name === 'acme/swarm'`.