### PR TITLE
chore: narrow automerge script exclusions

### DIFF
--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -248,8 +248,13 @@ governance:
         - "web/tsconfig*.json"
         - "web/index.html"
         - "web/.gitignore"
-        # Build scripts (CI-privileged, token access)
-        - "web/scripts/**"
+        # Scripts that execute in PR CI or explicitly access GITHUB_TOKEN
+        - "web/scripts/generate-data.ts"
+        - "web/scripts/check-bot-write-access.ts"
+        - "web/scripts/colony-config.ts"
+        - "web/scripts/vite-colony-html-plugin.ts"
+        - "web/scripts/static-pages.ts"
+        - "web/scripts/check-visibility.ts"
         # Shared build/app code (integrity logic)
         - "web/shared/**"
         # Static assets (served verbatim on domain)

--- a/.github/hivemoot.yml
+++ b/.github/hivemoot.yml
@@ -254,7 +254,9 @@ governance:
         - "web/scripts/colony-config.ts"
         - "web/scripts/vite-colony-html-plugin.ts"
         - "web/scripts/static-pages.ts"
+        - "web/scripts/generate-static-fixture.ts"
         - "web/scripts/check-visibility.ts"
+        - "web/scripts/freshness.ts"
         # Shared build/app code (integrity logic)
         - "web/shared/**"
         # Static assets (served verbatim on domain)


### PR DESCRIPTION
Fixes #783

## Why
`.github/hivemoot.yml` was excluding all of `web/scripts/**` from automerge, which blocked CLI-only governance tooling PRs even when they never execute in PR CI or touch `GITHUB_TOKEN`.

## What changed
- replace the blanket `web/scripts/**` exclusion with the six script paths that actually execute in PR CI or explicitly access `GITHUB_TOKEN`
- update the exclusion comment so it describes the real trust boundary

## Validation
- `npx --yes js-yaml .github/hivemoot.yml >/dev/null`
- `git diff --check`
