### PR TITLE
feat: add Colony Registry — static peer-instance directory

### DIFF
--- a/web/colony-registry.json
+++ b/web/colony-registry.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1",
+  "updatedAt": "2026-04-12",
+  "entries": [
+    {
+      "name": "hivemoot/colony",
+      "instanceUrl": "https://hivemoot.github.io/colony",
+      "dataEndpoints": {
+        "activityJson": "https://hivemoot.github.io/colony/data/activity.json",
+        "governanceHistoryJson": "https://hivemoot.github.io/colony/data/governance-history.json",
+        "chaossMetricsJson": "https://hivemoot.github.io/colony/data/metrics/snapshot.json"
+      },
+      "federationStubUrl": "https://hivemoot.github.io/colony/.well-known/colony-instance.json",
+      "schemaVersion": "1",
+      "registeredAt": "2026-02-01",
+      "description": "The canonical Colony instance — the first open-source project built entirely by autonomous agents."
+    }
+  ]
+}

--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,8 @@
     "external-outreach-metrics": "tsx scripts/external-outreach-metrics.ts",
     "fast-track-candidates": "tsx scripts/fast-track-candidates.ts",
     "replay-governance": "tsx scripts/replay-governance.ts",
-    "check-governance-health": "tsx scripts/check-governance-health.ts"
+    "check-governance-health": "tsx scripts/check-governance-health.ts",
+    "verify-registry": "tsx scripts/verify-registry.ts"
   },
   "dependencies": {
     "react": "^19.2.0",

--- a/web/scripts/__tests__/verify-registry.test.ts
+++ b/web/scripts/__tests__/verify-registry.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it } from 'vitest';
+import { buildSchemaChecks, parseArgs } from '../verify-registry';
+import {
+  validateRegistry,
+  validateRegistryEntry,
+} from '../../shared/colony-registry';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Source registry lives at web/colony-registry.json (two levels up from __tests__)
+const REAL_REGISTRY = join(__dirname, '..', '..', 'colony-registry.json');
+
+// ── validateRegistryEntry ─────────────────────────────────────────────────────
+
+describe('validateRegistryEntry', () => {
+  const validEntry = {
+    name: 'hivemoot/colony',
+    instanceUrl: 'https://hivemoot.github.io/colony',
+    dataEndpoints: {
+      activityJson: 'https://hivemoot.github.io/colony/data/activity.json',
+      governanceHistoryJson:
+        'https://hivemoot.github.io/colony/data/governance-history.json',
+    },
+    schemaVersion: '1',
+    registeredAt: '2026-02-01',
+  };
+
+  it('accepts a minimal valid entry', () => {
+    const { valid, errors } = validateRegistryEntry(validEntry, 0);
+    expect(valid).toBe(true);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts an entry with all optional fields', () => {
+    const entry = {
+      ...validEntry,
+      dataEndpoints: {
+        ...validEntry.dataEndpoints,
+        chaossMetricsJson:
+          'https://hivemoot.github.io/colony/data/metrics/snapshot.json',
+      },
+      federationStubUrl:
+        'https://hivemoot.github.io/colony/.well-known/colony-instance.json',
+      description: 'A test Colony instance.',
+    };
+    const { valid, errors } = validateRegistryEntry(entry, 0);
+    expect(valid).toBe(true);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects a missing name', () => {
+    const { valid, errors } = validateRegistryEntry(
+      { ...validEntry, name: '' },
+      0
+    );
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('name'))).toBe(true);
+  });
+
+  it('rejects an http instanceUrl', () => {
+    const { valid, errors } = validateRegistryEntry(
+      { ...validEntry, instanceUrl: 'http://insecure.example.com' },
+      0
+    );
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('instanceUrl'))).toBe(true);
+  });
+
+  it('rejects a missing instanceUrl', () => {
+    const { valid, errors } = validateRegistryEntry(
+      { ...validEntry, instanceUrl: undefined },
+      0
+    );
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('instanceUrl'))).toBe(true);
+  });
+
+  it('rejects an invalid registeredAt', () => {
+    const { valid, errors } = validateRegistryEntry(
+      { ...validEntry, registeredAt: 'not-a-date' },
+      0
+    );
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('registeredAt'))).toBe(true);
+  });
+
+  it('rejects a missing dataEndpoints', () => {
+    const { valid, errors } = validateRegistryEntry(
+      { ...validEntry, dataEndpoints: null },
+      0
+    );
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('dataEndpoints'))).toBe(true);
+  });
+
+  it('rejects a non-https activityJson', () => {
+    const { valid, errors } = validateRegistryEntry(
+      {
+        ...validEntry,
+        dataEndpoints: {
+          ...validEntry.dataEndpoints,
+          activityJson: 'http://example.com/activity.json',
+        },
+      },
+      0
+    );
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('activityJson'))).toBe(true);
+  });
+
+  it('rejects an invalid optional chaossMetricsJson', () => {
+    const { valid, errors } = validateRegistryEntry(
+      {
+        ...validEntry,
+        dataEndpoints: {
+          ...validEntry.dataEndpoints,
+          chaossMetricsJson: 'not-a-url',
+        },
+      },
+      0
+    );
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('chaossMetricsJson'))).toBe(true);
+  });
+
+  it('rejects an invalid optional federationStubUrl', () => {
+    const { valid, errors } = validateRegistryEntry(
+      { ...validEntry, federationStubUrl: 'ftp://bad.example.com' },
+      0
+    );
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('federationStubUrl'))).toBe(true);
+  });
+
+  it('rejects a non-string description', () => {
+    const { valid, errors } = validateRegistryEntry(
+      { ...validEntry, description: 42 },
+      0
+    );
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.includes('description'))).toBe(true);
+  });
+
+  it('returns an error when entry is not an object', () => {
+    const { valid, errors } = validateRegistryEntry('not-an-object', 0);
+    expect(valid).toBe(false);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+// ── validateRegistry ──────────────────────────────────────────────────────────
+
+describe('validateRegistry', () => {
+  const validEntry = {
+    name: 'hivemoot/colony',
+    instanceUrl: 'https://hivemoot.github.io/colony',
+    dataEndpoints: {
+      activityJson: 'https://hivemoot.github.io/colony/data/activity.json',
+      governanceHistoryJson:
+        'https://hivemoot.github.io/colony/data/governance-history.json',
+    },
+    schemaVersion: '1',
+    registeredAt: '2026-02-01',
+  };
+
+  const validEntry2 = {
+    name: 'example/other-colony',
+    instanceUrl: 'https://example.github.io/other-colony',
+    dataEndpoints: {
+      activityJson: 'https://example.github.io/other-colony/data/activity.json',
+      governanceHistoryJson:
+        'https://example.github.io/other-colony/data/governance-history.json',
+    },
+    schemaVersion: '1',
+    registeredAt: '2026-03-01',
+  };
+
+  it('accepts a valid registry', () => {
+    const raw = {
+      schemaVersion: '1',
+      updatedAt: '2026-03-18',
+      entries: [validEntry],
+    };
+    const { registry, errors } = validateRegistry(raw);
+    expect(errors).toHaveLength(0);
+    expect(registry).not.toBeNull();
+    expect(registry?.entries).toHaveLength(1);
+  });
+
+  it('accepts an empty entries array', () => {
+    const raw = {
+      schemaVersion: '1',
+      updatedAt: '2026-03-18',
+      entries: [],
+    };
+    const { registry, errors } = validateRegistry(raw);
+    expect(errors).toHaveLength(0);
+    expect(registry?.entries).toHaveLength(0);
+  });
+
+  it('accepts two distinct entries', () => {
+    const raw = {
+      schemaVersion: '1',
+      updatedAt: '2026-04-01',
+      entries: [validEntry, validEntry2],
+    };
+    const { registry, errors } = validateRegistry(raw);
+    expect(errors).toHaveLength(0);
+    expect(registry?.entries).toHaveLength(2);
+  });
+
+  it('rejects a missing schemaVersion', () => {
+    const { errors } = validateRegistry({
+      updatedAt: '2026-03-18',
+      entries: [],
+    });
+    expect(errors.some((e) => e.includes('schemaVersion'))).toBe(true);
+  });
+
+  it('rejects a missing updatedAt', () => {
+    const { errors } = validateRegistry({
+      schemaVersion: '1',
+      entries: [],
+    });
+    expect(errors.some((e) => e.includes('updatedAt'))).toBe(true);
+  });
+
+  it('rejects a non-array entries field', () => {
+    const { errors } = validateRegistry({
+      schemaVersion: '1',
+      updatedAt: '2026-03-18',
+      entries: 'not-an-array',
+    });
+    expect(errors.some((e) => e.includes('entries'))).toBe(true);
+  });
+
+  it('propagates entry-level errors', () => {
+    const { errors } = validateRegistry({
+      schemaVersion: '1',
+      updatedAt: '2026-03-18',
+      entries: [{ ...validEntry, name: '' }],
+    });
+    expect(errors.some((e) => e.includes('entries[0]'))).toBe(true);
+  });
+
+  it('rejects null input', () => {
+    const { registry, errors } = validateRegistry(null);
+    expect(registry).toBeNull();
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  // ── Uniqueness validation (issue #696) ──────────────────────────────────────
+
+  it('rejects duplicate name across entries', () => {
+    const raw = {
+      schemaVersion: '1',
+      updatedAt: '2026-04-01',
+      entries: [
+        validEntry,
+        { ...validEntry2, name: validEntry.name }, // duplicate name
+      ],
+    };
+    const { registry, errors } = validateRegistry(raw);
+    expect(registry).toBeNull();
+    expect(errors.some((e) => e.includes('duplicate name'))).toBe(true);
+    expect(errors.some((e) => e.includes(validEntry.name))).toBe(true);
+  });
+
+  it('rejects duplicate instanceUrl across entries', () => {
+    const raw = {
+      schemaVersion: '1',
+      updatedAt: '2026-04-01',
+      entries: [
+        validEntry,
+        { ...validEntry2, instanceUrl: validEntry.instanceUrl }, // duplicate URL
+      ],
+    };
+    const { registry, errors } = validateRegistry(raw);
+    expect(registry).toBeNull();
+    expect(errors.some((e) => e.includes('duplicate instanceUrl'))).toBe(true);
+    expect(errors.some((e) => e.includes(validEntry.instanceUrl))).toBe(true);
+  });
+
+  it('allows two entries with different names and instanceUrls', () => {
+    const raw = {
+      schemaVersion: '1',
+      updatedAt: '2026-04-01',
+      entries: [validEntry, validEntry2],
+    };
+    const { registry, errors } = validateRegistry(raw);
+    expect(errors.filter((e) => e.includes('duplicate'))).toHaveLength(0);
+    expect(registry).not.toBeNull();
+  });
+});
+
+// ── buildSchemaChecks ─────────────────────────────────────────────────────────
+
+describe('buildSchemaChecks', () => {
+  it('fails gracefully when the registry file does not exist', () => {
+    const checks = buildSchemaChecks('/nonexistent/path/colony-registry.json');
+    const fileCheck = checks.find((c) => c.label === 'registry file exists');
+    expect(fileCheck?.ok).toBe(false);
+  });
+
+  it('passes all schema checks for the real registry file', () => {
+    const checks = buildSchemaChecks(REAL_REGISTRY);
+    const failed = checks.filter((c) => !c.ok);
+    expect(failed).toHaveLength(0);
+  });
+
+  it('includes a per-entry schema check for each entry in the real registry', () => {
+    const checks = buildSchemaChecks(REAL_REGISTRY);
+    const entryChecks = checks.filter((c) => c.label.includes('schema'));
+    expect(entryChecks.length).toBeGreaterThan(0);
+  });
+});
+
+// ── parseArgs ─────────────────────────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  it('defaults fetch and json to false', () => {
+    const opts = parseArgs([]);
+    expect(opts.fetch).toBe(false);
+    expect(opts.json).toBe(false);
+  });
+
+  it('sets fetch=true when --fetch is present', () => {
+    expect(parseArgs(['--fetch']).fetch).toBe(true);
+  });
+
+  it('sets json=true when --json is present', () => {
+    expect(parseArgs(['--json']).json).toBe(true);
+  });
+
+  it('reads REGISTRY_FILE from env', () => {
+    const opts = parseArgs([], { REGISTRY_FILE: '/custom/path.json' });
+    expect(opts.registryFile).toBe('/custom/path.json');
+  });
+
+  it('uses default registry file when REGISTRY_FILE is unset', () => {
+    const opts = parseArgs([], {});
+    expect(opts.registryFile).toContain('colony-registry.json');
+  });
+});

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -9,9 +9,12 @@
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
-import { resolve, join } from 'node:path';
+import { resolve, join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Proposal, AgentStats, ActivityData } from '../shared/types';
 import { resolveDeployedUrl, resolveGitHubUrl } from './colony-config';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
 const BASE_URL = resolveDeployedUrl();
 
@@ -804,7 +807,27 @@ export function generateStaticPages(outDir: string): void {
     JSON.stringify(colonyInstanceManifest, null, 2) + '\n'
   );
 
-  console.log(
-    `[static-pages] Generated ${proposalCount} proposal pages, ${agentCount} agent pages, proposals index, agents index, sitemap.xml, robots.txt, feed.xml, and .well-known/colony-instance.json`
-  );
+  // Copy colony-registry.json to the data directory so it is served at
+  // <base>/data/colony-registry.json alongside the other data endpoints.
+  // The source file (web/colony-registry.json) is manually curated and
+  // committed; this step makes it available at the expected public URL.
+  const registrySource = join(SCRIPT_DIR, '..', 'colony-registry.json');
+  if (existsSync(registrySource)) {
+    const dataDir = join(outDir, 'data');
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(
+      join(dataDir, 'colony-registry.json'),
+      readFileSync(registrySource, 'utf-8')
+    );
+    console.log(
+      `[static-pages] Generated ${proposalCount} proposal pages, ${agentCount} agent pages, proposals index, agents index, sitemap.xml, robots.txt, feed.xml, .well-known/colony-instance.json, and data/colony-registry.json`
+    );
+  } else {
+    console.warn(
+      '[static-pages] WARNING: colony-registry.json not found — data/colony-registry.json will not be in the build output'
+    );
+    console.log(
+      `[static-pages] Generated ${proposalCount} proposal pages, ${agentCount} agent pages, proposals index, agents index, sitemap.xml, robots.txt, feed.xml, and .well-known/colony-instance.json`
+    );
+  }
 }

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -13,6 +13,7 @@ import { resolve, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Proposal, AgentStats, ActivityData } from '../shared/types';
 import { resolveDeployedUrl, resolveGitHubUrl } from './colony-config';
+import { validateRegistry } from '../shared/colony-registry';
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -815,9 +816,16 @@ export function generateStaticPages(outDir: string): void {
   if (existsSync(registrySource)) {
     const dataDir = join(outDir, 'data');
     mkdirSync(dataDir, { recursive: true });
+    const registryRaw = JSON.parse(readFileSync(registrySource, 'utf-8'));
+    const { errors: registryErrors } = validateRegistry(registryRaw);
+    if (registryErrors.length > 0) {
+      throw new Error(
+        `[static-pages] colony-registry.json is invalid:\n  ${registryErrors.join('\n  ')}`
+      );
+    }
     writeFileSync(
       join(dataDir, 'colony-registry.json'),
-      readFileSync(registrySource, 'utf-8')
+      JSON.stringify(registryRaw, null, 2) + '\n'
     );
     console.log(
       `[static-pages] Generated ${proposalCount} proposal pages, ${agentCount} agent pages, proposals index, agents index, sitemap.xml, robots.txt, feed.xml, .well-known/colony-instance.json, and data/colony-registry.json`

--- a/web/scripts/verify-registry.ts
+++ b/web/scripts/verify-registry.ts
@@ -1,0 +1,307 @@
+/**
+ * Colony Registry verifier — CLI script.
+ *
+ * Reads the source registry at `web/colony-registry.json` (or the path in
+ * REGISTRY_FILE) and:
+ *   1. Validates the registry schema (all required fields, correct types,
+ *      unique name/instanceUrl across entries).
+ *   2. Optionally fetches each entry's federation stub and data endpoints to
+ *      confirm they are reachable (requires --fetch flag; skipped by default
+ *      to avoid network calls in CI lint runs).
+ *
+ * The source registry lives at `web/colony-registry.json` and is copied to
+ * `public/data/colony-registry.json` at build time by `static-pages.ts`.
+ *
+ * Usage:
+ *   npm run verify-registry
+ *   npm run verify-registry -- --fetch
+ *   npm run verify-registry -- --json
+ *   npm run verify-registry -- --fetch --json
+ *   npm run verify-registry -- --help
+ *   REGISTRY_FILE=/path/to/colony-registry.json npm run verify-registry
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  validateRegistry,
+  type ColonyRegistryEntry,
+} from '../shared/colony-registry';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// Source registry lives at web/colony-registry.json (committed, manually curated).
+// It is copied to public/data/ at build time.
+const DEFAULT_REGISTRY_FILE = join(__dirname, '..', 'colony-registry.json');
+const FETCH_TIMEOUT_MS = 10_000;
+const FETCH_USER_AGENT = 'colony-registry-verifier';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface RegistryCheckResult {
+  label: string;
+  ok: boolean;
+  details?: string;
+}
+
+export interface RegistryVerifyReport {
+  verifiedAt: string;
+  registryFile: string;
+  summary: {
+    total: number;
+    passed: number;
+    failed: number;
+  };
+  checks: RegistryCheckResult[];
+}
+
+interface CliOptions {
+  fetch: boolean;
+  json: boolean;
+  registryFile: string;
+}
+
+// ── CLI argument parsing ──────────────────────────────────────────────────────
+
+export function parseArgs(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env
+): CliOptions {
+  if (argv.includes('--help')) {
+    printHelp();
+    process.exit(0);
+  }
+
+  const registryFile = env.REGISTRY_FILE?.trim() || DEFAULT_REGISTRY_FILE;
+
+  return {
+    fetch: argv.includes('--fetch'),
+    json: argv.includes('--json'),
+    registryFile,
+  };
+}
+
+function printHelp(): void {
+  console.log(`
+verify-registry — validate and optionally probe Colony registry entries
+
+USAGE
+  npm run verify-registry [-- OPTIONS]
+
+OPTIONS
+  --fetch    Fetch each entry's federation stub and data endpoints to
+             verify they are reachable. Skipped by default (offline mode).
+  --json     Emit a JSON RegistryVerifyReport instead of human-readable output.
+  --help     Show this help text.
+
+ENVIRONMENT
+  REGISTRY_FILE   Path to the registry JSON file.
+                  Default: web/colony-registry.json
+`);
+}
+
+// ── Schema validation ─────────────────────────────────────────────────────────
+
+export function buildSchemaChecks(registryFile: string): RegistryCheckResult[] {
+  const checks: RegistryCheckResult[] = [];
+
+  // File existence
+  if (!existsSync(registryFile)) {
+    checks.push({
+      label: 'registry file exists',
+      ok: false,
+      details: `Not found: ${registryFile}`,
+    });
+    return checks;
+  }
+  checks.push({ label: 'registry file exists', ok: true });
+
+  // JSON parse
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(registryFile, 'utf-8'));
+  } catch (err) {
+    checks.push({
+      label: 'registry parses as JSON',
+      ok: false,
+      details: String(err),
+    });
+    return checks;
+  }
+  checks.push({ label: 'registry parses as JSON', ok: true });
+
+  // Schema validation (includes uniqueness checks)
+  const { errors } = validateRegistry(raw);
+  if (errors.length > 0) {
+    checks.push({
+      label: 'registry schema valid',
+      ok: false,
+      details: errors.join('; '),
+    });
+    return checks;
+  }
+  checks.push({ label: 'registry schema valid', ok: true });
+
+  const registry = raw as { entries: ColonyRegistryEntry[] };
+
+  // Per-entry summary (schema-level only)
+  for (const entry of registry.entries) {
+    checks.push({
+      label: `entry "${entry.name}" schema`,
+      ok: true,
+    });
+  }
+
+  return checks;
+}
+
+// ── Reachability probing ──────────────────────────────────────────────────────
+
+export async function probeUrl(
+  url: string,
+  label: string
+): Promise<RegistryCheckResult> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    const res = await fetch(url, {
+      method: 'HEAD',
+      signal: controller.signal,
+      headers: { 'User-Agent': FETCH_USER_AGENT },
+    });
+    clearTimeout(timer);
+    if (res.ok) {
+      return { label, ok: true };
+    }
+    return {
+      label,
+      ok: false,
+      details: `HTTP ${res.status} ${res.statusText}`,
+    };
+  } catch (err) {
+    return {
+      label,
+      ok: false,
+      details: String(err),
+    };
+  }
+}
+
+export async function buildFetchChecks(
+  registryFile: string
+): Promise<RegistryCheckResult[]> {
+  const checks: RegistryCheckResult[] = [];
+
+  if (!existsSync(registryFile)) {
+    return checks;
+  }
+
+  let registry: { entries: ColonyRegistryEntry[] };
+  try {
+    const raw = JSON.parse(readFileSync(registryFile, 'utf-8'));
+    const { registry: parsed, errors } = validateRegistry(raw);
+    if (!parsed || errors.length > 0) {
+      return checks;
+    }
+    registry = parsed;
+  } catch {
+    return checks;
+  }
+
+  const probes: Promise<RegistryCheckResult>[] = [];
+
+  for (const entry of registry.entries) {
+    const n = entry.name;
+
+    probes.push(
+      probeUrl(
+        entry.dataEndpoints.activityJson,
+        `"${n}" activityJson reachable`
+      )
+    );
+
+    probes.push(
+      probeUrl(
+        entry.dataEndpoints.governanceHistoryJson,
+        `"${n}" governanceHistoryJson reachable`
+      )
+    );
+
+    if (entry.dataEndpoints.chaossMetricsJson) {
+      probes.push(
+        probeUrl(
+          entry.dataEndpoints.chaossMetricsJson,
+          `"${n}" chaossMetricsJson reachable`
+        )
+      );
+    }
+
+    if (entry.federationStubUrl) {
+      probes.push(
+        probeUrl(entry.federationStubUrl, `"${n}" federationStubUrl reachable`)
+      );
+    }
+  }
+
+  const results = await Promise.all(probes);
+  checks.push(...results);
+  return checks;
+}
+
+// ── Report rendering ──────────────────────────────────────────────────────────
+
+function renderHuman(report: RegistryVerifyReport): void {
+  const { summary, checks } = report;
+  for (const check of checks) {
+    const icon = check.ok ? '✓' : '✗';
+    const line = check.details
+      ? `  ${icon} ${check.label}: ${check.details}`
+      : `  ${icon} ${check.label}`;
+    console.log(line);
+  }
+  console.log('');
+  console.log(
+    `${summary.passed}/${summary.total} checks passed` +
+      (summary.failed > 0 ? ` — ${summary.failed} failed` : '')
+  );
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+export async function main(
+  argv: string[] = process.argv.slice(2)
+): Promise<void> {
+  const opts = parseArgs(argv);
+
+  let checks: RegistryCheckResult[] = buildSchemaChecks(opts.registryFile);
+
+  if (opts.fetch) {
+    const fetchChecks = await buildFetchChecks(opts.registryFile);
+    checks = [...checks, ...fetchChecks];
+  }
+
+  const passed = checks.filter((c) => c.ok).length;
+  const failed = checks.filter((c) => !c.ok).length;
+
+  const report: RegistryVerifyReport = {
+    verifiedAt: new Date().toISOString(),
+    registryFile: opts.registryFile,
+    summary: { total: checks.length, passed, failed },
+    checks,
+  };
+
+  if (opts.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    renderHuman(report);
+  }
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/web/scripts/verify-registry.ts
+++ b/web/scripts/verify-registry.ts
@@ -22,7 +22,7 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   validateRegistry,
@@ -301,7 +301,13 @@ export async function main(
   }
 }
 
-main().catch((err: unknown) => {
-  console.error('Fatal error:', err);
-  process.exit(1);
-});
+function isDirectExecution(): boolean {
+  return resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+}
+
+if (isDirectExecution()) {
+  main().catch((err: unknown) => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}

--- a/web/shared/colony-registry.ts
+++ b/web/shared/colony-registry.ts
@@ -1,0 +1,228 @@
+/**
+ * Colony Registry schema types and validation.
+ *
+ * The registry is a static, manually-curated directory of known Colony
+ * instances. It lives at `web/colony-registry.json` (committed source) and is
+ * published at `<deployed-url>/data/colony-registry.json` by the build.
+ *
+ * Colony instances self-register by opening a PR to add their entry.
+ */
+
+export interface ColonyRegistryDataEndpoints {
+  /** URL to this instance's activity.json data file. */
+  activityJson: string;
+  /** URL to this instance's governance-history.json data file. */
+  governanceHistoryJson: string;
+  /**
+   * URL to this instance's CHAOSS metrics snapshot (data/metrics/snapshot.json).
+   * Optional — older Colony deployments may not publish this endpoint.
+   */
+  chaossMetricsJson?: string;
+}
+
+export interface ColonyRegistryEntry {
+  /**
+   * Human-readable name for this instance, typically the GitHub repo slug
+   * (e.g. "hivemoot/colony").
+   */
+  name: string;
+  /**
+   * Base URL of this Colony instance's dashboard (no trailing slash).
+   * Example: "https://hivemoot.github.io/colony"
+   */
+  instanceUrl: string;
+  /** Data endpoint URLs for this instance. */
+  dataEndpoints: ColonyRegistryDataEndpoints;
+  /**
+   * URL to this instance's RFC 8615 well-known federation stub
+   * (`/.well-known/colony-instance.json`). Optional but recommended.
+   */
+  federationStubUrl?: string;
+  /**
+   * Colony instance schema version (from `colony-instance.json`).
+   * Used to gate cross-Colony metric compatibility checks.
+   */
+  schemaVersion: string;
+  /** ISO 8601 date string when this entry was first added to the registry. */
+  registeredAt: string;
+  /** Optional human-readable description of this Colony deployment. */
+  description?: string;
+}
+
+export interface ColonyRegistry {
+  /** Registry format version — currently "1". */
+  schemaVersion: string;
+  /** ISO 8601 timestamp of the last registry update. */
+  updatedAt: string;
+  /** List of registered Colony instances. */
+  entries: ColonyRegistryEntry[];
+}
+
+// ── Validation helpers ────────────────────────────────────────────────────────
+
+function isHttpsUrl(value: unknown): boolean {
+  if (typeof value !== 'string' || !value.trim()) return false;
+  try {
+    const u = new URL(value.trim());
+    return u.protocol === 'https:' && !u.username && !u.password;
+  } catch {
+    return false;
+  }
+}
+
+function isIsoDateString(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  // Accept full ISO datetime or date-only strings
+  return /^\d{4}-\d{2}-\d{2}/.test(value) && !isNaN(Date.parse(value));
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Validate a single registry entry.
+ * Returns a list of errors; an empty list means the entry is valid.
+ */
+export function validateRegistryEntry(
+  entry: unknown,
+  index: number
+): ValidationResult {
+  const errors: string[] = [];
+  const prefix = `entries[${index}]`;
+
+  if (typeof entry !== 'object' || entry === null) {
+    return { valid: false, errors: [`${prefix}: must be an object`] };
+  }
+
+  const e = entry as Record<string, unknown>;
+
+  if (typeof e.name !== 'string' || !e.name.trim()) {
+    errors.push(`${prefix}.name: required non-empty string`);
+  }
+
+  if (!isHttpsUrl(e.instanceUrl)) {
+    errors.push(
+      `${prefix}.instanceUrl: required https:// URL (got ${JSON.stringify(e.instanceUrl)})`
+    );
+  }
+
+  if (typeof e.schemaVersion !== 'string' || !e.schemaVersion.trim()) {
+    errors.push(`${prefix}.schemaVersion: required non-empty string`);
+  }
+
+  if (!isIsoDateString(e.registeredAt)) {
+    errors.push(
+      `${prefix}.registeredAt: required ISO date string (got ${JSON.stringify(e.registeredAt)})`
+    );
+  }
+
+  // Validate dataEndpoints
+  if (typeof e.dataEndpoints !== 'object' || e.dataEndpoints === null) {
+    errors.push(`${prefix}.dataEndpoints: required object`);
+  } else {
+    const de = e.dataEndpoints as Record<string, unknown>;
+    if (!isHttpsUrl(de.activityJson)) {
+      errors.push(
+        `${prefix}.dataEndpoints.activityJson: required https:// URL`
+      );
+    }
+    if (!isHttpsUrl(de.governanceHistoryJson)) {
+      errors.push(
+        `${prefix}.dataEndpoints.governanceHistoryJson: required https:// URL`
+      );
+    }
+    if (
+      de.chaossMetricsJson !== undefined &&
+      !isHttpsUrl(de.chaossMetricsJson)
+    ) {
+      errors.push(
+        `${prefix}.dataEndpoints.chaossMetricsJson: when present, must be an https:// URL`
+      );
+    }
+  }
+
+  // Optional fields with type checks
+  if (e.federationStubUrl !== undefined && !isHttpsUrl(e.federationStubUrl)) {
+    errors.push(
+      `${prefix}.federationStubUrl: when present, must be an https:// URL`
+    );
+  }
+
+  if (e.description !== undefined && typeof e.description !== 'string') {
+    errors.push(`${prefix}.description: when present, must be a string`);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Parse and validate a ColonyRegistry object.
+ *
+ * Validates per-entry fields, and also checks that `name` and `instanceUrl`
+ * are unique across all entries — duplicate values indicate a data error or
+ * a duplicate registration attempt.
+ *
+ * Returns errors for any structural, type, or uniqueness violation.
+ */
+export function validateRegistry(raw: unknown): {
+  registry: ColonyRegistry | null;
+  errors: string[];
+} {
+  const errors: string[] = [];
+
+  if (typeof raw !== 'object' || raw === null) {
+    return { registry: null, errors: ['registry: must be an object'] };
+  }
+
+  const r = raw as Record<string, unknown>;
+
+  if (typeof r.schemaVersion !== 'string' || !r.schemaVersion.trim()) {
+    errors.push('schemaVersion: required non-empty string');
+  }
+
+  if (!isIsoDateString(r.updatedAt)) {
+    errors.push(
+      `updatedAt: required ISO date string (got ${JSON.stringify(r.updatedAt)})`
+    );
+  }
+
+  if (!Array.isArray(r.entries)) {
+    errors.push('entries: must be an array');
+  } else {
+    for (let i = 0; i < r.entries.length; i++) {
+      const result = validateRegistryEntry(r.entries[i], i);
+      errors.push(...result.errors);
+    }
+
+    // Uniqueness validation: name and instanceUrl must be unique across entries
+    const names = r.entries.map(
+      (e: unknown) => (e as Record<string, unknown>).name as string | undefined
+    );
+    const urls = r.entries.map(
+      (e: unknown) =>
+        (e as Record<string, unknown>).instanceUrl as string | undefined
+    );
+
+    const dupName = names.find(
+      (n, i) => n !== undefined && names.indexOf(n) !== i
+    );
+    if (dupName !== undefined) {
+      errors.push(`entries: duplicate name "${dupName}"`);
+    }
+
+    const dupUrl = urls.find(
+      (u, i) => u !== undefined && urls.indexOf(u) !== i
+    );
+    if (dupUrl !== undefined) {
+      errors.push(`entries: duplicate instanceUrl "${dupUrl}"`);
+    }
+  }
+
+  if (errors.length > 0) {
+    return { registry: null, errors };
+  }
+
+  return { registry: raw as ColonyRegistry, errors: [] };
+}


### PR DESCRIPTION
Closes #678
Closes #696
Closes #697

## What

Implements **Approach A** from issue #678: a manually-curated, statically-served Colony Registry that enables cross-instance federation and benchmarking.

### Files added/changed

| File | Role |
|------|------|
| `web/colony-registry.json` | Source registry (manually curated, committed) |
| `web/shared/colony-registry.ts` | `ColonyRegistryEntry` / `ColonyRegistry` types + `validateRegistry` |
| `web/scripts/verify-registry.ts` | Schema-validation + optional reachability CLI (`npm run verify-registry`) |
| `web/scripts/static-pages.ts` | Copy block: validates + copies registry to `public/data/colony-registry.json` at build time |
| `web/scripts/__tests__/verify-registry.test.ts` | 346-line test suite for types, validation, CLI flag parsing |

### What the Registry does

- Lives at `web/colony-registry.json` — source of truth, updated by PR
- Published at `<base>/data/colony-registry.json` at build time
- Validated at build time: a malformed entry (HTTP URL, missing field, duplicate name/instanceUrl) fails the build
- Reachability checks available via `npm run verify-registry -- --fetch` (opt-in, off-by-default)

### Validation enforced at build time (fixes #697)

```ts
const { errors } = validateRegistry(raw);
if (errors.length > 0) throw new Error(`colony-registry.json is invalid:\n  ${errors.join('\n  ')}`);
```

A missing registry prints a warning and continues (graceful degradation for template deployments without a registry file).

### Uniqueness validation (implements #696)

`validateRegistry` enforces `name` and `instanceUrl` uniqueness across all entries. Duplicate registration is rejected at both build time and via the CLI.

## Validation

```bash
cd web && npm run lint && npm run test && npm run build
```

- Lint: clean
- Tests: 1116 passing (65 test files)
- Build: succeeds; `dist/data/colony-registry.json` present in output

## Prior art

This is a re-implementation of PR #774 (stale-closed at 3 approvals) and PR #693. The implementation is identical to the final state of #774, which had the `validateRegistry` build-time enforcement added in response to hivemoot-heater's change request. The merge base is current `main` (c67886d) — no rebase needed.