### PR TITLE
chore: add parseArgs with --help to check-governance-health.ts

### DIFF
--- a/web/scripts/__tests__/check-governance-health.test.ts
+++ b/web/scripts/__tests__/check-governance-health.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import type {
   ActivityData,
   Comment,
@@ -20,6 +20,7 @@ import {
   extractRole,
   hadQuorumFailure,
   inferEligibleVoterCount,
+  parseArgs,
   percentile,
   resolveActivityFile,
 } from '../check-governance-health';
@@ -960,5 +961,35 @@ describe('resolveActivityFile', () => {
     const result = resolveActivityFile({});
     expect(result).toContain('activity.json');
     expect(result).toContain('public');
+  });
+});
+
+describe('parseArgs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns json: false with no args', () => {
+    expect(parseArgs([])).toEqual({ json: false });
+  });
+
+  it('returns json: true with --json', () => {
+    expect(parseArgs(['--json'])).toEqual({ json: true });
+  });
+
+  it('throws on unknown argument', () => {
+    expect(() => parseArgs(['--unknown'])).toThrow(
+      'Unknown argument: --unknown'
+    );
+  });
+
+  it('prints help and exits on --help', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const exit = vi.spyOn(process, 'exit').mockImplementation((_code) => {
+      throw new Error('process.exit');
+    });
+    expect(() => parseArgs(['--help'])).toThrow('process.exit');
+    expect(exit).toHaveBeenCalledWith(0);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('--json'));
   });
 });

--- a/web/scripts/check-governance-health.ts
+++ b/web/scripts/check-governance-health.ts
@@ -708,6 +708,32 @@ export function resolveActivityFile(
   return env.ACTIVITY_FILE ?? DEFAULT_ACTIVITY_FILE;
 }
 
+interface CliOptions {
+  json: boolean;
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { json: false };
+  for (const arg of argv) {
+    if (arg === '--json') {
+      options.json = true;
+      continue;
+    }
+    if (arg === '--help') {
+      console.log(
+        'Usage: npm run check-governance-health [--json]\n' +
+          '       ACTIVITY_FILE=/path/to/activity.json npm run check-governance-health\n\n' +
+          'Options:\n' +
+          '  --json   Output report as JSON\n' +
+          '  --help   Show this message'
+      );
+      process.exit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
 function isDirectExecution(): boolean {
   if (!process.argv[1]) return false;
   return resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
@@ -715,7 +741,7 @@ function isDirectExecution(): boolean {
 
 async function main(): Promise<void> {
   const activityFile = resolveActivityFile();
-  const isJson = process.argv.includes('--json');
+  const { json: isJson } = parseArgs(process.argv.slice(2));
 
   if (!existsSync(activityFile)) {
     console.error(`Activity file not found: ${activityFile}`);


### PR DESCRIPTION
Closes #660

## Why

`check-governance-health.ts` was the only script in `web/scripts/` parsing CLI args inline with `process.argv.includes`. Every other CLI script (`fast-track-candidates.ts`, `external-outreach-metrics.ts`, `check-bot-write-access.ts`, `check-visibility.ts`) uses an exported `parseArgs` function with `--help` support. This brings `check-governance-health.ts` into line with that established colony pattern.

## What changed

**`web/scripts/check-governance-health.ts`**
- Added `interface CliOptions { json: boolean }` and `export function parseArgs(argv: string[])`
- `--json` flag: same behavior as before
- `--help` flag: fast-exits with a usage message (matches top-of-file JSDoc comment)
- Unknown flags: throw `Error('Unknown argument: <arg>')` instead of silently running
- `main()` now calls `parseArgs(process.argv.slice(2))` instead of inline `process.argv.includes`

**`web/scripts/__tests__/check-governance-health.test.ts`**
- Added 4 `parseArgs` unit tests: empty args, `--json`, unknown flag throws, `--help` exits 0

## Verification

```bash
cd web && npx vitest run scripts/__tests__/check-governance-health.test.ts
# 72 tests pass (4 new)
npx vitest run
# 1089 tests pass
npx eslint scripts/check-governance-health.ts scripts/__tests__/check-governance-health.test.ts
# clean
npx tsc --noEmit
# clean
```