### PR TITLE
chore: advertise CHAOSS metrics endpoint in colony-instance.json

### DIFF
--- a/web/scripts/__tests__/static-pages.test.ts
+++ b/web/scripts/__tests__/static-pages.test.ts
@@ -1473,6 +1473,9 @@ describe('generateStaticPages', () => {
       expect(manifest.dataEndpoints.governanceHistoryJson).toBe(
         'https://my-org.github.io/my-project/data/governance-history.json'
       );
+      expect(manifest.dataEndpoints.chaossMetricsJson).toBe(
+        'https://my-org.github.io/my-project/data/metrics/snapshot.json'
+      );
       expect(manifest.dashboardUrl).not.toContain('hivemoot.github.io');
       expect(manifest.version).toBe('1');
       expect(manifest.type).toBe('colony-instance');

--- a/web/scripts/static-pages.ts
+++ b/web/scripts/static-pages.ts
@@ -794,6 +794,7 @@ export function generateStaticPages(outDir: string): void {
     dataEndpoints: {
       activityJson: `${BASE_URL}/data/activity.json`,
       governanceHistoryJson: `${BASE_URL}/data/governance-history.json`,
+      chaossMetricsJson: `${BASE_URL}/data/metrics/snapshot.json`,
     },
     sourceRepository: 'https://github.com/hivemoot/colony',
     framework: 'https://github.com/hivemoot/hivemoot',


### PR DESCRIPTION
Closes #763

## Why

PR #600 explicitly deferred `chaossMetricsJson` from `/.well-known/colony-instance.json` with the note: "will be added in a follow-up PR once the metrics snapshot endpoint from #599 is deployed and the advertised URL is actually live."

PR #599 merged 2026-03-13. The endpoint `/data/metrics/snapshot.json` has been live for over a month.

## What

One line added to `dataEndpoints` in `static-pages.ts`:

```ts
dataEndpoints: {
  activityJson: `${BASE_URL}/data/activity.json`,
  governanceHistoryJson: `${BASE_URL}/data/governance-history.json`,
  chaossMetricsJson: `${BASE_URL}/data/metrics/snapshot.json`,
},
```

One assertion added to the existing `colony-instance.json` test to verify the new field uses the correct deployment URL.

## Validation

```bash
cd web && npx vitest run scripts/__tests__/static-pages.test.ts
# 49 tests passed
npx prettier --check scripts/static-pages.ts scripts/__tests__/static-pages.test.ts
# All matched files use Prettier code style!
npx tsc --noEmit
# clean
```

**Note:** My fork PRs don't trigger GitHub Actions CI automatically — a maintainer needs to approve the first workflow run (issue #630). The change is a one-line additive diff with a passing local test suite.