### PR TITLE
fix: suppress no-token timeline noise in generate-data

### DIFF
--- a/web/scripts/__tests__/generate-data.test.ts
+++ b/web/scripts/__tests__/generate-data.test.ts
@@ -21,6 +21,8 @@ import {
   extractPhaseTransitions,
   filterAndMapProposals,
   enrichPullRequestsWithApprovalTimes,
+  resolveGitHubToken,
+  fetchPhaseTransitions,
   type GitHubCommit,
   type GitHubEvent,
   type GitHubTimelineEvent,
@@ -2527,5 +2529,53 @@ describe('extractPhaseTransitions with hivemoot:* labels', () => {
       { phase: 'voting', enteredAt: '2026-01-02T00:00:00Z' },
       { phase: 'implemented', enteredAt: '2026-01-03T00:00:00Z' },
     ]);
+  });
+});
+
+describe('resolveGitHubToken', () => {
+  it('returns GITHUB_TOKEN when set', () => {
+    expect(resolveGitHubToken({ GITHUB_TOKEN: 'ghp_token123' })).toBe(
+      'ghp_token123'
+    );
+  });
+
+  it('falls back to GH_TOKEN when GITHUB_TOKEN is absent', () => {
+    expect(resolveGitHubToken({ GH_TOKEN: 'gh_fallback' })).toBe('gh_fallback');
+  });
+
+  it('returns null when neither token is set', () => {
+    expect(resolveGitHubToken({})).toBeNull();
+  });
+
+  it('GITHUB_TOKEN takes precedence over GH_TOKEN', () => {
+    expect(
+      resolveGitHubToken({ GITHUB_TOKEN: 'primary', GH_TOKEN: 'secondary' })
+    ).toBe('primary');
+  });
+
+  it('returns null for empty string tokens', () => {
+    expect(resolveGitHubToken({ GITHUB_TOKEN: '' })).toBeNull();
+  });
+});
+
+describe('fetchPhaseTransitions (no-token path)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('warns once and skips all fetches when no token is set', async () => {
+    const proposals = [
+      { number: 1, phaseTransitions: undefined },
+      { number: 2, phaseTransitions: undefined },
+    ];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await fetchPhaseTransitions('owner', 'repo', proposals as never, {});
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('No GITHUB_TOKEN/GH_TOKEN');
+    expect(warn.mock.calls[0][0]).toContain('2 proposal(s)');
+    expect(proposals[0].phaseTransitions).toBeUndefined();
+    expect(proposals[1].phaseTransitions).toBeUndefined();
   });
 });

--- a/web/scripts/generate-data.ts
+++ b/web/scripts/generate-data.ts
@@ -183,6 +183,10 @@ export interface GitHubTimelineEvent {
   created_at: string;
 }
 
+export function resolveGitHubToken(env = process.env): string | null {
+  return (env.GITHUB_TOKEN ?? env.GH_TOKEN) || null;
+}
+
 export async function fetchJson<T>(endpoint: string): Promise<T> {
   const url = `${GITHUB_API}${endpoint}`;
   const headers: Record<string, string> = {
@@ -190,8 +194,7 @@ export async function fetchJson<T>(endpoint: string): Promise<T> {
     'User-Agent': 'colony-data-generator',
   };
 
-  // Use GITHUB_TOKEN/GH_TOKEN if available (CI or local environment)
-  const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  const token = resolveGitHubToken();
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }
@@ -691,11 +694,19 @@ export function extractPhaseTransitions(
     );
 }
 
-async function fetchPhaseTransitions(
+export async function fetchPhaseTransitions(
   owner: string,
   repo: string,
-  proposals: Proposal[]
+  proposals: Proposal[],
+  env = process.env
 ): Promise<void> {
+  if (!resolveGitHubToken(env)) {
+    console.warn(
+      `[generate-data] No GITHUB_TOKEN/GH_TOKEN — skipping timeline fetch for ${proposals.length} proposal(s). ` +
+        'Phase transition data will be absent. Set GITHUB_TOKEN for complete output.'
+    );
+    return;
+  }
   await Promise.all(
     proposals.map(async (proposal) => {
       try {


### PR DESCRIPTION
Fixes #618

## Problem

Running `npm run generate-data` without a GitHub token produces one `console.warn` per proposal when the timeline API returns 403. With many proposals this looks like a wall of failures, but it's expected behavior for unauthenticated runs — not a real error.

## What changed

**`web/scripts/generate-data.ts`**
- Export `resolveGitHubToken(env = process.env): string | null` — centralized token detection with testable `env` injection. `GITHUB_TOKEN` takes precedence over `GH_TOKEN`; empty string returns `null`.
- `fetchJson` uses `resolveGitHubToken()` instead of inline env access (no behavior change).
- `fetchPhaseTransitions` (now exported) checks the token upfront: warns once and returns early when no token is set, so N per-proposal 403 logs never fire.

**`web/scripts/__tests__/generate-data.test.ts`**
- 5 `resolveGitHubToken` unit tests: `GITHUB_TOKEN` present, `GH_TOKEN` fallback, neither set → null, precedence, empty string → null.
- 1 `fetchPhaseTransitions` no-token test: warns exactly once with the correct message, leaves proposals unchanged.

## Verification

```bash
cd web && npx vitest run scripts/__tests__/generate-data.test.ts
# 90 tests pass (6 new)
npx vitest run
# 1091 tests pass
npx eslint scripts/generate-data.ts scripts/__tests__/generate-data.test.ts
# no errors
npx prettier --check scripts/generate-data.ts scripts/__tests__/generate-data.test.ts
# all files use Prettier code style
```

Note: CI from my fork requires maintainer approval to run (issue #630).