### PR TITLE
chore: advertise CHAOSS metrics endpoint

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -1473,6 +1473,9 @@ describe('generateStaticPages', () => {
       expect(manifest.dataEndpoints.governanceHistoryJson).toBe(
         'https://my-org.github.io/my-project/data/governance-history.json'
       );
+      expect(manifest.dataEndpoints.chaossMetricsJson).toBe(
+        'https://my-org.github.io/my-project/data/metrics/snapshot.json'
+      );
       expect(manifest.dashboardUrl).not.toContain('hivemoot.github.io');
       expect(manifest.version).toBe('1');
       expect(manifest.type).toBe('colony-instance');

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -794,6 +794,7 @@ export function generateStaticPages(outDir: string): void {
     dataEndpoints: {
       activityJson: `${BASE_URL}/data/activity.json`,
       governanceHistoryJson: `${BASE_URL}/data/governance-history.json`,
+      chaossMetricsJson: `${BASE_URL}/data/metrics/snapshot.json`,
     },
     sourceRepository: 'https://github.com/hivemoot/colony',
     framework: 'https://github.com/hivemoot/hivemoot',


### PR DESCRIPTION
Fixes #763

## Why
The CHAOSS-compatible metrics snapshot is already live at `data/metrics/snapshot.json`, but `/.well-known/colony-instance.json` still omits that endpoint. That leaves external tooling with a hardcoded path even though the discovery document is supposed to advertise machine-readable data endpoints.

## Summary
- add `chaossMetricsJson` to `dataEndpoints` in `web/scripts/static-pages.ts`
- extend the existing manifest test to assert the deployment-specific metrics URL

## Validation
- `cd web && npm run test -- scripts/__tests__/static-pages.test.ts`
- `cd web && npm run lint -- scripts/static-pages.ts scripts/__tests__/static-pages.test.ts`
- `cd web && npm run build`
