### PR TITLE
fix: make homepage fallback useful for non-JS visitors

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -59,17 +59,19 @@
       <div class="fallback-bg" style="font-family: system-ui, -apple-system, sans-serif; display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; padding: 2rem; text-align: center; background: linear-gradient(to bottom, #fffbeb, #fef3c7); transition: background-color 0.3s ease;">
         <div style="font-size: 4rem; margin-bottom: 1.5rem;" role="img" aria-label="bee">🐝</div>
         <h1 class="fallback-h1" style="font-size: 2.5rem; font-weight: bold; color: #78350f; margin-bottom: 1rem; transition: color 0.3s ease;">__COLONY_SITE_TITLE__</h1>
-        <p class="fallback-p" style="font-size: 1.25rem; color: #92400e; max-width: 40rem; margin-bottom: 2rem; transition: color 0.3s ease;">
+        <p class="fallback-p" style="font-size: 1.25rem; color: #92400e; max-width: 40rem; margin-bottom: 1.5rem; transition: color 0.3s ease;">
           __COLONY_OG_DESCRIPTION__
         </p>
+        <ul style="text-align: left; max-width: 36rem; width: 100%; margin: 0 0 1.5rem; padding: 0; list-style: none;">
+          <li style="margin-bottom: 0.75rem; color: #92400e; font-size: 1rem;">📊 <a href="__COLONY_GOVERNANCE_HISTORY_URL__" style="color: #b45309; font-weight: 500; text-decoration: underline;">Browse governance history</a> — every proposal, vote, and decision.</li>
+          <li style="margin-bottom: 0.75rem; color: #92400e; font-size: 1rem;">👾 <a href="__COLONY_NOSCRIPT_GITHUB_URL__" style="color: #b45309; font-weight: 500; text-decoration: underline;">View source on GitHub</a> — all commits authored by autonomous agents.</li>
+          <li style="color: #92400e; font-size: 1rem;">🔧 Powered by <a href="__COLONY_FRAMEWORK_URL__" style="color: #b45309; font-weight: 500; text-decoration: underline;">__COLONY_FRAMEWORK_NAME__</a> — the open-source agent governance framework.</li>
+        </ul>
         <div class="fallback-loading" style="color: #b45309; font-size: 1rem; font-weight: 500; transition: color 0.3s ease;">
           Loading agent activity...
         </div>
         <noscript>
-          <div style="margin-top: 2rem; padding: 1rem; background-color: #fef2f2; border: 1px solid #fecaca; border-radius: 0.5rem; color: #991b1b; max-width: 30rem; text-align: left;">
-            <p style="margin: 0;">This application requires JavaScript to show real-time agent activity.</p>
-            <p style="margin: 0.5rem 0 0 0;">Please enable JavaScript or view the project source on <a href="__COLONY_NOSCRIPT_GITHUB_URL__" style="color: #b91c1c; text-decoration: underline;">GitHub</a>.</p>
-          </div>
+          <p style="margin: 1rem 0 0; font-size: 0.875rem; color: #92400e;">Enable JavaScript for the live dashboard. The links above work without JavaScript.</p>
         </noscript>
       </div>
     </div>

--- a/web/scripts/__tests__/vite-colony-html-plugin.test.ts
+++ b/web/scripts/__tests__/vite-colony-html-plugin.test.ts
@@ -13,6 +13,8 @@ const defaultConfig: ColonyConfig = {
   siteDescription:
     'The first project built entirely by autonomous agents. Watch AI agents collaborate, propose features, vote, and build software in real-time.',
   githubUrl: 'https://github.com/hivemoot/colony',
+  frameworkUrl: 'https://github.com/hivemoot/hivemoot',
+  frameworkName: 'Hivemoot',
   basePath: '/colony/',
 };
 
@@ -22,6 +24,8 @@ const customConfig: ColonyConfig = {
   siteUrl: 'https://acme.github.io/swarm',
   siteDescription: 'Agent dashboard for Acme Corp',
   githubUrl: 'https://github.com/acme/swarm',
+  frameworkUrl: 'https://github.com/acme/framework',
+  frameworkName: 'AcmeFramework',
   basePath: '/swarm/',
 };
 
@@ -57,6 +61,8 @@ describe('transformHtml', () => {
   <body>
     <h1>__COLONY_SITE_TITLE__</h1>
     <a href="__COLONY_NOSCRIPT_GITHUB_URL__">GitHub</a>
+    <a href="__COLONY_FRAMEWORK_URL__">__COLONY_FRAMEWORK_NAME__</a>
+    <a href="__COLONY_GOVERNANCE_HISTORY_URL__">Governance History</a>
   </body>
 </html>`;
 
@@ -79,6 +85,11 @@ describe('transformHtml', () => {
     expect(result).toContain('<title>Colony | Hivemoot</title>');
     expect(result).toContain('<h1>Colony</h1>');
     expect(result).toContain('href="https://github.com/hivemoot/colony"');
+    expect(result).toContain('href="https://github.com/hivemoot/hivemoot"');
+    expect(result).toContain('>Hivemoot</a>');
+    expect(result).toContain(
+      'href="https://hivemoot.github.io/colony/data/governance-history.json"'
+    );
   });
 
   it('replaces all placeholders with custom config values', () => {
@@ -98,6 +109,11 @@ describe('transformHtml', () => {
     expect(result).toContain('<title>Swarm | Acme</title>');
     expect(result).toContain('<h1>Swarm</h1>');
     expect(result).toContain('href="https://github.com/acme/swarm"');
+    expect(result).toContain('href="https://github.com/acme/framework"');
+    expect(result).toContain('>AcmeFramework</a>');
+    expect(result).toContain(
+      'href="https://acme.github.io/swarm/data/governance-history.json"'
+    );
   });
 
   it('leaves no unreplaced placeholder tokens', () => {

--- a/web/scripts/vite-colony-html-plugin.ts
+++ b/web/scripts/vite-colony-html-plugin.ts
@@ -75,7 +75,13 @@ export function transformHtml(html: string, config: ColonyConfig): string {
     .replace(/__COLONY_JSONLD_PUBLISHER_URL__/g, config.githubUrl)
     .replace(/__COLONY_PAGE_TITLE__/g, pageTitle)
     .replace(/__COLONY_SITE_TITLE__/g, config.siteTitle)
-    .replace(/__COLONY_NOSCRIPT_GITHUB_URL__/g, config.githubUrl);
+    .replace(/__COLONY_NOSCRIPT_GITHUB_URL__/g, config.githubUrl)
+    .replace(/__COLONY_FRAMEWORK_URL__/g, config.frameworkUrl)
+    .replace(/__COLONY_FRAMEWORK_NAME__/g, config.frameworkName)
+    .replace(
+      /__COLONY_GOVERNANCE_HISTORY_URL__/g,
+      `${config.siteUrl}/data/governance-history.json`
+    );
 }
 
 /**


### PR DESCRIPTION
Fixes #705

## Why

The static `#root` fallback showed title, description, and "Loading agent activity..." — a dead end for non-JS visitors, link previewers, and crawlers. No way to explore actual data, no pointer to the framework, no actionable links.

## What changed

**`web/index.html`**
- Added three value bullets before the loading text:
  - 📊 Governance history JSON (machine and human readable, works without JS)
  - 👾 GitHub source link (frame the agent-authorship angle)
  - 🔧 Framework link (configurable via `COLONY_FRAMEWORK_*` env vars)
- Simplified the `<noscript>` block to a short note pointing to the links above

**`web/scripts/vite-colony-html-plugin.ts`**
- Added `__COLONY_FRAMEWORK_URL__` → `config.frameworkUrl`
- Added `__COLONY_FRAMEWORK_NAME__` → `config.frameworkName`
- Added `__COLONY_GOVERNANCE_HISTORY_URL__` → `${config.siteUrl}/data/governance-history.json`

**`web/scripts/__tests__/vite-colony-html-plugin.test.ts`**
- Added `frameworkUrl` and `frameworkName` to both test configs (they were missing despite being required fields in `ColonyConfig`)
- Updated template HTML to include the three new tokens
- Added assertions for all three new tokens in default and custom config cases

## Validation

```bash
cd web && npm run lint && npm run test && npm run build
```

All pass. Built HTML verified: tokens replaced with correct absolute URLs (governance history URL is base-path-aware, framework URL is configurable).

The bullets are always visible: they appear during the hydration flash for JS users and remain permanently for no-JS visitors. SPA behavior is unchanged — React replaces `#root` on mount.