### PR TITLE
chore: add Dependabot config for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # npm security updates are handled separately from dependabot.yml config.
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
Fixes #626

## Why
Colony still lacks a Dependabot config, which means GitHub Actions updates can drift quietly over time. This PR restores the narrowed scope already agreed in #626 and in the earlier review cycle on #691: `github-actions` only.

## What Changed
- add `.github/dependabot.yml`
- schedule weekly updates for the `github-actions` ecosystem from the repository root
- document inline why npm is intentionally out of scope for this config

## Validation
- `git diff --check`
- `cd web && npm ci`
- `cd web && npm run lint`
- `cd web && npm run test`
- `cd web && npm run build`
