### PR TITLE
perf: batch issue-state lookups in fast-track-candidates

### DIFF
--- a/web/scripts/fast-track-candidates.ts
+++ b/web/scripts/fast-track-candidates.ts
@@ -1,4 +1,7 @@
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 
 const DEFAULT_REPO = 'hivemoot/colony';
 export const DEFAULT_LIMIT = 200;
@@ -423,11 +426,27 @@ function parseIssueRefFromUrl(
   }
 }
 
-function resolveIssueStates(
+async function resolveIssueStates(
   repo: string,
   prs: PullRequestNode[]
-): Map<string, string> {
-  const issueKeys = Array.from(
+): Promise<Map<string, string>> {
+  const states = new Map<string, string>();
+
+  // Pre-populate from states already returned by the GraphQL query — no API
+  // call needed for these. getLinkedOpenIssues trusts this state directly, so
+  // we avoid a round-trip for every issue GitHub already told us about.
+  for (const pr of prs) {
+    for (const issue of pr.closingIssuesReferences ?? []) {
+      const directState = issue.state?.toUpperCase();
+      if (directState === 'OPEN' || directState === 'CLOSED') {
+        states.set(getIssueKey(issue, repo), directState);
+      }
+    }
+  }
+
+  // Collect unique keys for issues whose state GraphQL didn't return, then
+  // fetch them in parallel instead of one serial execFileSync per issue.
+  const unknownKeys = Array.from(
     new Set(
       prs.flatMap((pr) =>
         (pr.closingIssuesReferences ?? []).map((issue) =>
@@ -435,35 +454,35 @@ function resolveIssueStates(
         )
       )
     )
+  ).filter((key) => !states.has(key));
+
+  await Promise.all(
+    unknownKeys.map(async (issueKey) => {
+      const hashIndex = issueKey.lastIndexOf('#');
+      const issueRepo = issueKey.slice(0, hashIndex);
+      const issueNumber = issueKey.slice(hashIndex + 1);
+
+      try {
+        const { stdout } = await execFileAsync(
+          'gh',
+          ['api', `repos/${issueRepo}/issues/${issueNumber}`, '--jq', '.state'],
+          { encoding: 'utf8' }
+        );
+        states.set(issueKey, stdout.trim().toUpperCase());
+      } catch {
+        states.set(issueKey, 'UNKNOWN');
+      }
+    })
   );
-  const states = new Map<string, string>();
-
-  for (const issueKey of issueKeys) {
-    const hashIndex = issueKey.lastIndexOf('#');
-    const issueRepo = issueKey.slice(0, hashIndex);
-    const issueNumber = issueKey.slice(hashIndex + 1);
-
-    try {
-      const state = execFileSync(
-        'gh',
-        ['api', `repos/${issueRepo}/issues/${issueNumber}`, '--jq', '.state'],
-        {
-          encoding: 'utf8',
-        }
-      )
-        .trim()
-        .toUpperCase();
-      states.set(issueKey, state);
-    } catch {
-      states.set(issueKey, 'UNKNOWN');
-    }
-  }
 
   return states;
 }
 
-function buildReport(prs: PullRequestNode[], repo: string): Report {
-  const issueStates = resolveIssueStates(repo, prs);
+async function buildReport(
+  prs: PullRequestNode[],
+  repo: string
+): Promise<Report> {
+  const issueStates = await resolveIssueStates(repo, prs);
   const candidates: CandidateRecord[] = prs.map((pr) => {
     const evaluation = evaluateEligibility(pr, issueStates, repo);
     return {
@@ -578,10 +597,10 @@ export function printHumanReport(report: Report): void {
   }
 }
 
-function main(): void {
+async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
   const prs = loadPullRequests(options.repo, options.limit);
-  const report = buildReport(prs, options.repo);
+  const report = await buildReport(prs, options.repo);
 
   if (options.json) {
     console.log(JSON.stringify(report, null, 2));
@@ -592,5 +611,8 @@ function main(): void {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main();
+  main().catch((e: unknown) => {
+    console.error('Fatal:', e);
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
Closes #687

## Problem

`resolveIssueStates` was calling `execFileSync` once per linked issue in a serial loop — one full round-trip per issue even when the GraphQL query had already returned its state in `closingIssuesReferences[].state`.

## What changed

**`web/scripts/fast-track-candidates.ts`**

**1. Pre-populate from GraphQL state (no API call)**  
`closingIssuesReferences[].state` is already returned by `gh pr list --json`. When that field is `OPEN` or `CLOSED`, we populate the map directly without any `gh api` call. `getLinkedOpenIssues` already trusts this field first, so this is semantically identical to the previous behavior.

**2. Parallel-fetch remaining unknowns**  
Issues whose state GraphQL didn't return are now fetched in parallel with `Promise.all` + `execFileAsync` (promisified `execFile`) instead of blocking on each one serially with `execFileSync`.

**3. `main().catch()` pattern**  
`buildReport` and `main` are now async; `main().catch()` replaces the bare `main()` call, matching the established CLI error-handling convention.

## Validation

```bash
cd web && npm run lint && npm run typecheck && npm run test
```

All 1085 tests pass, type check clean, lint clean.