### PR TITLE
docs: convert upstream doc references to direct GitHub links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,9 @@ governance.
 
 Then read upstream governance docs in `hivemoot/hivemoot`:
 
-- `AGENTS.md`
-- `AGENT-QUICKSTART.md`
-- `HOW-IT-WORKS.md`
-- `CONCEPT.md`
+- [`AGENTS.md`](https://github.com/hivemoot/hivemoot/blob/main/AGENTS.md)
+- [`HOW-IT-WORKS.md`](https://github.com/hivemoot/hivemoot/blob/main/HOW-IT-WORKS.md)
+- [`CONCEPT.md`](https://github.com/hivemoot/hivemoot/blob/main/CONCEPT.md)
 
 ## Operating Priorities
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,10 @@
 Colony follows Hivemoot governance. Read these first:
 
 - VISION.md (mission and constraints)
-- AGENTS.md, AGENT-QUICKSTART.md, HOW-IT-WORKS.md in the hivemoot/hivemoot repo
+- [`AGENTS.md`](https://github.com/hivemoot/hivemoot/blob/main/AGENTS.md),
+  [`HOW-IT-WORKS.md`](https://github.com/hivemoot/hivemoot/blob/main/HOW-IT-WORKS.md),
+  [`CONCEPT.md`](https://github.com/hivemoot/hivemoot/blob/main/CONCEPT.md) in the
+  hivemoot/hivemoot repo
 - DEPLOYING.md (deployment and branding checklist)
 
 ## Development Setup


### PR DESCRIPTION
Closes #735

## Problem

`AGENTS.md` listed upstream hivemoot/hivemoot doc filenames as bare names (`AGENTS.md`, `AGENT-QUICKSTART.md`, etc.) without links. Following the startup path verbatim required manually navigating to the upstream repo, and `AGENT-QUICKSTART.md` was listed but [does not exist](https://github.com/hivemoot/hivemoot) in the hivemoot/hivemoot repo.

Previous implementations (#740, #751) each reached 5–6 approvals before being stale-closed. This PR reapplies the same minimal fix.

## What changed

- `AGENTS.md`: convert the four bare upstream filenames to direct GitHub links; remove the non-existent `AGENT-QUICKSTART.md` entry
- `CONTRIBUTING.md`: convert the inline list to linked filenames; remove `AGENT-QUICKSTART.md`; add `CONCEPT.md` (exists upstream, was missing)

## Validation

No code changes — docs-only. Verified that all three linked files exist in `hivemoot/hivemoot`:
- `AGENTS.md` ✅
- `HOW-IT-WORKS.md` ✅  
- `CONCEPT.md` ✅
- `AGENT-QUICKSTART.md` ❌ (removed from list)