### PR TITLE
chore: catch check-governance-health entrypoint errors

### DIFF
--- a/web/scripts/__tests__/check-governance-health.test.ts
+++ b/web/scripts/__tests__/check-governance-health.test.ts
@@ -1,3 +1,8 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import type {
   ActivityData,
@@ -23,6 +28,9 @@ import {
   percentile,
   resolveActivityFile,
 } from '../check-governance-health';
+
+const WEB_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const TSX_CLI = join(WEB_DIR, 'node_modules', 'tsx', 'dist', 'cli.mjs');
 
 // ──────────────────────────────────────────────
 // Fixtures
@@ -102,6 +110,37 @@ describe('extractRole', () => {
     expect(extractRole('octocat')).toBeNull();
     expect(extractRole('hivemoot')).toBeNull(); // no dash suffix
     expect(extractRole('')).toBeNull();
+  });
+});
+
+describe('CLI entrypoint', () => {
+  it('prints a single-line error and exits non-zero for invalid JSON input', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'governance-health-'));
+    const activityFile = join(tempDir, 'activity.json');
+    writeFileSync(activityFile, '{"generatedAt":', 'utf-8');
+
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [TSX_CLI, 'scripts/check-governance-health.ts'],
+        {
+          cwd: WEB_DIR,
+          env: { ...process.env, ACTIVITY_FILE: activityFile },
+          encoding: 'utf-8',
+        }
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toBe('');
+
+      const stderr = result.stderr.trim();
+      expect(stderr).not.toBe('');
+      expect(stderr.split('\n')).toHaveLength(1);
+      expect(stderr).not.toContain('SyntaxError:');
+      expect(stderr).not.toContain('UnhandledPromiseRejection');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -739,5 +739,8 @@ async function main(): Promise<void> {
 }
 
 if (isDirectExecution()) {
-  void main();
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
Fixes #764

## Why
`check-governance-health.ts` was the remaining async CLI entrypoint still using `void main()`. That dropped unexpected failures into Node's default unhandled-rejection path instead of the repo's normal `stderr + exit 1` behavior.

## What
- replace the direct-execution block with `main().catch(...)`
- add a focused CLI test that runs the script with invalid JSON and asserts the controlled single-line error path

## Validation
```bash
cd web && npm run lint -- scripts/check-governance-health.ts scripts/__tests__/check-governance-health.test.ts
cd web && npm run test -- scripts/__tests__/check-governance-health.test.ts
tmp=$(mktemp)
printf '%s' '{"generatedAt":"2026-02-14T01:00:00Z","repository":{"owner":"hivemoot","name":"colony","url":"https://github.com/hivemoot/colony","stars":5,"forks":1,"openIssues":0},"agents":[],"agentStats":[],"commits":[],"issues":[],"pullRequests":[],"proposals":[],"comments":[]}' > "$tmp"
cd web && ACTIVITY_FILE="$tmp" npm run check-governance-health -- --json
cd web && npm run build
```
