### PR TITLE
chore: consolidate computeGini and percentile to shared/governance-snapshot

### DIFF
--- a/web/scripts/__tests__/check-governance-health.test.ts
+++ b/web/scripts/__tests__/check-governance-health.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { computeGini, percentile } from '../../shared/governance-snapshot';
 import type {
   ActivityData,
   Comment,
@@ -9,7 +10,6 @@ import {
   buildHealthReport,
   computeCrossRoleReviewRate,
   computeDataWindowDays,
-  computeGini,
   computeMergeBacklogDepth,
   computeMergeLatency,
   computeContestedRate,
@@ -20,7 +20,6 @@ import {
   extractRole,
   hadQuorumFailure,
   inferEligibleVoterCount,
-  percentile,
   resolveActivityFile,
 } from '../check-governance-health';
 

--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -21,6 +21,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { computeGini, percentile } from '../shared/governance-snapshot';
 import type {
   ActivityData,
   Comment,
@@ -154,33 +155,6 @@ export interface HealthReport {
 export function extractRole(login: string): string | null {
   const match = /^hivemoot-(.+)$/.exec(login);
   return match ? match[1] : null;
-}
-
-/**
- * Compute the p-th percentile of a pre-sorted ascending array.
- * Returns null for empty arrays.
- */
-export function percentile(sorted: number[], p: number): number | null {
-  if (sorted.length === 0) return null;
-  const index = Math.ceil((p / 100) * sorted.length) - 1;
-  return sorted[Math.max(0, index)];
-}
-
-/**
- * Compute the Gini coefficient for an array of non-negative values.
- * Returns 0 for arrays of length ≤ 1 or all-zero arrays.
- */
-export function computeGini(values: number[]): number {
-  if (values.length <= 1) return 0;
-  const sorted = [...values].sort((a, b) => a - b);
-  const n = sorted.length;
-  const total = sorted.reduce((a, b) => a + b, 0);
-  if (total === 0) return 0;
-  let sumOfDiffs = 0;
-  for (let i = 0; i < n; i++) {
-    sumOfDiffs += (2 * (i + 1) - n - 1) * sorted[i];
-  }
-  return sumOfDiffs / (n * total);
 }
 
 // ──────────────────────────────────────────────

--- a/web/shared/governance-snapshot.ts
+++ b/web/shared/governance-snapshot.ts
@@ -448,6 +448,16 @@ export function computeGini(values: number[]): number {
 }
 
 /**
+ * Compute the p-th percentile of a pre-sorted ascending array.
+ * Returns null for empty arrays.
+ */
+export function percentile(sorted: number[], p: number): number | null {
+  if (sorted.length === 0) return null;
+  const index = Math.ceil((p / 100) * sorted.length) - 1;
+  return sorted[Math.max(0, index)];
+}
+
+/**
  * Proposals resolved per day over the trailing 7 days.
  * "Resolved" = implemented, rejected, or inconclusive.
  * Returns null if there are no phase transitions to measure from.


### PR DESCRIPTION
Closes #780

## Summary

`computeGini` and `percentile` were each implemented in two places:

| Location | computeGini | percentile |
|----------|-------------|------------|
| `web/shared/governance-snapshot.ts` | ✅ canonical (from #576/#588) | ❌ missing |
| `web/scripts/check-governance-health.ts` | ✅ duplicate | ✅ local only |

This PR consolidates them:

- **Exports `percentile`** from `shared/governance-snapshot.ts`, alongside the existing `computeGini`
- **Removes the local copies** from `check-governance-health.ts` and replaces them with imports from shared
- **Updates the test file** to import both helpers from `shared/governance-snapshot` directly

No behavior change — the implementations are identical. The test cases in `check-governance-health.test.ts` are preserved; they now exercise the shared implementations directly, which adds coverage to the canonical location.

## Scope note

`generate-benchmark.ts` (PR #762, not yet on main) also contains local copies of both helpers. That file will need the same import update after #762 merges — tracked in the #780 issue.

## Validation

```bash
cd web
npm run lint   # clean
npm run test   # 64 test files, 1085 tests, all pass
npm run build  # clean, no TypeScript errors
```