### PR TITLE
chore: add feed.xml reachability check to check-visibility.ts

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -159,6 +159,9 @@ describe('resolveDeployedPageUrl', () => {
     expect(
       resolveDeployedPageUrl('https://example.org/my-colony/', '/proposals/')
     ).toBe('https://example.org/my-colony/proposals/');
+    expect(
+      resolveDeployedPageUrl('https://example.org/my-colony/', 'feed.xml')
+    ).toBe('https://example.org/my-colony/feed.xml');
   });
 });
 

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -376,12 +376,15 @@ async function runChecks(): Promise<CheckResult[]> {
     }
   };
 
-  const [rootRes, robotsRes, sitemapRes, activityRes] = await Promise.all([
-    fetchWithTimeout(baseUrl),
-    fetchWithTimeout(`${baseUrl}/robots.txt`),
-    fetchWithTimeout(`${baseUrl}/sitemap.xml`),
-    fetchWithTimeout(`${baseUrl}/data/activity.json`),
-  ]);
+  const feedUrl = resolveDeployedPageUrl(baseUrl, 'feed.xml');
+  const [rootRes, robotsRes, sitemapRes, activityRes, feedRes] =
+    await Promise.all([
+      fetchWithTimeout(baseUrl),
+      fetchWithTimeout(`${baseUrl}/robots.txt`),
+      fetchWithTimeout(`${baseUrl}/sitemap.xml`),
+      fetchWithTimeout(`${baseUrl}/data/activity.json`),
+      fetchWithTimeout(feedUrl),
+    ]);
 
   results.push({
     label: 'Deployed site is reachable',
@@ -411,6 +414,14 @@ async function runChecks(): Promise<CheckResult[]> {
       details: proposalsOk
         ? `GET ${proposalsHubUrl} returned 200`
         : `GET ${proposalsHubUrl} returned ${proposalsHubRes?.status ?? 'no response'}`,
+    },
+    {
+      label: 'Deployed /feed.xml is reachable',
+      ok: feedRes?.status === 200,
+      details:
+        feedRes?.status === 200
+          ? `GET ${feedUrl} returned 200`
+          : `GET ${feedUrl} returned ${feedRes?.status ?? 'no response'}`,
     }
   );
 


### PR DESCRIPTION
Fixes #574

## Summary
- add a deployed `feed.xml` reachability check to `check-visibility.ts`
- keep the status details consistent with the existing `/agents/` and `/proposals/` checks
- extend the resolver test to cover `feed.xml` under nested base-path deployments

## Validation
- `cd web && npm run lint -- scripts/check-visibility.ts scripts/__tests__/check-visibility.test.ts`
- `cd web && npm test -- --run scripts/__tests__/check-visibility.test.ts`
- `cd web && npm run check-visibility -- --json`
