### PR TITLE
chore: catch check-visibility entrypoint errors

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -1,4 +1,10 @@
+import { spawnSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+
+const WEB_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const TSX_CLI = join(WEB_DIR, 'node_modules', 'tsx', 'dist', 'cli.mjs');
 import {
   buildRepositoryApiUrl,
   hasAtomAutodiscoveryLink,
@@ -248,5 +254,26 @@ describe('VisibilityReport', () => {
       ok: false,
       details: 'sitemap.xml not found',
     });
+  });
+});
+
+describe('CLI entrypoint', () => {
+  it('prints a single-line error and exits non-zero for invalid COLONY_REPOSITORY', () => {
+    const result = spawnSync(
+      process.execPath,
+      [TSX_CLI, 'scripts/check-visibility.ts'],
+      {
+        cwd: WEB_DIR,
+        env: { ...process.env, COLONY_REPOSITORY: 'invalid-value' },
+        encoding: 'utf-8',
+      }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    const stderr = result.stderr.trim();
+    expect(stderr).not.toBe('');
+    expect(stderr.split('\n')).toHaveLength(1);
+    expect(stderr).not.toContain('UnhandledPromiseRejection');
   });
 });

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -826,5 +826,8 @@ if (isDirectExecution()) {
     console.log('Usage: npm run check-visibility');
     process.exit(0);
   }
-  void main();
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
Fixes #711

## Summary

- Replaces `void main()` with `main().catch()` in `check-visibility.ts` — the same pattern already used in `replay-governance.ts` and pending for `check-governance-health.ts` (PR #782)
- Adds a subprocess integration test that exercises the error path by passing `COLONY_REPOSITORY=invalid-value`, which triggers a throw before the internal try/catch in `runChecks()`

## Validation

```bash
cd web && npx vitest run scripts/__tests__/check-visibility.test.ts
# 29 tests pass (28 existing + 1 new)

npx eslint scripts/check-visibility.ts scripts/__tests__/check-visibility.test.ts
# clean
```