### PR TITLE
fix: extract resolveVisibilityToken — correct GITHUB_TOKEN priority

### DIFF
--- a/web/scripts/__tests__/check-visibility.test.ts
+++ b/web/scripts/__tests__/check-visibility.test.ts
@@ -8,6 +8,7 @@ import {
   resolveDeployedPageUrl,
   resolveRepositoryHomepage,
   resolveVisibilityRepository,
+  resolveVisibilityToken,
   resolveVisibilityUserAgent,
   type CheckResult,
   type VisibilityReport,
@@ -32,6 +33,34 @@ describe('resolveVisibilityUserAgent', () => {
         VISIBILITY_USER_AGENT: '   ',
       })
     ).toBe('colony-visibility-check');
+  });
+});
+
+describe('resolveVisibilityToken', () => {
+  it('returns GITHUB_TOKEN when set', () => {
+    expect(resolveVisibilityToken({ GITHUB_TOKEN: 'ghp_token' })).toBe(
+      'ghp_token'
+    );
+  });
+
+  it('falls back to GH_TOKEN when GITHUB_TOKEN is absent', () => {
+    expect(resolveVisibilityToken({ GH_TOKEN: 'gh_fallback' })).toBe(
+      'gh_fallback'
+    );
+  });
+
+  it('returns null when neither token is set', () => {
+    expect(resolveVisibilityToken({})).toBeNull();
+  });
+
+  it('GITHUB_TOKEN takes precedence over GH_TOKEN', () => {
+    expect(
+      resolveVisibilityToken({ GITHUB_TOKEN: 'primary', GH_TOKEN: 'secondary' })
+    ).toBe('primary');
+  });
+
+  it('returns null for empty string tokens', () => {
+    expect(resolveVisibilityToken({ GITHUB_TOKEN: '' })).toBeNull();
   });
 });
 

--- a/web/scripts/check-visibility.ts
+++ b/web/scripts/check-visibility.ts
@@ -42,6 +42,12 @@ function parseArgs(argv: string[]): CliOptions {
   return { json: argv.includes('--json') };
 }
 
+export function resolveVisibilityToken(
+  env: NodeJS.ProcessEnv = process.env
+): string | null {
+  return (env.GITHUB_TOKEN ?? env.GH_TOKEN) || null;
+}
+
 export function resolveVisibilityUserAgent(
   env: NodeJS.ProcessEnv = process.env
 ): string {
@@ -305,7 +311,7 @@ async function runChecks(): Promise<CheckResult[]> {
 
   // Repository metadata checks via GitHub API
   try {
-    const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+    const token = resolveVisibilityToken();
     const userAgent = resolveVisibilityUserAgent();
     const headers: Record<string, string> = {
       Accept: 'application/vnd.github.v3+json',


### PR DESCRIPTION
Fixes #631

## Problem

`check-visibility.ts` was resolving the GitHub token inline with the wrong priority:

```ts
const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
```

`GH_TOKEN` is the `gh` CLI fallback. `GITHUB_TOKEN` is the token GitHub Actions injects automatically. When running in CI, both may be set — `GITHUB_TOKEN` should win since it's the canonical Actions credential. This matches the established priority used by `generate-data.ts`.

Additionally, the inline resolution made it impossible to test without leaking `process.env` between test cases.

## What changed

**`web/scripts/check-visibility.ts`**
- Export `resolveVisibilityToken(env = process.env): string | null` — `(env.GITHUB_TOKEN ?? env.GH_TOKEN) || null`. Same idiom as `resolveGitHubToken` in `generate-data.ts`: `??` handles absent keys, `||` coerces empty string to null.
- Replace the inline `process.env.GH_TOKEN || process.env.GITHUB_TOKEN` at line 313 with `resolveVisibilityToken()`.

**`web/scripts/__tests__/check-visibility.test.ts`**
- Import `resolveVisibilityToken`.
- 5 unit tests: GITHUB_TOKEN present, GH_TOKEN fallback, neither → null, GITHUB_TOKEN wins precedence, empty string → null.

## Verification

```bash
cd web && npx vitest run scripts/__tests__/check-visibility.test.ts
# 33 tests pass (5 new)
npx vitest run
# 1090 tests pass
npx eslint scripts/check-visibility.ts scripts/__tests__/check-visibility.test.ts
# no errors
```

## Prior art

Previous implementations: PRs #628, #671, #747, #769 — all stale-closed after 4 approvals each. This PR applies the identical fix.