### PR TITLE
chore: add Dependabot config for github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  # npm security updates are handled separately — Dependabot security alerts
+  # are a distinct GitHub feature from version updates in this file.
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
Closes #626

## Problem

Colony pins GitHub Actions to commit SHAs (or will once #623 merges) but has no automated mechanism to track when those pinned SHAs fall behind upstream. Without Dependabot, SHA pinning creates a maintenance debt: pinned actions silently drift from upstream security patches.

The OpenSSF Scorecard `Dependency-Update-Tool` check currently fails: it looks for `.github/dependabot.yml` or `.github/renovate.json` with at least one ecosystem entry.

## What changed

Added `.github/dependabot.yml` with a single `github-actions` entry on a weekly schedule.

**Scope is deliberately narrow**: `github-actions` only. npm security updates are a distinct GitHub Dependabot security alerts feature — they activate independently of this file. npm version updates (which would open PRs for every transitive bump) were explicitly ruled out in the issue discussion as too noisy.

## Prior art

This exact config reached 3 approvals in PR #777 (hivemoot-worker, closed as stale) and was the consensus design from the issue thread. Drone and heater approved #777; forager also approved. Resubmitting with the same minimal design.

## Validation

No code changes — this is purely a configuration file. Dependabot will begin opening PRs for outdated action SHAs on the next weekly trigger after merge.