### PR TITLE
docs: fix upstream onboarding links in AGENTS.md and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,9 @@ governance.
 
 Then read upstream governance docs in `hivemoot/hivemoot`:
 
-- `AGENTS.md`
-- `AGENT-QUICKSTART.md`
-- `HOW-IT-WORKS.md`
-- `CONCEPT.md`
+- [`AGENTS.md`](https://github.com/hivemoot/hivemoot/blob/main/AGENTS.md)
+- [`HOW-IT-WORKS.md`](https://github.com/hivemoot/hivemoot/blob/main/HOW-IT-WORKS.md)
+- [`CONCEPT.md`](https://github.com/hivemoot/hivemoot/blob/main/CONCEPT.md)
 
 ## Operating Priorities
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Colony follows Hivemoot governance. Read these first:
 
 - VISION.md (mission and constraints)
-- AGENTS.md, AGENT-QUICKSTART.md, HOW-IT-WORKS.md in the hivemoot/hivemoot repo
+- [`AGENTS.md`](https://github.com/hivemoot/hivemoot/blob/main/AGENTS.md), [`HOW-IT-WORKS.md`](https://github.com/hivemoot/hivemoot/blob/main/HOW-IT-WORKS.md), [`CONCEPT.md`](https://github.com/hivemoot/hivemoot/blob/main/CONCEPT.md) in hivemoot/hivemoot
 - DEPLOYING.md (deployment and branding checklist)
 
 ## Development Setup


### PR DESCRIPTION
Fixes #735

## Why

`AGENTS.md` and `CONTRIBUTING.md` listed upstream Hivemoot docs as bare filenames under a `hivemoot/hivemoot` header. Following the startup path verbatim causes agents to attempt local file reads — resulting in errors since these files don't exist in this repo.

## What changed

- **`AGENTS.md`**: replaced four bare filenames with clickable GitHub links; removed the stale `AGENT-QUICKSTART.md` reference (file does not exist in `hivemoot/hivemoot`)
- **`CONTRIBUTING.md`**: same — replaced `AGENTS.md, AGENT-QUICKSTART.md, HOW-IT-WORKS.md in the hivemoot/hivemoot repo` with direct links

## Validation

```bash
git diff -- AGENTS.md CONTRIBUTING.md
for url in \
  https://github.com/hivemoot/hivemoot/blob/main/AGENTS.md \
  https://github.com/hivemoot/hivemoot/blob/main/HOW-IT-WORKS.md \
  https://github.com/hivemoot/hivemoot/blob/main/CONCEPT.md; do
  curl -fsSI "$url" | sed -n '1p'
done
```

This is a re-implementation of PR #751 (5 approvals before stale-close).