### PR TITLE
fix: add manifest link to static pages

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -95,6 +95,9 @@ describe('generateStaticPages', () => {
     // breadcrumb links to /proposals/ hub, not the SPA hash
     expect(html).toContain('href="/colony/proposals/"');
     expect(html).toContain('>Proposals<');
+    expect(html).toContain(
+      'rel="manifest" href="/colony/manifest.webmanifest"'
+    );
   });
 
   it('generates agent pages', () => {
@@ -127,6 +130,9 @@ describe('generateStaticPages', () => {
     expect(html).toContain('50'); // commits
     expect(html).toContain('20'); // PRs merged
     expect(html).toContain('30'); // reviews
+    expect(html).toContain(
+      'rel="manifest" href="/colony/manifest.webmanifest"'
+    );
   });
 
   it('generates agents index page', () => {
@@ -192,6 +198,9 @@ describe('generateStaticPages', () => {
 
     const html = readFileSync(join(TEST_OUT, 'agents', 'index.html'), 'utf-8');
     expect(html).toContain('No agents yet.');
+    expect(html).toContain(
+      'rel="manifest" href="/colony/manifest.webmanifest"'
+    );
   });
 
   it('agent breadcrumb links to /agents/', () => {

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -210,6 +210,7 @@ function htmlShell(meta: PageMeta, content: string): string {
   <link rel="canonical" href="${escapeHtml(fullUrl)}" />
   <link rel="icon" href="${basePath()}favicon.ico" sizes="any" />
   <link rel="apple-touch-icon" sizes="180x180" href="${basePath()}apple-touch-icon.png" />${meta.extraHeadTags ? `\n  ${meta.extraHeadTags}` : ''}
+  <link rel="manifest" href="${basePath()}manifest.webmanifest" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="${escapeHtml(fullUrl)}" />
   <meta property="og:title" content="${escapeHtml(meta.title)}" />

--- a/web/scripts/vite-colony-html-plugin.ts
+++ b/web/scripts/vite-colony-html-plugin.ts
@@ -84,8 +84,10 @@ export function transformHtml(html: string, config: ColonyConfig): string {
  *
  * Uses enforce:'pre' + order:'pre' so placeholder replacement runs before
  * Vite's own HTML transforms. Absolute URLs (canonical, OG, Twitter) are
- * left alone by Vite. The manifest href is emitted as a relative path
+ * left alone by Vite. The homepage manifest href is emitted as a relative path
  * ('manifest.webmanifest') so Vite's base-prefixing applies exactly once.
+ * Static pages are generated outside Vite's HTML transform and therefore emit
+ * their own base-prefixed manifest path directly.
  */
 export function colonyHtmlPlugin(): Plugin {
   const config = resolveColonyConfig();


### PR DESCRIPTION
Fixes #781

## Why
Static pages generated through `htmlShell()` were missing `<link rel="manifest">`, so `/proposals/`, `/agents/`, and their detail pages did not advertise the web manifest even though the homepage already did. That creates avoidable PWA/metadata inconsistency on non-homepage entry points.

This is a small throughput-friendly fix: recent merged PR cycle time is about p50 72.5h / p90 182.4h, so the change stays narrow and avoids touching the already-correct homepage Vite path handling.

## What changed
- add a base-prefixed manifest link to the static page shell
- add regression assertions for generated proposal, agent, and agents index pages
- clarify in the Vite plugin comment why homepage and static pages use different manifest href strategies

## Validation
- `cd web && npm test -- scripts/__tests__/static-pages.test.ts scripts/__tests__/vite-colony-html-plugin.test.ts`
- `cd web && npx eslint scripts/static-pages.ts scripts/vite-colony-html-plugin.ts scripts/__tests__/static-pages.test.ts`
- `cd web && npm run build`
